### PR TITLE
Solr: use nested query syntax for AltParser queries

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -592,7 +592,7 @@ class SolrSearchQuery(BaseSearchQuery):
 
     def build_alt_parser_query(self, parser_name, query_string='', **kwargs):
         if query_string:
-            kwargs['v'] = query_string
+            kwargs['v'] = Clean(query_string).prepare(self)
 
         kwarg_bits = []
 
@@ -602,7 +602,7 @@ class SolrSearchQuery(BaseSearchQuery):
             else:
                 kwarg_bits.append(u"%s=%s" % (key, kwargs[key]))
 
-        return u"{!%s %s}" % (parser_name, ' '.join(kwarg_bits))
+        return u'_query_:"{!%s %s}"' % (parser_name, Clean(' '.join(kwarg_bits)))
 
     def build_params(self, spelling_query=None, **kwargs):
         search_kwargs = {

--- a/tests/elasticsearch_tests/tests/inputs.py
+++ b/tests/elasticsearch_tests/tests/inputs.py
@@ -77,5 +77,5 @@ class ElasticsearchInputTestCase(TestCase):
 
     def test_altparser_prepare(self):
         altparser = inputs.AltParser('dismax', 'douglas adams', qf='author', mm=1)
-        # Not supported on that backend.
-        self.assertEqual(altparser.prepare(self.query_obj), u"{!dismax mm=1 qf=author v='douglas adams'}")
+        self.assertEqual(altparser.prepare(self.query_obj),
+                         u"""_query_:"{!dismax mm=1 qf=author v='douglas adams'}\"""")

--- a/tests/solr_tests/tests/inputs.py
+++ b/tests/solr_tests/tests/inputs.py
@@ -77,5 +77,5 @@ class SolrInputTestCase(TestCase):
 
     def test_altparser_prepare(self):
         altparser = inputs.AltParser('dismax', 'douglas adams', qf='author', mm=1)
-        # Not supported on that backend.
-        self.assertEqual(altparser.prepare(self.query_obj), u"{!dismax mm=1 qf=author v='douglas adams'}")
+        self.assertEqual(altparser.prepare(self.query_obj),
+                         u"""_query_:"{!dismax mm=1 qf=author v='douglas adams'}\"""")

--- a/tests/solr_tests/tests/solr_query.py
+++ b/tests/solr_tests/tests/solr_query.py
@@ -1,7 +1,7 @@
 import datetime
 from django.test import TestCase
 from haystack import connections
-from haystack.inputs import Exact
+from haystack.inputs import Exact, AltParser
 from haystack.models import SearchResult
 from haystack.query import SQ
 from core.models import MockModel, AnotherMockModel
@@ -73,6 +73,16 @@ class SolrSearchQueryTestCase(TestCase):
         self.sq.add_filter(SQ(id__in=[1, 2, 3]))
         self.sq.add_filter(SQ(rating__range=[3, 5]))
         self.assertEqual(self.sq.build_query(), u'((why) AND pub_date:([* TO "2009-02-10 01:59:00"]) AND author:({"daniel" TO *}) AND created:({* TO "2009-02-12 12:13:00"}) AND title:(["B" TO *]) AND id:("1" OR "2" OR "3") AND rating:(["3" TO "5"]))')
+
+    def test_build_complex_altparser_query(self):
+        self.sq.add_filter(SQ(content=AltParser('dismax', 'why', qf='text')))
+        self.sq.add_filter(SQ(pub_date__lte=Exact('2009-02-10 01:59:00')))
+        self.sq.add_filter(SQ(author__gt='daniel'))
+        self.sq.add_filter(SQ(created__lt=Exact('2009-02-12 12:13:00')))
+        self.sq.add_filter(SQ(title__gte='B'))
+        self.sq.add_filter(SQ(id__in=[1, 2, 3]))
+        self.sq.add_filter(SQ(rating__range=[3, 5]))
+        self.assertEqual(self.sq.build_query(), u'((_query_:"{!dismax qf=text v=why}") AND pub_date:([* TO "2009-02-10 01:59:00"]) AND author:({"daniel" TO *}) AND created:({* TO "2009-02-12 12:13:00"}) AND title:(["B" TO *]) AND id:("1" OR "2" OR "3") AND rating:(["3" TO "5"]))')
 
     def test_build_query_multiple_filter_types_with_datetimes(self):
         self.sq.add_filter(SQ(content='why'))


### PR DESCRIPTION
The previous implementation would, given a query like this::

```
sqs.filter(content=AltParser('dismax', 'library', qf="title^2 text" mm=1))
```

generate a query like this::

```
{!dismax v=library qf="title^2 text" mm=1}
```

This works in certain situations but causes Solr to choke while parsing it
when Haystack wraps this term in parentheses::

```
org.apache.lucene.queryParser.ParseException: Cannot parse '({!dismax mm=1 qf='title^2 text institution^0.8' v=library})':
Encountered " &lt;RANGEEX_GOOP&gt; "qf=\'title^1.25 "" at line 1, column 16.
```

The solution is to use the nested query syntax described here:

```
http://searchhub.org/2009/03/31/nested-queries-in-solr/
```

This will produce a query like this, which works with Solr 3.6.2::

```
(_query_:"{!edismax mm=1 qf='title^1.5 text institution^0.5' v=library}")
```

Leaving the actual URL query string looking like this::

```
q=%28_query_%3A%22%7B%21edismax+mm%3D1+qf%3D%27title%5E1.5+text+institution%5E0.5%27+v%3Dlibrary%7D%22%29
```
