### PR TITLE
Make identifier tolerant of different sorts of primary keys

### DIFF
--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -3,7 +3,7 @@ from haystack.constants import ID, DJANGO_CT, DJANGO_ID
 from haystack.utils.highlighting import Highlighter
 
 
-IDENTIFIER_REGEX = re.compile('^[\w\d_]+\.[\w\d_]+\.\d+$')
+IDENTIFIER_REGEX = re.compile('^[\w\d_]+\.[\w\d_]+\..+$')
 
 
 def get_model_ct(model):


### PR DESCRIPTION
This is a fix for an issue related to issue #399 (https://github.com/toastdriven/django-haystack/issues/399).

I had an issue running the tests. Nothing would run (even before I'd made any changes) because `SITE_ID` wasn't set in the settings. I set that temporarily and the tests all ran fine.
