### PR TITLE
Allow custom analyzer for whoosh backend

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -153,7 +153,7 @@ class WhooshSearchBackend(BaseSearchBackend):
             elif field_class.field_type == 'edge_ngram':
                 schema_fields[field_class.index_fieldname] = NGRAMWORDS(minsize=2, maxsize=15, at='start', stored=field_class.stored, field_boost=field_class.boost)
             else:
-                schema_fields[field_class.index_fieldname] = TEXT(stored=True, analyzer=StemmingAnalyzer(), field_boost=field_class.boost)
+                schema_fields[field_class.index_fieldname] = TEXT(stored=True, analyzer=field_class.analyzer or StemmingAnalyzer(), field_boost=field_class.boost)
 
             if field_class.document is True:
                 content_field_name = field_class.index_fieldname

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -21,7 +21,7 @@ class SearchField(object):
     def __init__(self, model_attr=None, use_template=False, template_name=None,
                  document=False, indexed=True, stored=True, faceted=False,
                  default=NOT_PROVIDED, null=False, index_fieldname=None,
-                 facet_class=None, boost=1.0, weight=None):
+                 facet_class=None, boost=1.0, weight=None, analyzer=None):
         # Track what the index thinks this field is called.
         self.instance_name = None
         self.model_attr = model_attr
@@ -36,6 +36,7 @@ class SearchField(object):
         self.index_fieldname = index_fieldname
         self.boost = weight or boost
         self.is_multivalued = False
+        self.analyzer = analyzer
         
         # We supply the facet_class for making it easy to create a faceted
         # field based off of this field.


### PR DESCRIPTION
Currently the whoosh backend use StemmingAnalyzer for text fields. But sometimes we want to use other analyzer under some circumstances. For example, we may want to change the regular expression for the StemmingAnalyzer or we want a specific analyzer for some foreign languages.

This patch added analyzer argument for the SearchField. And user could use this argument to specify another analyzer other than the default one.
