### PR TITLE
Update solr schema template for current versions of solr

### DIFF
--- a/haystack/templates/search_configuration/solr.xml
+++ b/haystack/templates/search_configuration/solr.xml
@@ -66,7 +66,7 @@
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
-                words="stopwords_en.txt"
+                words="lang/stopwords_en.txt"
                 enablePositionIncrements="true"
                 />
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -82,7 +82,7 @@
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
-                words="stopwords_en.txt"
+                words="lang/stopwords_en.txt"
                 enablePositionIncrements="true"
                 />
         <filter class="solr.LowerCaseFilterFactory"/>


### PR DESCRIPTION
Seems that in versions >3.6 and >4 stopwords_en.txt moved
to a new location. This won't be backwards compatible for
older versions of solr.

Addresses issues #558, #560
In addition, issue #671 references this problem
