### PR TITLE
Bug fix to allow object removal without a commit

### DIFF
--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -228,7 +228,7 @@ class SearchIndex(threading.local):
         used. Default relies on the routers to decide which backend should
         be used.
         """
-        self._get_backend(using).remove(instance)
+        self._get_backend(using).remove(instance, **kwargs)
 
     def clear(self, using=None):
         """


### PR DESCRIPTION
On removing objects, controlling "commit=False" was not possible since kwargs were not passed on to  remove function.
