### PR TITLE
Bounding box calculations fixed, remember that order is relevant

### DIFF
--- a/docs/spatial.rst
+++ b/docs/spatial.rst
@@ -218,9 +218,7 @@ finding results within an area.
 
 ``within`` is a bounding box comparison. A bounding box is a rectangular area
 within which to search. It's composed of a bottom-left point & a top-right
-point, though provided you give two opposing corners in either order, Haystack
-will determine the right coordinates. It is faster but slighty sloppier than
-its counterpart.
+point. It is faster but slighty sloppier than its counterpart.
 
 Examples::
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -400,17 +400,17 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         if within is not None:
             from haystack.utils.geo import generate_bounding_box
 
-            ((min_lat, min_lng), (max_lat, max_lng)) = generate_bounding_box(within['point_1'], within['point_2'])
+            ((south, west), (north, east)) = generate_bounding_box(within['point_1'], within['point_2'])
             within_filter = {
                 "geo_bounding_box": {
                     within['field']: {
                         "top_left": {
-                            "lat": max_lat,
-                            "lon": min_lng
+                            "lat": north,
+                            "lon": west
                         },
                         "bottom_right": {
-                            "lat": min_lat,
-                            "lon": max_lng
+                            "lat": south,
+                            "lon": east
                         }
                     }
                 },

--- a/haystack/utils/geo.py
+++ b/haystack/utils/geo.py
@@ -60,15 +60,15 @@ def ensure_distance(dist):
     return dist
 
 
-def generate_bounding_box(point_1, point_2):
+def generate_bounding_box(bottom_left, top_right):
     """
-    Takes two opposite corners of a bounding box (in any order) & generates
+    Takes two opposite corners of a bounding box (order matters!) & generates
     a two-tuple of the correct coordinates for the bounding box.
 
     The two-tuple is in the form ``((min_lat, min_lng), (max_lat, max_lng))``.
     """
-    lng_1, lat_1 = point_1.get_coords()
-    lng_2, lat_2 = point_2.get_coords()
+    west, lat_1 = bottom_left.get_coords()
+    east, lat_2 = top_right.get_coords()
     min_lat, max_lat = min(lat_1, lat_2), max(lat_1, lat_2)
-    min_lng, max_lng = min(lng_1, lng_2), max(lng_1, lng_2)
-    return ((min_lat, min_lng), (max_lat, max_lng))
+    return ((min_lat, west), (max_lat, east))
+

--- a/tests/spatial/tests.py
+++ b/tests/spatial/tests.py
@@ -54,6 +54,15 @@ class SpatialUtilitiesTestCase(TestCase):
         self.assertEqual(max_lat, 38.973081081164715)
         self.assertEqual(max_lng, -95.23362278938293)
 
+    def test_generate_bounding_box_crossing_line_date(self):
+        downtown_bottom_left = Point(95.23947, 38.9637903)
+        downtown_top_right = Point(-95.23362278938293, 38.973081081164715)
+        ((south, west), (north, east)) = generate_bounding_box(downtown_bottom_left, downtown_top_right)
+        self.assertEqual(south, 38.9637903)
+        self.assertEqual(west, 95.23947)
+        self.assertEqual(north, 38.973081081164715)
+        self.assertEqual(east, -95.23362278938293)
+
 
 class SpatialSolrNoDistanceTestCase(TestCase):
     fixtures = ['sample_spatial_data.json']


### PR DESCRIPTION
Bounding box calculation is wrong (in elasticsearch for sure, haven't checked others).
We cannot assume that calculating minimal and maximal longitudes is relevant. If someone searches and "crosses" International Line Date we start to query not for he wanted, but opposite.
Therefore order in which corner points are given matters.
