### PR TITLE
Fixes incorrect call to put_mapping on ElasticSearch backend

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -127,7 +127,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             try:
                 # Make sure the index is there first.
                 self.conn.create_index(self.index_name, self.DEFAULT_SETTINGS)
-                self.conn.put_mapping('modelresult', current_mapping, index=self.index_name)
+                self.conn.put_mapping(self.index_name, 'modelresult', current_mapping)
                 self.existing_mapping = current_mapping
             except Exception:
                 if not self.silently_fail:


### PR DESCRIPTION
This fixes an issue already reported:

https://github.com/toastdriven/django-haystack/issues/665
