### PR TITLE
Refactor Solr & ES SearchQuery subclasses to use the ``build_params`` fr...

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -758,12 +758,10 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
 
         return u"{!%s %s}" % (parser_name, ' '.join(kwarg_bits))
 
-    def run(self, spelling_query=None, **kwargs):
-        """Builds and executes the query. Returns a list of search results."""
-        final_query = self.build_query()
+    def build_params(self, spelling_query=None, **kwargs):
         search_kwargs = {
             'start_offset': self.start_offset,
-            'result_class': self.result_class,
+            'result_class': self.result_class
         }
         order_by_list = None
 
@@ -771,52 +769,56 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             if order_by_list is None:
                 order_by_list = []
 
+            for order_by in self.order_by:
+                if order_by.startswith('-'):
+                    order_by_list.append('%s desc' % order_by[1:])
+                else:
+                    order_by_list.append('%s asc' % order_by)
 
-            for field in self.order_by:
-                direction = 'asc'
-                if field.startswith('-'):
-                    direction = 'desc'
-                    field = field[1:]
-                order_by_list.append((field, direction))
-
-            search_kwargs['sort_by'] = order_by_list
-
-        if self.end_offset is not None:
-            search_kwargs['end_offset'] = self.end_offset
-
-        if self.highlight:
-            search_kwargs['highlight'] = self.highlight
-
-        if self.facets:
-            search_kwargs['facets'] = list(self.facets)
+            search_kwargs['sort_by'] = ", ".join(order_by_list)
 
         if self.date_facets:
             search_kwargs['date_facets'] = self.date_facets
 
-        if self.query_facets:
-            search_kwargs['query_facets'] = self.query_facets
-
-        if self.narrow_queries:
-            search_kwargs['narrow_queries'] = self.narrow_queries
-
-        if self.fields:
-            search_kwargs['fields'] = self.fields
-
-        if self.models:
-            search_kwargs['models'] = self.models
-
-        if spelling_query:
-            search_kwargs['spelling_query'] = spelling_query
-
-        if self.within:
-            search_kwargs['within'] = self.within
+        if self.distance_point:
+            search_kwargs['distance_point'] = self.distance_point
 
         if self.dwithin:
             search_kwargs['dwithin'] = self.dwithin
 
-        if self.distance_point:
-            search_kwargs['distance_point'] = self.distance_point
+        if self.end_offset is not None:
+            search_kwargs['end_offset'] = self.end_offset
 
+        if self.facets:
+            search_kwargs['facets'] = list(self.facets)
+
+        if self.fields:
+            search_kwargs['fields'] = self.fields
+
+        if self.highlight:
+            search_kwargs['highlight'] = self.highlight
+
+        if self.models:
+            search_kwargs['models'] = self.models
+
+        if self.narrow_queries:
+            search_kwargs['narrow_queries'] = self.narrow_queries
+
+        if self.query_facets:
+            search_kwargs['query_facets'] = self.query_facets
+
+        if self.within:
+            search_kwargs['within'] = self.within
+
+        if spelling_query:
+            search_kwargs['spelling_query'] = spelling_query
+
+        return search_kwargs
+        
+    def run(self, spelling_query=None, **kwargs):
+        """Builds and executes the query. Returns a list of search results."""
+        final_query = self.build_query()
+        search_kwargs = self.build_params(spelling_query, **kwargs)
         results = self.backend.search(final_query, **search_kwargs)
         self._results = results.get('results', [])
         self._hit_count = results.get('hits', 0)

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -610,13 +610,11 @@ class SolrSearchQuery(BaseSearchQuery):
 
         return u"{!%s %s}" % (parser_name, ' '.join(kwarg_bits))
 
-    def run(self, spelling_query=None, **kwargs):
-        """Builds and executes the query. Returns a list of search results."""
-        final_query = self.build_query()
+    def build_params(self, spelling_query=None, **kwargs):
         search_kwargs = {
             'start_offset': self.start_offset,
-            'result_class': self.result_class,
-        }
+            'result_class': self.result_class
+        }        
         order_by_list = None
 
         if self.order_by:
@@ -631,42 +629,48 @@ class SolrSearchQuery(BaseSearchQuery):
 
             search_kwargs['sort_by'] = ", ".join(order_by_list)
 
-        if self.end_offset is not None:
-            search_kwargs['end_offset'] = self.end_offset
-
-        if self.highlight:
-            search_kwargs['highlight'] = self.highlight
-
-        if self.facets:
-            search_kwargs['facets'] = list(self.facets)
-
         if self.date_facets:
             search_kwargs['date_facets'] = self.date_facets
-
-        if self.query_facets:
-            search_kwargs['query_facets'] = self.query_facets
-
-        if self.narrow_queries:
-            search_kwargs['narrow_queries'] = self.narrow_queries
-
-        if self.fields:
-            search_kwargs['fields'] = self.fields
-
-        if self.models:
-            search_kwargs['models'] = self.models
-
-        if spelling_query:
-            search_kwargs['spelling_query'] = spelling_query
-
-        if self.within:
-            search_kwargs['within'] = self.within
-
-        if self.dwithin:
-            search_kwargs['dwithin'] = self.dwithin
 
         if self.distance_point:
             search_kwargs['distance_point'] = self.distance_point
 
+        if self.dwithin:
+            search_kwargs['dwithin'] = self.dwithin
+
+        if self.end_offset is not None:
+            search_kwargs['end_offset'] = self.end_offset
+
+        if self.facets:
+            search_kwargs['facets'] = list(self.facets)
+
+        if self.fields:
+            search_kwargs['fields'] = self.fields
+
+        if self.highlight:
+            search_kwargs['highlight'] = self.highlight
+
+        if self.models:
+            search_kwargs['models'] = self.models
+
+        if self.narrow_queries:
+            search_kwargs['narrow_queries'] = self.narrow_queries
+
+        if self.query_facets:
+            search_kwargs['query_facets'] = self.query_facets
+
+        if self.within:
+            search_kwargs['within'] = self.within
+
+        if spelling_query:
+            search_kwargs['spelling_query'] = spelling_query
+
+        return search_kwargs
+        
+    def run(self, spelling_query=None, **kwargs):
+        """Builds and executes the query. Returns a list of search results."""
+        final_query = self.build_query()
+        search_kwargs = self.build_params(spelling_query, **kwargs)
         results = self.backend.search(final_query, **search_kwargs)
         self._results = results.get('results', [])
         self._hit_count = results.get('hits', 0)


### PR DESCRIPTION
...om `BaseSearchQuery` to build the kwargs to be passed to the search engine.

This refactor is made to make extending Haystack simpler. I only ran the Solr tests which invoked a `run` call (via `get_results`), and those passed. I did not run the ElasticSearch tests; however, the `run` method for both Lucene-based search engines were identical before, and are identical now. The test I did run -- `LiveSolrSearchQueryTestCase.test_log_query` -- passed.
