### PR TITLE
Send valid query when string contains double space

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -433,10 +433,11 @@ class SearchQuerySet(object):
         for field_name, query in kwargs.items():
             for word in query.split(' '):
                 bit = clone.query.clean(word.strip())
-                kwargs = {
-                    field_name: bit,
-                }
-                query_bits.append(SQ(**kwargs))
+                if bit:
+                    kwargs = {
+                        field_name: bit,
+                    }
+                    query_bits.append(SQ(**kwargs))
 
         return clone.filter(reduce(operator.__and__, query_bits))
 


### PR DESCRIPTION
For example searching for "hello  world" results in a query similar
to "name:hello AND name: AND name:world" which elasticsearch chokes on.
