### PR TITLE
Better solr update error reporting

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -51,15 +51,21 @@ class SearchBackend(BaseSearchBackend):
     def update(self, index, iterable, commit=True):
         docs = []
         
-        try:
-            for obj in iterable:
+        for obj in iterable:
+            try:
                 docs.append(index.full_prepare(obj))
-        except UnicodeDecodeError:
-            if not self.silently_fail:
-                raise
-            
-            self.log.error("Chunk failed.\n")
-        
+            except UnicodeDecodeError:
+                if not self.silently_fail:
+                    raise
+
+                # We'll log the object identifier but won't include the actual object
+                # to avoid the possibility of that generating encoding errors while
+                # processing the log message:
+                self.log.error(u"UnicodeDecodeError while preparing object for update",
+                               exc_info=True,
+                               extra={"data": {"index": index,
+                                               "object": get_identifier(obj)}})
+
         if len(docs) > 0:
             try:
                 self.conn.add(docs, commit=commit, boost=index.get_field_weights())


### PR DESCRIPTION
Two changes:
1. Log more context about a failure and do so in a format which provides the raw data for tools like Sentry
2. Do this inside the for loop so a single object can be skipped without dropping the rest of its batch

As discussed on IRC, this makes an immediate improvement for me but might make more sense to refactor into a common method on the base class. Perhaps do that when updating for 2.x?
