### PR TITLE
If only one found word in search, highight around

### DIFF
--- a/haystack/utils/highlighting.py
+++ b/haystack/utils/highlighting.py
@@ -77,7 +77,10 @@ class Highlighter(object):
             return (best_start, best_end)
 
         if len(words_found) == 1:
-            return (words_found[0], words_found[0] + self.max_length)
+            # Center the text around the found word if possible
+            best_start = max(words_found[0] - self.max_length / 2, 0)
+            best_end = best_start + self.max_length
+            return (best_start, best_end)
 
         # Sort the list so it's in ascending order.
         words_found = sorted(words_found)

--- a/test_haystack/test_templatetags.py
+++ b/test_haystack/test_templatetags.py
@@ -69,7 +69,7 @@ the attribute of the object to populate that field with.
         context = {"entry": self.sample_entry, "query": "Haystack"}
         self.assertEqual(
             self.render(template, context),
-            '...<div class="foo">Haystack</div> is very similar to registering models and\nModelAdmin classes in the Django admin site. If y...',
+            '\nRegistering indexes in <div class="foo">Haystack</div> is very similar to registering models and\nModelAdmin classes in the...'
         )
 
         template = """{% load highlight %}{% highlight "xxxxxxxxxxxxx foo bbxxxxx foo" with "foo" max_length 5 html_tag "span" %}"""

--- a/test_haystack/test_utils.py
+++ b/test_haystack/test_utils.py
@@ -115,7 +115,7 @@ class HighlighterTestCase(TestCase):
             highlighter.find_window({"highlight": [203], "tests": [120]}), (120, 320)
         )
         self.assertEqual(
-            highlighter.find_window({"highlight": [], "tests": [100]}), (100, 300)
+            highlighter.find_window({"highlight": [], "tests": [100]}), (0, 200)
         )
         self.assertEqual(
             highlighter.find_window({"highlight": [0], "tests": [80], "moof": [120]}),
@@ -284,11 +284,11 @@ class HighlighterTestCase(TestCase):
         highlighter = Highlighter("content detection")
         self.assertEqual(
             highlighter.highlight(self.document_1),
-            '...<span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-air.',
+            'This is a test of the highlightable words <span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-air.',
         )
         self.assertEqual(
             highlighter.highlight(self.document_2),
-            '...<span class="highlighted">content</span> of words in no particular order causes nothing to occur.',
+            'The <span class="highlighted">content</span> of words in no particular order causes nothing to occur.',
         )
         self.assertEqual(
             highlighter.highlight(self.document_3),
@@ -298,11 +298,11 @@ class HighlighterTestCase(TestCase):
         highlighter = Highlighter("content detection", max_length=100)
         self.assertEqual(
             highlighter.highlight(self.document_1),
-            '...<span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-...',
+            'This is a test of the highlightable words <span class="highlighted">detection</span>. This is only a test. Were this an actual emerge...',
         )
         self.assertEqual(
             highlighter.highlight(self.document_2),
-            '...<span class="highlighted">content</span> of words in no particular order causes nothing to occur.',
+            'The <span class="highlighted">content</span> of words in no particular order causes nothing to occur.',
         )
         self.assertEqual(
             highlighter.highlight(self.document_3),


### PR DESCRIPTION
It seems odd to me that when a single result is found, only text after
the term is highlighted. This change will center the found term in
search results.
