### PR TITLE
Patching HAYSTACK_EXLUCDED_INDEXES bug.

### DIFF
--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -150,7 +150,7 @@ class UnifiedIndex(object):
         self.fields = SortedDict()
         self._built = False
         self._indexes_setup = False
-        self.excluded_indexes = excluded_indexes or []
+        self.excluded_indexes = excluded_indexes or getattr(settings, 'HAYSTACK_EXCLUDED_INDEXES', [])
         self.excluded_indexes_ids = {}
         self.document_field = getattr(settings, 'HAYSTACK_DOCUMENT_FIELD', 'text')
         self._fieldnames = {}


### PR DESCRIPTION
Specifying 
`HAYSTACK_EXCLUDED_INDEXES = ['path.to.exlucded.index',]` 
in a project's settings file should now be respected and each specified index in the setting should be excluded appropriately.
