### PR TITLE
Field collapsing / result grouping

### DIFF
--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from django.db.models.base import ModelBase
 from django.utils import tree
 from django.utils.encoding import force_unicode
+from django.utils.translation import get_language
 from haystack.constants import DJANGO_CT, VALID_FILTERS, FILTER_SEPARATOR, DEFAULT_ALIAS
 from haystack.exceptions import MoreLikeThisError, FacetingError
 from haystack.models import SearchResult
@@ -68,6 +69,7 @@ class BaseSearchBackend(object):
         self.include_spelling = connection_options.get('INCLUDE_SPELLING', False)
         self.batch_size = connection_options.get('BATCH_SIZE', 1000)
         self.silently_fail = connection_options.get('SILENTLY_FAIL', True)
+        self.language = connection_options.get('LANGUAGE', get_language())
     
     def update(self, index, iterable):
         """

--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -103,7 +103,8 @@ class BaseSearchBackend(object):
     def search(self, query_string, sort_by=None, start_offset=0, end_offset=None,
                fields='', highlight=False, facets=None, date_facets=None, query_facets=None,
                narrow_queries=None, spelling_query=None,
-               limit_to_registered_models=None, result_class=None, **kwargs):
+               limit_to_registered_models=None, result_class=None,
+               collapse=None, **kwargs):
         """
         Takes a query to search on and returns dictionary.
         
@@ -264,6 +265,7 @@ class BaseSearchQuery(object):
         self.start_offset = 0
         self.end_offset = None
         self.highlight = False
+        self.collapse = None
         self.facets = set()
         self.date_facets = {}
         self.query_facets = []
@@ -315,6 +317,9 @@ class BaseSearchQuery(object):
         
         if self.highlight:
             kwargs['highlight'] = self.highlight
+            
+        if self.collapse:
+            kwargs['collapse'] = self.collapse 
         
         if self.facets:
             kwargs['facets'] = list(self.facets)
@@ -561,13 +566,21 @@ class BaseSearchQuery(object):
     def add_order_by(self, field):
         """Orders the search result by a field."""
         self.order_by.append(field)
-    
+
     def clear_order_by(self):
         """
         Clears out all ordering that has been already added, reverting the
         query to relevancy.
         """
         self.order_by = []
+        
+    def add_collapse(self, collapse):
+        """Group the search results by a field and display only the first result of the group"""
+        self.collapse = collapse
+              
+    def clear_collapse(self):
+        """Cancel field collapsing"""
+        self.collapse = None
     
     def add_model(self, model):
         """
@@ -721,6 +734,7 @@ class BaseSearchQuery(object):
         clone.models = self.models.copy()
         clone.boost = self.boost.copy()
         clone.highlight = self.highlight
+        clone.collapse = self.collapse
         clone.facets = self.facets.copy()
         clone.date_facets = self.date_facets.copy()
         clone.query_facets = self.query_facets[:]

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -108,7 +108,8 @@ class SolrSearchBackend(BaseSearchBackend):
     def search(self, query_string, sort_by=None, start_offset=0, end_offset=None,
                fields='', highlight=False, facets=None, date_facets=None, query_facets=None,
                narrow_queries=None, spelling_query=None,
-               limit_to_registered_models=None, result_class=None, **kwargs):
+               limit_to_registered_models=None, result_class=None,
+               collapse=None, **kwargs):
         if len(query_string) == 0:
             return {
                 'results': [],
@@ -119,6 +120,12 @@ class SolrSearchBackend(BaseSearchBackend):
             'fl': '* score',
         }
         
+        if collapse:
+            kwargs['group'] = 'true'
+            kwargs['group.field'] = collapse
+            # Until now we can only ask for a flat list of results without groups data
+            kwargs['group.main'] = 'true'
+                    
         if fields:
             kwargs['fl'] = fields
         
@@ -454,7 +461,10 @@ class SolrSearchQuery(BaseSearchQuery):
         
         if self.highlight:
             kwargs['highlight'] = self.highlight
-        
+            
+        if self.collapse:
+            kwargs['collapse'] = self.collapse
+
         if self.facets:
             kwargs['facets'] = list(self.facets)
         

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -170,7 +170,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         writer = AsyncWriter(self.index)
         
         for obj in iterable:
-            doc = index.full_prepare(obj)
+            doc = index.full_prepare(obj)print
             
             # Really make sure it's unicode, because Whoosh won't have it any
             # other way.
@@ -256,6 +256,7 @@ class WhooshSearchBackend(BaseSearchBackend):
                limit_to_registered_models=None, result_class=None, **kwargs):
         if not self.setup_complete:
             self.setup()
+
         
         # A zero length query should return no results.
         if len(query_string) == 0:
@@ -363,6 +364,7 @@ class WhooshSearchBackend(BaseSearchBackend):
                 end_offset = 1
             
             raw_results = searcher.search(parsed_query, limit=end_offset, sortedby=sort_by, reverse=reverse)
+
             
             # Handle the case where the results have been narrowed.
             if narrowed_results:

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -170,7 +170,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         writer = AsyncWriter(self.index)
         
         for obj in iterable:
-            doc = index.full_prepare(obj)print
+            doc = index.full_prepare(obj)
             
             # Really make sure it's unicode, because Whoosh won't have it any
             # other way.

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -304,6 +304,13 @@ class SearchQuerySet(object):
             clone.query.add_order_by(field)
         
         return clone
+        
+    def collapse_by(self, field_name):
+        """Group results by a field"""
+        clone = self._clone()
+        clone.query.add_collapse(field_name)
+        return clone
+ 
     
     def highlight(self):
         """Adds highlighting to the results."""

--- a/haystack/routers.py
+++ b/haystack/routers.py
@@ -1,10 +1,10 @@
 from haystack.constants import DEFAULT_ALIAS
 
+from django.utils.translation import get_language
 
 class BaseRouter(object):
     # Reserved for future extension.
     pass
-
 
 class DefaultRouter(BaseRouter):
     def for_read(self, **hints):
@@ -13,3 +13,8 @@ class DefaultRouter(BaseRouter):
     def for_write(self, **hints):
         return DEFAULT_ALIAS
     
+class LanguageRouter(BaseRouter):
+    def for_read(self, **hints):
+        return 'default_'+get_language()
+    def for_write(self, **hints):
+        return 'default_'+get_language()

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -98,6 +98,12 @@ class ConnectionHandler(object):
         self.ensure_defaults(key)
         self._connections[key] = load_backend(self.connections_info[key]['ENGINE'])(using=key)
         return self._connections[key]
+     
+    def __iter__(self):
+        return self.iterkeys()
+        
+    def iterkeys(self):
+        return self.connections_info.iterkeys()
     
     def all(self):
         return [self[alias] for alias in self.connections_info]

--- a/haystack/views.py
+++ b/haystack/views.py
@@ -199,7 +199,10 @@ def basic_search(request, template='search/search.html', load_all=True, form_cla
     else:
         form = form_class(searchqueryset=searchqueryset, load_all=load_all)
     
-    paginator = Paginator(results, results_per_page or RESULTS_PER_PAGE)
+    # this should not be necessary, but somehow when using field collapsing some None results are returned.
+    results_list = filter(None,results)
+    
+    paginator = Paginator(results_list, results_per_page or RESULTS_PER_PAGE)
     
     try:
         page = paginator.page(int(request.GET.get('page', 1)))


### PR DESCRIPTION
I added support for field collapsing with the solr backend.

cf http://groups.google.com/group/django-haystack/browse_thread/thread/7ad2466ce4f7993c?pli=1

SearchQuerySet has a collapse_by(self, field) function that will activate collapsing of results on the given field.

I didn't dive into haystack long enough to pretend it's a clean feature. But it works for me, it might deserve to be reviewed and amended if needed.

A few remarks for future work on this feature:

From what I have seen pysolr cannot run a query with grouping option activated without asking for a flat list of results (option group.main), the format returned without this option isn't supported and results aren't processed. Therefore the group value and size data is lost.

It would be nice also to make it easy to expand a group (e.g. 'more from this website'). It means running the same query after removing the collapse option and adding a filter on the current group value. I don't know if it deserves to be done by a template tag or directly in the search templates.

Alban