### PR TITLE
Fix for issue #563 (with unit tests)

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -829,8 +829,11 @@ class WhooshSearchQuery(BaseSearchQuery):
 
                     if is_datetime is True:
                         pv = self._convert_datetime(pv)
-
-                    in_options.append('"%s"' % pv)
+                    
+                    if isinstance(pv, basestring) and not is_datetime:
+                        in_options.append('"%s"' % pv)
+                    else:
+                        in_options.append('%s' % pv)
 
                 query_frag = "(%s)" % " OR ".join(in_options)
             elif filter_type == 'range':

--- a/tests/whoosh_tests/tests/whoosh_backend.py
+++ b/tests/whoosh_tests/tests/whoosh_backend.py
@@ -631,7 +631,7 @@ class LiveWhooshSearchQuerySetTestCase(TestCase):
         self.assertEqual(len(sqs), 2)
 
         sqs = self.sqs.auto_query('Indexed!').filter(pub_date__lte=date(2009, 2, 25)).filter(django_id__in=[1, 2]).exclude(name='daniel1')
-        self.assertEqual(sqs.query.build_query(), u'((\'Indexed!\') AND pub_date:([to 20090225000000]) AND django_id:("1" OR "2") AND NOT (name:(daniel1)))')
+        self.assertEqual(sqs.query.build_query(), u'((\'Indexed!\') AND pub_date:([to 20090225000000]) AND django_id:(1 OR 2) AND NOT (name:(daniel1)))')
         self.assertEqual(len(sqs), 1)
 
         sqs = self.sqs.auto_query('re-inker')

--- a/tests/whoosh_tests/tests/whoosh_query.py
+++ b/tests/whoosh_tests/tests/whoosh_query.py
@@ -78,7 +78,7 @@ class WhooshSearchQueryTestCase(TestCase):
         self.sq.add_filter(SQ(title__gte='B'))
         self.sq.add_filter(SQ(id__in=[1, 2, 3]))
         self.sq.add_filter(SQ(rating__range=[3, 5]))
-        self.assertEqual(self.sq.build_query(), u'((why) AND pub_date:([to 20090210015900]) AND author:({daniel to}) AND created:({to 20090212121300}) AND title:([B to]) AND id:("1" OR "2" OR "3") AND rating:([3 to 5]))')
+        self.assertEqual(self.sq.build_query(), u'((why) AND pub_date:([to 20090210015900]) AND author:({daniel to}) AND created:({to 20090212121300}) AND title:([B to]) AND id:(1 OR 2 OR 3) AND rating:([3 to 5]))')
 
     def test_build_query_in_filter_multiple_words(self):
         self.sq.add_filter(SQ(content='why'))
@@ -88,7 +88,7 @@ class WhooshSearchQueryTestCase(TestCase):
     def test_build_query_in_filter_datetime(self):
         self.sq.add_filter(SQ(content='why'))
         self.sq.add_filter(SQ(pub_date__in=[datetime.datetime(2009, 7, 6, 1, 56, 21)]))
-        self.assertEqual(self.sq.build_query(), u'((why) AND pub_date:("20090706015621"))')
+        self.assertEqual(self.sq.build_query(), u'((why) AND pub_date:(20090706015621))')
 
     def test_build_query_in_with_set(self):
         self.sq.add_filter(SQ(content='why'))
@@ -140,4 +140,4 @@ class WhooshSearchQueryTestCase(TestCase):
     def test_in_filter_values_list(self):
         self.sq.add_filter(SQ(content='why'))
         self.sq.add_filter(SQ(title__in=MockModel.objects.values_list('id', flat=True)))
-        self.assertEqual(self.sq.build_query(), u'((why) AND title:("1" OR "2" OR "3"))')
+        self.assertEqual(self.sq.build_query(), u'((why) AND title:(1 OR 2 OR 3))')


### PR DESCRIPTION
As mentioned in issue #563 unit tests are needed. This change effectively makes it so that non-string based arguments used in an __in operation do not have quotes put around them. String based arguments are still quoted.
