### PR TITLE
Added missing reference to README.rst.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ recursive-include docs *
 recursive-include haystack/templates/search_configuration *.xml
 include AUTHORS
 include LICENSE
+include README.rst


### PR DESCRIPTION
Hi,
I've fixed the "No such file or directory: 'README.rst'" exception raised when updating django-haystack to the new v1.2.6 release.
Thanks again for this great app.
Cheers,
Sebastien
