### PR TITLE
Fix for compatibility with django's development version

### DIFF
--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -1,6 +1,7 @@
 from django.contrib.admin.options import ModelAdmin
-from django.contrib.admin.views.main import (ChangeList, MAX_SHOW_ALL_ALLOWED,
-                                             SEARCH_VAR)
+from django.contrib.admin.views.main import (ChangeList, SEARCH_VAR)
+if not hasattr(ModelAdmin, 'list_max_show_all'):
+    from django.contrib.admin.views.main import MAX_SHOW_ALL_ALLOWED
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, InvalidPage
 from django.shortcuts import render_to_response
@@ -36,7 +37,7 @@ class SearchChangeList(ChangeList):
         result_count = paginator.count
         full_result_count = SearchQuerySet().models(self.model).all().count()
         
-        can_show_all = result_count <= MAX_SHOW_ALL_ALLOWED
+        can_show_all = result_count <= self.list_max_show_all if hasattr(ModelAdmin, 'list_max_show_all') else result_count <= MAX_SHOW_ALL_ALLOWED
         multi_page = result_count > self.list_per_page
         
         # Get the list of objects to display on this page.


### PR DESCRIPTION
Hi Daniel,

Changes in Django's development version (see ticket #15997 https://code.djangoproject.com/ticket/15997 ) removed MAX_SHOW_ALL_ALLOWED  which was used in haystack code.

The change is backward compatible

Regards,

SM
