### PR TITLE
Fix deferred handling for more_like_this on Django 1.3

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -8,7 +8,7 @@ from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, lo
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID, DEFAULT_OPERATOR
 from haystack.exceptions import MissingDependency, MoreLikeThisError
 from haystack.inputs import PythonData, Clean, Exact
-from haystack.models import SearchResult
+from haystack.models import SearchResult, get_concrete_model_for_instance
 from haystack.utils import get_identifier
 from haystack.utils import log as logging
 
@@ -509,9 +509,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         if not self.setup_complete:
             self.setup()
 
-        # Deferred models will have a different class ("RealClass_Deferred_fieldname")
-        # which won't be in our registry:
-        model_klass = model_instance._meta.concrete_model
+        model_klass = get_concrete_model_for_instance(model_instance)
 
         index = connections[self.connection_alias].get_unified_index().get_index(model_klass)
         field_name = index.get_content_field()

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -6,7 +6,7 @@ from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, lo
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID
 from haystack.exceptions import MissingDependency, MoreLikeThisError
 from haystack.inputs import PythonData, Clean, Exact
-from haystack.models import SearchResult
+from haystack.models import SearchResult, get_concrete_model_for_instance
 from haystack.utils import get_identifier
 from haystack.utils import log as logging
 
@@ -260,9 +260,7 @@ class SolrSearchBackend(BaseSearchBackend):
                        limit_to_registered_models=None, result_class=None, **kwargs):
         from haystack import connections
 
-        # Deferred models will have a different class ("RealClass_Deferred_fieldname")
-        # which won't be in our registry:
-        model_klass = model_instance._meta.concrete_model
+        model_klass = get_concrete_model_for_instance(model_instance)
 
         index = connections[self.connection_alias].get_unified_index().get_index(model_klass)
         field_name = index.get_content_field()

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -12,7 +12,7 @@ from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, lo
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID
 from haystack.exceptions import MissingDependency, SearchBackendError
 from haystack.inputs import PythonData, Clean, Exact
-from haystack.models import SearchResult
+from haystack.models import SearchResult, get_concrete_model_for_instance
 from haystack.utils import get_identifier
 from haystack.utils import log as logging
 
@@ -444,9 +444,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         if not self.setup_complete:
             self.setup()
 
-        # Deferred models will have a different class ("RealClass_Deferred_fieldname")
-        # which won't be in our registry:
-        model_klass = model_instance._meta.concrete_model
+        model_klass = get_concrete_model_for_instance(model_instance)
 
         field_name = self.content_field_name
         narrow_queries = set()

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -13,6 +13,25 @@ except ImportError:
     geopy_distance = None
 
 
+def get_concrete_model_for_instance(obj):
+    """
+    Return the model for a given instance, accounting for defer()
+
+    Deferred models will have a different class ("RealClass_Deferred_fieldname")
+    which won't be in our registry
+    """
+
+    if hasattr(obj._meta, 'concrete_model'):
+        model_klass = obj._meta.concrete_model
+    else:
+        # Compatibility with Django 1.3, where concrete_model isn't always set:
+        model_klass = type(obj)
+        while model_klass._meta.proxy:
+            model_klass = model_klass._meta.proxy_for_model
+
+    return model_klass
+
+
 # Not a Django model, but tightly tied to them and there doesn't seem to be a
 # better spot in the tree.
 class SearchResult(object):


### PR DESCRIPTION
Now that tox is working, it highlighted that the MLT check for deferred proxy models wasn't functional on Django 1.3

This bug was introduced in my acdha@c8b601be0b1fd814663ecc4fc30545573c74b7d9; the failure had previously been silent because the defer check was failing to see any object as deferred.
