### PR TITLE
Adapted the documentation of the highlight tag to work for a standard Sea

### DIFF
--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -25,15 +25,16 @@ Syntax::
 
 Example::
 
+    {% load highlight %}
     # Highlight summary with default behavior.
-    {% highlight result.summary with request.query %}
+    {% highlight result.summary with query %}
     
     # Highlight summary but wrap highlighted words with a div and the
     # following CSS class.
-    {% highlight result.summary with request.query html_tag "div" class "highlight_me_please" %}
+    {% highlight result.summary with query html_tag "div" class "highlight_me_please" %}
     
     # Highlight summary but only show 40 words.
-    {% highlight result.summary with request.query max_length 40 %}
+    {% highlight result.summary with query max_length 40 %}
 
 The highlighter used by this tag can be overridden as needed. See the
 :doc:`highlighting` documentation for more information.


### PR DESCRIPTION
Adapted the documentation of the highlight tag to work for a standard SearchView
- highlight tag must be loaded before it can be used;
- SearchView exposes query in the context, not in result.query
