### PR TITLE
Refactor SolrSearchBackend.search so that kwarg-generation operations are in a discrete method.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,3 +63,4 @@ Thanks to
     * Alex Vidal (avidal) for a patch allowing developers to override the queryset used for update operations.
     * Igor Támara (ikks) for a patch related to Unicode ``verbose_name_plural``.
     * Dan Helfman (witten) for a patch related to highlighting.
+    * Matt DeBoard for refactor of ``SolrSearchBackend.search`` method to allow simpler extension of the class.


### PR DESCRIPTION
This makes it much simpler to subclass `SolrSearchBackend` to add support for new parameters. Currently, you have to -- as far as I know -- copy and paste the entire `search` method and insert your code where needed. By factoring out the creation of the dictionary to a discrete method you can simply override & extend the `_build_search_kwargs` method:

``` python
class MySolrSearchBackend(SolrSearchBackend):
    def _build_search_kwargs(new_param="somevalue", **kwargs):
        kwargs = super(MySolrSearchBackend, self)._build_search_kwargs(**kwargs)
        kwargs['new_param'] = new_param
        return kwargs
```

All tests pass.
