### PR TITLE
Update readme to use new/updated Whoosh URL.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Elasticsearch_, Whoosh_, Xapian_, etc.) without having to modify your code.
 
 .. _Solr: http://lucene.apache.org/solr/
 .. _Elasticsearch: http://elasticsearch.org/
-.. _Whoosh: http://whoosh.ca/
+.. _Whoosh: https://bitbucket.org/mchaput/whoosh/
 .. _Xapian: http://xapian.org/
 
 Haystack is BSD licensed, plays nicely with third-party app without needing to


### PR DESCRIPTION
The previous was just a redirect page.
