### PR TITLE
Handle data saved from django fixtures better even with inheritance

### DIFF
--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -215,6 +215,11 @@ class SearchIndex(threading.local):
         used. Default relies on the routers to decide which backend should
         be used.
         """
+        if kwargs.get('raw', False):
+            # if loading inherited models from fixtures Django will pass in a crippled instance
+            # see https://code.djangoproject.com/ticket/13299
+            instance = instance.__class__._default_manager.get(pk=instance.pk)
+
         # Check to make sure we want to index this first.
         if self.should_update(instance, **kwargs):
             self._get_backend(using).update(self, [instance])


### PR DESCRIPTION
When loading inherited models from fixtures, Django doesn't pass in a valid object through the post_save signal. Detect this and compensate.

see https://code.djangoproject.com/ticket/13299 for details
