### PR TITLE
Import geospatial modules only when needed

### DIFF
--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -10,9 +10,7 @@ from haystack.constants import DJANGO_CT, VALID_FILTERS, FILTER_SEPARATOR, DEFAU
 from haystack.exceptions import MoreLikeThisError, FacetingError
 from haystack.inputs import Clean
 from haystack.models import SearchResult
-from haystack.utils.geo import ensure_point, ensure_distance
 from haystack.utils.loading import UnifiedIndex
-
 
 VALID_GAPS = ['year', 'month', 'day', 'hour', 'minute', 'second']
 
@@ -700,6 +698,7 @@ class BaseSearchQuery(object):
 
     def add_within(self, field, point_1, point_2):
         """Adds bounding box parameters to search query."""
+        from haystack.utils.geo import ensure_point
         self.within = {
             'field': field,
             'point_1': ensure_point(point_1),
@@ -708,6 +707,7 @@ class BaseSearchQuery(object):
 
     def add_dwithin(self, field, point, distance):
         """Adds radius-based parameters to search query."""
+        from haystack.utils.geo import ensure_point, ensure_distance
         self.dwithin = {
             'field': field,
             'point': ensure_point(point),
@@ -719,6 +719,7 @@ class BaseSearchQuery(object):
         Denotes that results should include distance measurements from the
         point passed in.
         """
+        from haystack.utils.geo import ensure_point
         self.distance_point = {
             'field': field,
             'point': ensure_point(point),

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -9,7 +9,6 @@ from haystack.exceptions import MissingDependency, MoreLikeThisError
 from haystack.inputs import PythonData, Clean, Exact
 from haystack.models import SearchResult
 from haystack.utils import get_identifier
-from haystack.utils.geo import Distance, generate_bounding_box
 try:
     from django.db.models.sql.query import get_proxied_model
 except ImportError:
@@ -208,6 +207,8 @@ class SolrSearchBackend(BaseSearchBackend):
             kwargs['fq'] = list(narrow_queries)
 
         if within is not None:
+            from haystack.utils.geo import generate_bounding_box
+
             kwargs.setdefault('fq', [])
             ((min_lat, min_lng), (max_lat, max_lng)) = generate_bounding_box(within['point_1'], within['point_2'])
             # Bounding boxes are min, min TO max, max. Solr's wiki was *NOT*
@@ -360,6 +361,7 @@ class SolrSearchBackend(BaseSearchBackend):
                     additional_fields['_point_of_origin'] = distance_point
 
                     if raw_result.get('__dist__'):
+                        from haystack.utils.geo import Distance
                         additional_fields['_distance'] = Distance(km=float(raw_result['__dist__']))
                     else:
                         additional_fields['_distance'] = None

--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -14,17 +14,17 @@ class Command(BaseCommand):
                     help='If provided, chooses a connection to work with.'),
     )
     option_list = BaseCommand.option_list + base_options
-    
+
     def handle(self, **options):
         """Generates a Solr schema that reflects the indexes."""
         using = options.get('using')
         schema_xml = self.build_template(using=using)
-        
+
         if options.get('filename'):
             self.write_file(options.get('filename'), schema_xml)
         else:
             self.print_stdout(schema_xml)
-    
+
     def build_context(self, using):
         from haystack import connections, connection_router
         backend = connections[using].get_backend()
@@ -37,12 +37,12 @@ class Command(BaseCommand):
             'DJANGO_CT': DJANGO_CT,
             'DJANGO_ID': DJANGO_ID,
         })
-    
+
     def build_template(self, using):
         t = loader.get_template('search_configuration/solr.xml')
         c = self.build_context(using=using)
         return t.render(c)
-    
+
     def print_stdout(self, schema_xml):
         sys.stderr.write("\n")
         sys.stderr.write("\n")
@@ -51,7 +51,7 @@ class Command(BaseCommand):
         sys.stderr.write("--------------------------------------------------------------------------------------------\n")
         sys.stderr.write("\n")
         print schema_xml
-    
+
     def write_file(self, filename, schema_xml):
         schema_file = open(filename, 'w')
         schema_file.write(schema_xml)

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.utils.encoding import force_unicode
 from django.utils.text import capfirst
 from haystack.exceptions import NotHandled, SpatialError
-from haystack.utils.geo import Distance
 
 try:
     from geopy import distance as geopy_distance
@@ -99,6 +98,8 @@ class SearchResult(object):
     model = property(_get_model, _set_model)
 
     def _get_distance(self):
+        from haystack.utils.geo import Distance
+
         if self._distance is None:
             # We didn't get it from the backend & we haven't tried calculating
             # it yet. Check if geopy is available to do it the "slow" way


### PR DESCRIPTION
Otherwise, Haystack users who have no need for geospatial indexing will find themselves needing to satisfy a laundry list of requirements that they have no need for.

Thanks!
