### PR TITLE
Allow for onetoone relationships for search index

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -2,6 +2,7 @@ import re
 from django.utils import datetime_safe
 from django.template import loader, Context
 from haystack.exceptions import SearchFieldError
+from django.core.exceptions import ObjectDoesNotExist
 
 
 class NOT_PROVIDED:
@@ -78,9 +79,13 @@ class SearchField(object):
 
             for attr in attrs:
                 if not hasattr(current_object, attr):
-                    raise SearchFieldError("The model '%s' does not have a model_attr '%s'." % (repr(obj), attr))
-
-                current_object = getattr(current_object, attr, None)
+                    if attr not in dir(current_object):
+                        raise SearchFieldError("The model '%s' does not have a model_attr '%s'." % (repr(obj), attr))
+                
+                try:
+                    current_object = getattr(current_object, attr, None)
+                except ObjectDoesNotExist:
+                    current_object = None
 
                 if current_object is None:
                     if self.has_default():


### PR DESCRIPTION
Because hasattr will only evaluate the onetoone reverse relationship manager when the referenced object is present, I created a small work around to allow for drilldowns in the this way.

So, let's say you have

class Address(Model):
    addr = OneToOneField(Business)
    city = some_char_field

With the above change, you can now do something like (where object = Business):

```
city = indexes.CharField(model_attr='address__city', default='', null=True)
```

However, if that particular business does not have an address the above code change will allow for the default of empty string to be created in the index.
