### PR TITLE
When using RealTimeSearchIndex, build_solr_schema doesn't work

### DIFF
--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -139,8 +139,8 @@ class UnifiedIndex(object):
         self._facet_fieldnames = {}
     
     def collect_indexes(self):
-        from haystack.indexes import SearchIndex, BasicSearchIndex, ModelSearchIndex
-        base_classes = [Indexable, SearchIndex, BasicSearchIndex, ModelSearchIndex]
+        from haystack.indexes import SearchIndex, BasicSearchIndex, ModelSearchIndex, RealTimeSearchIndex
+        base_classes = [Indexable, SearchIndex, BasicSearchIndex, ModelSearchIndex, RealTimeSearchIndex]
         indexes = []
         
         for app in settings.INSTALLED_APPS:


### PR DESCRIPTION
When using RealTimeSearchIndex, build_solr_schema exploded in millions of pieces
