### PR TITLE
Fixes process leak when using update_index with workers.

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -228,6 +228,7 @@ class Command(LabelCommand):
             if self.workers > 0:
                 pool = multiprocessing.Pool(self.workers)
                 pool.map(worker, ghetto_queue)
+                pool.terminate()
 
             if self.remove:
                 if self.start_date or self.end_date or total <= 0:
@@ -251,3 +252,4 @@ class Command(LabelCommand):
                 if self.workers > 0:
                     pool = multiprocessing.Pool(self.workers)
                     pool.map(worker, ghetto_queue)
+                    pool.terminate()


### PR DESCRIPTION
Currently I am calling update_index, with workers, using call_command multiple times from the same process. The workers used by the command are never destroyed. This patch fixes the issue.

I am using pool.terminate() instead of pool.close() because pool.close() suffers from a [bug](http://lists.opensuse.org/opensuse-bugs/2012-02/msg02297.html) on Python 2.7.2.
