### PR TITLE
SearchResult Comparison (#446)

### DIFF
--- a/haystack/models.py
+++ b/haystack/models.py
@@ -57,6 +57,19 @@ class SearchResult(object):
 
         return self.__dict__.get(attr, None)
 
+    def __eq__(self, other):
+        try:
+            return (
+                (self.app_label == other.app_label) and
+                (self.model_name == other.model_name) and
+                (self.pk == other.pk)
+            )
+        except AttributeError:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def _get_searchindex(self):
         from haystack import connections
         return connections['default'].get_unified_index().get_index(self.model)

--- a/tests/core/tests/models.py
+++ b/tests/core/tests/models.py
@@ -37,7 +37,7 @@ class SearchResultTestCase(TestCase):
         self.no_data_sr = MockSearchResult('haystack', 'mockmodel', '1', 2)
         self.extra_data_sr = MockSearchResult('haystack', 'mockmodel', '1', 3, **self.extra_data)
         self.no_overwrite_data_sr = MockSearchResult('haystack', 'mockmodel', '1', 4, **self.no_overwrite_data)
-    
+
     def test_init(self):
         self.assertEqual(self.no_data_sr.app_label, 'haystack')
         self.assertEqual(self.no_data_sr.model_name, 'mockmodel')
@@ -171,3 +171,23 @@ class SearchResultTestCase(TestCase):
         self.assertEqual(pickle_me_1.model_name, pickle_me_2.model_name)
         self.assertEqual(pickle_me_1.pk, pickle_me_2.pk)
         self.assertEqual(pickle_me_1.score, pickle_me_2.score)
+
+    def test_equality(self):
+        self.assertEqual(self.no_data_sr,
+                MockSearchResult('haystack', 'mockmodel', '1', 2))
+        self.assertEqual(self.extra_data_sr,
+            MockSearchResult('haystack', 'mockmodel',
+                                '1', 3, **self.extra_data))
+        self.assertEqual(self.no_overwrite_data_sr,
+             MockSearchResult('haystack', 'mockmodel',
+                            '1', 4, **self.no_overwrite_data))
+
+    def test_inequality(self):
+        self.assertNotEqual(self.no_data_sr,
+                MockSearchResult('haystack', 'mockmodel', '2', 2))
+        self.assertNotEqual(self.extra_data_sr,
+            MockSearchResult('haystack', 'mockmodel',
+                                '2', 3, **self.extra_data))
+        self.assertNotEqual(self.no_overwrite_data_sr,
+             MockSearchResult('haystack', 'mockmodel',
+                            '2', 4, **self.no_overwrite_data))


### PR DESCRIPTION
Implements SearchResult comparisons as mentioned in #446 (no hashing however as that was for creating sets from SearchQuerySets and I couldn't find a good test in core in hook into) and also cleans up the tests in 'core.tests.models'
