### PR TITLE
Fixed an ElasticSearch error when running `rebuild_index`

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -219,9 +219,6 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 # Delete by query in Elasticsearch asssumes you're dealing with
                 # a ``query`` root object. :/
                 self.conn.delete_by_query(self.index_name, 'modelresult', {'query_string': {'query': " OR ".join(models_to_delete)}})
-
-            if commit:
-                self.conn.refresh(indexes=[self.index_name])
         except (requests.RequestException, pyelasticsearch.ElasticSearchError), e:
             if not self.silently_fail:
                 raise


### PR DESCRIPTION
When using ElasticSearch as the search engine you get a strange 404 error. This is because the backend is trying to refresh the index after it has deleted the index.

```
$ bin/manage rebuild_index
WARNING: This will irreparably remove EVERYTHING from your search index in connection 'default'.
Your choices after this are to restore from backups or rebuild via the `rebuild_index` command.
Are you sure you wish to continue? [y/N] y

Removing all documents from your index because you said so.
Failed to clear Elasticsearch index: Non-OK status code returned (404) containing u'IndexMissingException[[my_index] missing]'.
All documents removed.
Indexing 40 components.
```
