### PR TITLE
Add support for __foo__ style values for SearchField.model_attr

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -72,8 +72,12 @@ class SearchField(object):
         if self.use_template:
             return self.prepare_template(obj)
         elif self.model_attr is not None:
-            # Check for `__` in the field for looking through the relation.
-            attrs = self.model_attr.split('__')
+            if self.model_attr.startswith('__'):
+                # Support special attributes that start with __
+                attrs = [self.model_attr]
+            else:
+                # Check for `__` in the field for looking through the relation.
+                attrs = self.model_attr.split('__')
             current_object = obj
 
             for attr in attrs:


### PR DESCRIPTION
I want to use the **unicode** method of my models as the content for EdgeNgramFields. This patch adds support for that.
