### PR TITLE
build_solr_schema tries to use None as a HAYSTACK_CONNECTIONS key

### DIFF
--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -11,7 +11,8 @@ class Command(BaseCommand):
         make_option("-f", "--filename", action="store", type="string", dest="filename",
                     help='If provided, directs output to a file instead of stdout.'),
         make_option("-u", "--using", action="store", type="string", dest="using",
-                    help='If provided, chooses a connection to work with.'),
+                    help='If provided, chooses a connection to work with.',
+                    default=DEFAULT_ALIAS),
     )
     option_list = BaseCommand.option_list + base_options
     


### PR DESCRIPTION
Hiya,

While trying to run the management command `python manage.py build_solr_schema` it wasn't picking up the default `HAYSTACK_CONNECTIONS` option, It was getting a `None` as the engine key.

 {'settings': None, 'pythonpath': None, 'verbosity': '1', 'traceback': None, 'filename': None, 'using': None}

I've added `default` parameter  to `make_option`

{'settings': None, 'pythonpath': None, 'verbosity': '1', 'traceback': None, 'filename': None, 'using': 'default'}

This was using Django 1.3 and Python 2.7. Hopefully I am making some sense, please let me know if not!

Cheers!

A
