### PR TITLE
Updating Solr download and installation instructions for version 1.4.1

### DIFF
--- a/docs/installing_search_engines.rst
+++ b/docs/installing_search_engines.rst
@@ -13,16 +13,16 @@ Solr is Java but comes in a pre=packaged form that requires very little other
 than the JRE and Jetty. It's very performant and has an advanced featureset.
 Haystack requires Solr 1.3+. Installation is relatively simple::
 
-    curl -O http://apache.mirrors.tds.net/lucene/solr/1.3.0/apache-solr-1.3.0.tgz
-    tar xvzf apache-solr-1.3.0.tgz
-    cd apache-solr-1.3.0
+    curl -O http://apache.mirrors.tds.net/lucene/solr/1.4.1/apache-solr-1.4.1.tgz
+    tar xvzf apache-solr-1.4.1.tgz
+    cd apache-solr-1.4.1
     cd example
     java -jar start.jar
 
 You'll need to revise your schema. You can generate this from your application
 (once Haystack is installed and setup) by running 
 ``./manage.py build_solr_schema``. Take the output from that command and place
-it in ``apache-solr-1.3.0/example/solr/conf/schema.xml``. Then restart Solr.
+it in ``apache-solr-1.4.1/example/solr/conf/schema.xml``. Then restart Solr.
 
 You'll also need a Solr binding, ``pysolr``. The official ``pysolr`` package,
 distributed via PyPI, is the best version to use (2.0.13+). Place ``pysolr.py``


### PR DESCRIPTION
Updating Solr download and installation instructions to reference version 1.4.1 as 1.3.x is no longer available. Fixes #341.
