### PR TITLE
fixing __all__ typo

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -8,7 +8,7 @@ from haystack.utils import loading
 
 __author__ = 'Daniel Lindsley'
 __version__ = (2, 0, 0, 'beta')
-__all__ = ['backend']
+__all__ = ['backends']
 
 
 # Setup default logging.


### PR DESCRIPTION
Fixed the typo in the name of the submodule
