### PR TITLE
Handle sorting for ElasticSearch better.

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -752,8 +752,8 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             for field in self.order_by:
                 direction = 'asc'
                 if field.startswith('-'):
-                    direction = 'dest'
-                    field = field[1:] 
+                    direction = 'desc'
+                    field = field[1:]
                 order_by_list.append((field, direction))
 
             search_kwargs['sort_by'] = order_by_list


### PR DESCRIPTION
sort_by argument to seach() method wasn't handled properly, this should fix it.
