### PR TITLE
Fix FacetedModelSearchForm

### DIFF
--- a/haystack/forms.py
+++ b/haystack/forms.py
@@ -111,6 +111,10 @@ class HighlightedModelSearchForm(ModelSearchForm):
 
 class FacetedModelSearchForm(ModelSearchForm):
     selected_facets = forms.CharField(required=False, widget=forms.HiddenInput)
+    
+    def __init__(self, *args, **kwargs):
+        self.selected_facets = kwargs.pop("selected_facets", [])
+        super(FacetedModelSearchForm, self).__init__(*args, **kwargs)
 
     def search(self):
         sqs = super(FacetedModelSearchForm, self).search()


### PR DESCRIPTION
FacetedModelSearchForm inherits from ModelSearchForm, which means that the selected_facets kwarg is not popped anywhere down the chain until it gets passed to Form, which explodes because its not expecting it.

The fix is simple: make FacetedModelSearchFrom pop the "selected_facets" kwarg just like FacetedSearchForm.