### PR TITLE
Add support for Django ORM-like 'extras' method to specify extra search ...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,4 +63,4 @@ Thanks to
     * Alex Vidal (avidal) for a patch allowing developers to override the queryset used for update operations.
     * Igor Támara (ikks) for a patch related to Unicode ``verbose_name_plural``.
     * Dan Helfman (witten) for a patch related to highlighting.
-    * Matt DeBoard for refactor of ``SolrSearchBackend.search`` method to allow simpler extension of the class.
+    * Matt DeBoard for refactor of ``SolrSearchBackend.search`` method to allow simpler extension of the class, and for contributing the ``extra`` method to ``SearchQuerySet``.

--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -622,6 +622,9 @@ class BaseSearchQuery(object):
         if subtree:
             self.query_filter.end_subtree()
 
+    def add_extras(self, extra_dict=None):
+        raise NotImplementedError
+
     def add_order_by(self, field):
         """Orders the search result by a field."""
         self.order_by.append(field)

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -491,6 +491,23 @@ class SolrSearchBackend(BaseSearchBackend):
 
 
 class SolrSearchQuery(BaseSearchQuery):
+    def __init__(self, **kwargs):
+        super(SolrSearchQuery, self).__init__(**kwargs)
+        self.extras = {}
+
+    def _clone(self, **kwargs):
+        clone = super(SolrSearchQuery, self)._clone(**kwargs)
+        clone.extras = self.extras.copy()
+        return clone
+
+    def add_extras(self, extras):
+        """
+        Adds any 'extra' search params & values to a query at
+        search-time.
+
+        """
+        self.extras.update(extras)
+        
     def matching_all_fragment(self):
         return '*:*'
 
@@ -667,6 +684,8 @@ class SolrSearchQuery(BaseSearchQuery):
 
         if self.distance_point:
             search_kwargs['distance_point'] = self.distance_point
+
+        search_kwargs['extras'] = self.extras
 
         results = self.backend.search(final_query, **search_kwargs)
         self._results = results.get('results', [])

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -532,6 +532,26 @@ class SearchQuerySet(object):
         qs._flat = flat
         return qs
 
+    def extra(self, extras_dict=None):
+        """
+        Support for Django ORM-style ``extra`` specification to pass in
+        search-time search params.
+
+        ``extras_dict`` must be type ``dict`` or another type that can be
+        coerced to a ``dict``, e.g.
+
+        ```
+        sqs = DESearchQuerySet().extra([('rows', '1'), ('mlt', 'false')])
+        ```
+        
+        """
+        if not extras_dict:
+            return
+
+        clone = self._clone()
+        clone.query.add_extras(dict(extras_dict))
+        return clone
+
     # Utility methods.
 
     def _clone(self, klass=None):


### PR DESCRIPTION
...parameters that will not be processed in any way, except to be passed directly to Solr at search-time.

Added a test at `LiveSolrSearchQuerySetTestCase.test_extra`.

The new test passes. I also tested as much of the tests on master branch as I could, but there were a few that I couldn't get to pass, likely due to a misconfiguration in Solr. The failures were constrained to `more_like_this`-related tests I'm pretty confident they're not impacted by this change.
