### PR TITLE
Fix Import errors when Indexable is imported by name.

### DIFF
--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -170,7 +170,7 @@ class UnifiedIndex(object):
 
                 continue
 
-            for item_name, item in inspect.getmembers(search_index_module, lambda obj: issubclass(obj, Indexable):
+            for item_name, item in inspect.getmembers(search_index_module, lambda obj: inspect.isclass(obj) and Indexable in obj.__bases__):
                 if getattr(item, 'haystack_use_for_indexing', False):
                     # We've got an index. Check if we should be ignoring it.
                     class_path = "%s.search_indexes.%s" % (app, item_name)


### PR DESCRIPTION
Make sure that haystack does not pick up any old class, just classes that actually _subclass_ Indexable.
