### PR TITLE
Highlight template tag throws VariableDoesNotExist Exception when index out of sync

### DIFF
--- a/haystack/templatetags/highlight.py
+++ b/haystack/templatetags/highlight.py
@@ -28,7 +28,11 @@ class HighlightNode(template.Node):
             self.max_length = template.Variable(max_length)
     
     def render(self, context):
-        text_block = self.text_block.resolve(context)
+        try:
+            text_block = self.text_block.resolve(context)
+        except template.VariableDoesNotExist:
+            return u''
+            
         query = self.query.resolve(context)
         kwargs = {}
         


### PR DESCRIPTION
Fixes #328.
This error is caught and an empty string is returned instead. 