### PR TITLE
Fix exception in SearchIndex.get_model()

### DIFF
--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -117,7 +117,7 @@ class SearchIndex(threading.local):
 
         This method is required & you must override it to return the correct class.
         """
-        return NotImplementedError("You must provide a 'model' method for the '%r' index." % self)
+        raise NotImplementedError("You must provide a 'model' method for the '%r' index." % self)
 
     def index_queryset(self):
         """


### PR DESCRIPTION
This patch fixes `SearchIndex.get_model()` to raise `NotImplementedError` instead of returning it.
