### PR TITLE
If limitting by models, do it only once. Fixes #457

### DIFF
--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -505,7 +505,7 @@ class BaseSearchQuery(object):
         """Generates the query that matches all documents."""
         return '*'
 
-    def build_query(self):
+    def build_query(self, omit_models=False):
         """
         Interprets the collected query metadata and builds the final query to
         be sent to the backend.
@@ -516,7 +516,7 @@ class BaseSearchQuery(object):
             # Match all.
             query = self.matching_all_fragment()
 
-        if len(self.models):
+        if len(self.models) and not omit_models:
             models = sorted(['%s:%s.%s' % (DJANGO_CT, model._meta.app_label, model._meta.module_name) for model in self.models])
             models_clause = ' OR '.join(models)
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -747,12 +747,19 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
 
     def run(self, spelling_query=None, **kwargs):
         """Builds and executes the query. Returns a list of search results."""
-        final_query = self.build_query()
+        final_query = self.build_query(omit_models=True)
         search_kwargs = {
             'start_offset': self.start_offset,
             'result_class': self.result_class,
         }
         order_by_list = None
+
+        # if limitting by models...
+        if self.models:
+            # ...put that into narrow queries...
+            self.narrow_queries.add('%s:(%s)' % (DJANGO_CT, ' OR '.join(str(model._meta) for model in self.models)))
+            # ...and disable additional limitting to ALL models
+            search_kwargs['limit_to_registered_models'] = False
 
         if self.order_by:
             if order_by_list is None:


### PR DESCRIPTION
Fixes #457 for ElasticSearch backend, I _believe_ the same approach can be used for other backends as well.
