### PR TITLE
Fixing issue #480

### DIFF
--- a/haystack/forms.py
+++ b/haystack/forms.py
@@ -2,13 +2,14 @@ from django import forms
 from django.db import models
 from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
+from django.utils.encoding import smart_unicode
 from haystack import connections
 from haystack.constants import DEFAULT_ALIAS
 from haystack.query import SearchQuerySet, EmptySearchQuerySet
 
 
 def model_choices(using=DEFAULT_ALIAS):
-    choices = [("%s.%s" % (m._meta.app_label, m._meta.module_name), capfirst(unicode(m._meta.verbose_name_plural))) for m in connections[using].get_unified_index().get_indexed_models()]
+    choices = [("%s.%s" % (m._meta.app_label, m._meta.module_name), capfirst(smart_unicode(m._meta.verbose_name_plural))) for m in connections[using].get_unified_index().get_indexed_models()]
     return sorted(choices, key=lambda x: x[1])
 
 


### PR DESCRIPTION
Fixing issue #480, using `smart_unicode` instead of only `unicode` , to allow `verbose_name` be of the form u'blah, blá, blah`
