### PR TITLE
Why destroy the passed kwargs?

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -115,13 +115,11 @@ class SolrSearchBackend(BaseSearchBackend):
                 'hits': 0,
             }
 
-        kwargs = {
-            'fl': '* score',
-        }
-
         if fields:
             kwargs['fl'] = fields
-
+        else:
+            kwargs['fl'] = '* score'
+            
         if sort_by is not None:
             kwargs['sort'] = sort_by
 


### PR DESCRIPTION
Why is the passed kwargs discarded ? 
raw_query params did not work for me.
