### PR TITLE
Fixes bug __in filter tag with Whoosh

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -830,7 +830,7 @@ class WhooshSearchQuery(BaseSearchQuery):
                     if is_datetime is True:
                         pv = self._convert_datetime(pv)
 
-                    in_options.append('"%s"' % pv)
+                    in_options.append('%s' % pv)
 
                 query_frag = "(%s)" % " OR ".join(in_options)
             elif filter_type == 'range':


### PR DESCRIPTION
Fixes bug for the __in filter tag using whoosh backend. wrapping the value with quotation marks never worked, I had the same problem in haystack v1 and had to use a fork for that.

Hope that you can merge this fork quickly, thank you !
