### PR TITLE
"/src/django-haystack/haystack/__init__.py", line 65, in <module>     signals.request_started.connect(reset_search_queries)

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -62,4 +62,7 @@ def reset_search_queries(**kwargs):
 
 
 if settings.DEBUG:
-    signals.request_started.connect(reset_search_queries)
+    try:
+        signals.request_started.connect(reset_search_queries)
+    except:
+        pass


### PR DESCRIPTION
That went boom
