### PR TITLE
Changed e.__name__ to e at exception log message in whoosh_backend.py

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -190,7 +190,7 @@ class WhooshSearchBackend(BaseSearchBackend):
                 # We'll log the object identifier but won't include the actual object
                 # to avoid the possibility of that generating encoding errors while
                 # processing the log message:
-                self.log.error(u"%s while preparing object for update" % e.__name__, exc_info=True, extra={
+                self.log.error(u"%s while preparing object for update" % e, exc_info=True, extra={
                     "data": {
                         "index": index,
                         "object": get_identifier(obj)
@@ -829,7 +829,7 @@ class WhooshSearchQuery(BaseSearchQuery):
 
                     if is_datetime is True:
                         pv = self._convert_datetime(pv)
-                    
+
                     if isinstance(pv, basestring) and not is_datetime:
                         in_options.append('"%s"' % pv)
                     else:


### PR DESCRIPTION
Example:

```
#python code

class Project(models.Model):
    ...
    extras = models.OneToOneField("ProjectExtras", related_name="project", null=True, default=None)

class ProjectIndex(indexes.RealTimeSearchIndex, indexes.Indexable):
    text = indexes.CharField(document=True)
    ...
    extras = indexes.DateTimeField(model_attr='extras', null=True)
```

Now I try to load some fixtures and I have this error

```
Trying import local.py settings...
Trying import development.py settings...
Installed 2 object(s) from 1 fixture(s)
Traceback (most recent call last):
  File "./manage.py", line 8, in <module>
    execute_from_command_line(sys.argv)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
    utility.execute()
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(*args, **options)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/db/transaction.py", line 209, in inner
    return func(*args, **kwargs)
  File "/home/bameda/Kaleidos/project/2012/Green-Mine/src/greenmine/scrum/management/commands/sample_data.py", line 98, in handle
    status = 'completed',
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/db/models/manager.py", line 137, in create
    return self.get_query_set().create(**kwargs)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/db/models/query.py", line 377, in create
    obj.save(force_insert=True, using=self.db)
  File "/home/bameda/Kaleidos/project/2012/Green-Mine/src/greenmine/scrum/models.py", line 451, in save
    super(UserStory, self).save(*args, **kwargs)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/db/models/base.py", line 463, in save
    self.save_base(using=using, force_insert=force_insert, force_update=force_update)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/db/models/base.py", line 486, in save_base
    signals.pre_save.send(sender=origin, instance=self, raw=raw, using=using)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 172, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/home/bameda/Kaleidos/project/2012/Green-Mine/src/greenmine/base/models.py", line 41, in attach_unique_reference
    project.save()
  File "/home/bameda/Kaleidos/project/2012/Green-Mine/src/greenmine/scrum/models.py", line 115, in save
    super(Project, self).save(*args, **kwargs)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/db/models/base.py", line 463, in save
    self.save_base(using=using, force_insert=force_insert, force_update=force_update)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/db/models/base.py", line 565, in save_base
    created=(not record_exists), raw=raw, using=using)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 172, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/haystack/indexes.py", line 271, in update_object
    self._get_backend(using).update(self, [instance], commit=commit)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/haystack/backends/whoosh_backend.py", line 193, in update
    self.log.error(u"%s while preparing object for update" % e.__name__, exc_info=True, extra={
AttributeError: 'exceptions.ValueError' object has no attribute '__name__'
```

With this fixed I have the correct exception:

```
Traceback (most recent call last):
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/haystack/backends/whoosh_backend.py", line 185, in update
    writer.update_document(**doc)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/whoosh/writing.py", line 449, in update_document
    self._record("update_document", args, kwargs)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/whoosh/writing.py", line 426, in _record
    getattr(self.writer, method)(*args, **kwargs)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/whoosh/writing.py", line 356, in update_document
    self.add_document(**fields)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/whoosh/filedb/filewriting.py", line 369, in add_document
    items = field.index(value)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/whoosh/fields.py", line 466, in index
    return [(txt, 1, 1.0, '') for txt in self._tiers(num)]
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/whoosh/fields.py", line 454, in _tiers
    yield self.to_text(num, shift=shift)
  File "/home/bameda/.virtualenvs/greenmine/lib/python2.7/site-packages/whoosh/fields.py", line 584, in to_text
    raise ValueError("DATETIME.to_text can't convert from %r" % (x,))
ValueError: DATETIME.to_text can't convert from u'ProjectExtras object'
```
