### PR TITLE
Fixed logging in simple_backend

### DIFF
--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -10,7 +10,7 @@ from haystack.models import SearchResult
 
 
 if settings.DEBUG:
-    from haystack.utils import log as logging
+    import logging
 
     class NullHandler(logging.Handler):
         def emit(self, record):


### PR DESCRIPTION
The logging refactor in 433e154f76a450ffc095792c6f2e051ef508fc2d broke the simple_backend. It changed the logging import to the new log module, which doesn't contain any of the members used (logging.Handler, etc).

This fix simply reverts the import to the stdlib logging module.
