### PR TITLE
A couple Solr specific improvements

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -399,9 +399,11 @@ class SolrSearchBackend(BaseSearchBackend):
         schema_fields = []
 
         for field_name, field_class in fields.items():
+            field_text_type = (getattr(field_class, "field_text_type", None) or "text_en")
+
             field_data = {
                 'field_name': field_class.index_fieldname,
-                'type': 'text_en',
+                'type': field_text_type,
                 'indexed': 'true',
                 'stored': 'true',
                 'multi_valued': 'false',
@@ -440,13 +442,13 @@ class SolrSearchBackend(BaseSearchBackend):
 
                 # If it's text and not being indexed, we probably don't want
                 # to do the normal lowercase/tokenize/stemming/etc. dance.
-                if field_data['type'] == 'text_en':
+                if field_data['type'] == field_text_type:
                     field_data['type'] = 'string'
 
             # If it's a ``FacetField``, make sure we don't postprocess it.
             if hasattr(field_class, 'facet_for'):
                 # If it's text, it ought to be a string.
-                if field_data['type'] == 'text_en':
+                if field_data['type'] == field_text_type:
                     field_data['type'] = 'string'
 
             schema_fields.append(field_data)

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -20,7 +20,7 @@ class SearchField(object):
     def __init__(self, model_attr=None, use_template=False, template_name=None,
                  document=False, indexed=True, stored=True, faceted=False,
                  default=NOT_PROVIDED, null=False, index_fieldname=None,
-                 facet_class=None, boost=1.0, weight=None):
+                 facet_class=None, boost=1.0, weight=None, field_text_type = None):
         # Track what the index thinks this field is called.
         self.instance_name = None
         self.model_attr = model_attr
@@ -35,6 +35,7 @@ class SearchField(object):
         self.index_fieldname = index_fieldname
         self.boost = weight or boost
         self.is_multivalued = False
+        self.field_text_type = field_text_type
 
         # We supply the facet_class for making it easy to create a faceted
         # field based off of this field.

--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -12,13 +12,16 @@ class Command(BaseCommand):
                     help='If provided, directs output to a file instead of stdout.'),
         make_option("-u", "--using", action="store", type="string", dest="using", default=DEFAULT_ALIAS,
                     help='If provided, chooses a connection to work with.'),
+        make_option("-t", "--template", action="store", type="string", dest="template", default='search_configuration/solr.xml',
+                    help='Choose an XML template for the schema.'),
     )
     option_list = BaseCommand.option_list + base_options
 
     def handle(self, **options):
         """Generates a Solr schema that reflects the indexes."""
         using = options.get('using')
-        schema_xml = self.build_template(using=using)
+        template = options.get("template")
+        schema_xml = self.build_template(template, using)
 
         if options.get('filename'):
             self.write_file(options.get('filename'), schema_xml)
@@ -38,8 +41,8 @@ class Command(BaseCommand):
             'DJANGO_ID': DJANGO_ID,
         })
 
-    def build_template(self, using):
-        t = loader.get_template('search_configuration/solr.xml')
+    def build_template(self, template, using):
+        t = loader.get_template(template)
         c = self.build_context(using=using)
         return t.render(c)
 


### PR DESCRIPTION
These patches add support for an alternative schema template in build_solr_schema, and an option to change the Solr text field type (from the hard-coded default `text_en`) per-field.