### PR TITLE
Fix whoosh backend boolean representation.

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -509,9 +509,9 @@ class SearchBackend(BaseSearchBackend):
                 value = datetime(value.year, value.month, value.day, 0, 0, 0)
         elif isinstance(value, bool):
             if value:
-                value = True
+                value = 'true'
             else:
-                value = False
+                value = 'false'
         elif isinstance(value, (list, tuple)):
             value = u','.join([force_unicode(v) for v in value])
         elif isinstance(value, (int, long, float)):


### PR DESCRIPTION
Right now the whoosh backend doesn't convert booleans, which ends up creating a query with capitalized boolean values:

```
print SearchQuerySet().filter(published=True).query
published:True
```

Unforunately, whoosh doesn't recognize that. We need to change the backend so that the query becomes:

```
print SearchQuerySet().filter(published=True).query
published:true
```

This patch does that, and fixes the issue that I was having. (No results when I knew there should have been query results.)
