### PR TITLE
values() and values_list() fix for solr backend

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -665,6 +665,9 @@ class SolrSearchQuery(BaseSearchQuery):
         if spelling_query:
             search_kwargs['spelling_query'] = spelling_query
 
+        if kwargs:
+            search_kwargs.update(kwargs)
+
         return search_kwargs
         
     def run(self, spelling_query=None, **kwargs):
@@ -690,6 +693,9 @@ class SolrSearchQuery(BaseSearchQuery):
 
         if self.end_offset is not None:
             search_kwargs['end_offset'] = self.end_offset - self.start_offset
+
+        if kwargs:
+            search_kwargs.update(kwargs)
 
         results = self.backend.more_like_this(self._mlt_instance, additional_query_string, **search_kwargs)
         self._results = results.get('results', [])


### PR DESCRIPTION
Small fix to query solr only for specific fields when requested by the values() or values_list() methods
