### PR TITLE
Fixed deprecation warning

### DIFF
--- a/haystack/urls.py
+++ b/haystack/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, url
 except ImportError:
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, url
 from haystack.views import SearchView
 
 


### PR DESCRIPTION
`django.conf.urls.defaults` is now deprecated. Use `django.conf.urls` instead.
