### PR TITLE
MemoryError caused due to in memory list creation with very large indexes.

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -198,7 +198,6 @@ class Command(AppCommand):
             if self.verbosity >= 1:
                 print "Indexing %d %s." % (total, smart_str(model._meta.verbose_name_plural))
             
-            pks_seen = set([smart_str(pk) for pk in qs.values_list('pk', flat=True)])
             batch_size = self.batchsize or self.backend.batch_size
             
             if self.workers > 0:
@@ -217,6 +216,8 @@ class Command(AppCommand):
                 pool.map(worker, ghetto_queue)
             
             if self.remove:
+                pks_seen = set([smart_str(pk) for pk in qs.values_list('pk', flat=True)])
+                
                 if self.age or total <= 0:
                     # They're using a reduced set, which may not incorporate
                     # all pks. Rebuild the list with everything.


### PR DESCRIPTION
Issue is caused with large indexes(>10M), update_index mgmt command creates a python list in memory ok all pks_seen and then spits out MemoryError.
