### PR TITLE
Add --template option to management.build_solr_schema

### DIFF
--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -10,15 +10,17 @@ class Command(BaseCommand):
     base_options = (
         make_option("-f", "--filename", action="store", type="string",
                     dest="filename",
-                    help="""If provided, directs output to a file instead of
-                    stdout."""),
+                    help="If provided, directs output to a file instead of"
+                    " stdout."),
         make_option("-u", "--using", action="store", type="string",
                     dest="using", default=DEFAULT_ALIAS,
                     help='If provided, chooses a connection to work with.'),
         make_option("-t", "--template", action="store", type="string",
                     dest="template",
-                    help="""If provided, generates schema.xml from custom
-                    template instead of Haystack's default.""",
+                    help="If provided, generates schema.xml from custom "
+                    "template instead of Haystack's default. Requires an "
+                    "absolute path to the template file, e.g.:\n"
+                    "'/myproj/myapp/templates/search/mysolr.xml'.",
                     default="search_configuration/solr.xml"),
     )
     option_list = BaseCommand.option_list + base_options


### PR DESCRIPTION
This patch provides support for specifying a template to use to generate `schema.xml`, and uses the one provided by Haystack as the default.
