### PR TITLE
Update docs/installing_search_engines.rst

### DIFF
--- a/docs/installing_search_engines.rst
+++ b/docs/installing_search_engines.rst
@@ -42,7 +42,7 @@ somewhere on your ``PYTHONPATH``.
 
 .. note::
 
-    ``pysolr`` has it's own dependencies that aren't covered by Haystack. For
+    ``pysolr`` has its own dependencies that aren't covered by Haystack. For
     best results, you should have an ElementTree variant install (preferably the
     ``lxml`` variant), ``httplib2`` for timeouts (though it will fall back to
     ``httplib``) and either the ``json`` module that comes with Python 2.5+ or
@@ -117,7 +117,7 @@ Official Download Location: http://www.elasticsearch.org/download/
 
 Elasticsearch is Java but comes in a pre-packaged form that requires very
 little other than the JRE. It's also very performant, scales easily and has
-an advanced featureset. Haystack requires at least version 0.17.7 (0.18.6 is
+an advanced featureset. Haystack requires at least version 0.17.7 (0.20.2 is
 current as of writing). Installation is best done using a package manager::
 
     # On Mac OS X...
@@ -160,7 +160,7 @@ You'll also need an Elasticsearch binding: pyelasticsearch_ (**NOT**
 
 .. note::
 
-    ``pyelasticsearch`` has it's own dependencies that aren't covered by
+    ``pyelasticsearch`` has its own dependencies that aren't covered by
     Haystack. You'll also need ``requests`` & ``simplejson`` for speedier
     JSON construction/parsing.
 
@@ -172,11 +172,8 @@ Official Download Location: http://bitbucket.org/mchaput/whoosh/
 
 Whoosh is pure Python, so it's a great option for getting started quickly and
 for development, though it does work for small scale live deployments. The
-current recommended version is 1.3.1+. You can install via PyPI_ using::
-
-    sudo easy_install whoosh
-    # ... or ...
-    sudo pip install whoosh
+current recommended version is 1.3.1+. You can install via PyPI_ using 
+``sudo easy_install whoosh`` or ``sudo pip install whoosh``.
 
 Note that, while capable otherwise, the Whoosh backend does not currently
 support "More Like This" or faceting. Support for these features has recently


### PR DESCRIPTION
Minor grammar, Elasticsearch version and formatting consistency fixes to search engine installation docs.
