### PR TITLE
Silly little change, I know.. but I actually ran into a case where I acci

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -317,7 +317,7 @@ class SearchQuerySet(object):
 
         for model in models:
             if not model in connections[self.query._using].get_unified_index().get_indexed_models():
-                warnings.warn('The model %r is not registered for search.' % model)
+                warnings.warn('The model %r is not registered for search.' % (model,))
 
             clone.query.add_model(model)
 


### PR DESCRIPTION
Silly little change, I know.. but I actually ran into a case where I accidentally passed a list of models in without *ing them. When that happens, we get a string formatting exception (not all arguments were formatted) instead of the useful "that ain't a model, kid" business.
