### PR TITLE
Wrong SearchFieldError on ForeignKey/related without an attribute

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -78,7 +78,7 @@ class SearchField(object):
 
             for attr in attrs:
                 if not hasattr(current_object, attr):
-                    raise SearchFieldError("The model '%s' does not have a model_attr '%s'." % (repr(obj), attr))
+                    raise SearchFieldError("The model '%s' does not have a model_attr '%s'." % (repr(current_object), attr))
 
                 current_object = getattr(current_object, attr, None)
 


### PR DESCRIPTION
Basically, though the code checks `current_object` for an attribute, it puts `repr(obj)` in the error message. It's a bit confusing when you are trying to figure out what's going on.

You could also fix this by using the original `self.model_attr` or by checking to see if `current_object` is different than the original `obj` and then showing a more descriptive error message.

(e.g.:

``` python
if current_object is obj:
    raise SearchFieldError("The model %r has no model_attr %r." % (current_object, attr))
else:
    raise SearchFieldError("The model %r has no model_attr %r. (Found while indexing %r for model_attr %r)" % (current_object, attr, obj, self.model_attr))
```

(though the second might be more easily handled with a format string...)
)
