### PR TITLE
pass add'l options from management command to build_queryset

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -221,7 +221,7 @@ class Command(LabelCommand):
                 # workers resetting connections leads to references to models / connections getting stale and having their connection disconnected from under them. Resetting before the loop continues and it accesses the ORM makes it better.
                 db.close_connection()
 
-            qs = index.build_queryset(start_date=self.start_date, end_date=self.end_date)
+            qs = index.build_queryset(**options)
             total = qs.count()
 
             if self.verbosity >= 1:

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -147,12 +147,14 @@ class Command(LabelCommand):
 
         if age is not None:
             self.start_date = now() - timedelta(hours=int(age))
+            options['start_date'] = self.start_date
 
         if start_date is not None:
             from dateutil.parser import parse as dateutil_parse
 
             try:
                 self.start_date = dateutil_parse(start_date)
+                options['start_date'] = self.start_date
             except ValueError:
                 pass
 
@@ -161,6 +163,7 @@ class Command(LabelCommand):
 
             try:
                 self.end_date = dateutil_parse(end_date)
+                options['end_date'] = self.end_date
             except ValueError:
                 pass
 


### PR DESCRIPTION
Allows you to override build_queryset in a search_indexes.py like so:

```
    def build_queryset(self, **options):
        # Do something to build index_qs using add'l options and return
```
