### PR TITLE
Fixed bug when using altparser with single quote in query

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -592,7 +592,7 @@ class SolrSearchQuery(BaseSearchQuery):
 
     def build_alt_parser_query(self, parser_name, query_string='', **kwargs):
         if query_string:
-            kwargs['v'] = Clean(query_string).prepare(self)
+            query_string = Clean(query_string).prepare(self)
 
         kwarg_bits = []
 
@@ -602,7 +602,7 @@ class SolrSearchQuery(BaseSearchQuery):
             else:
                 kwarg_bits.append(u"%s=%s" % (key, kwargs[key]))
 
-        return u'_query_:"{!%s %s}"' % (parser_name, Clean(' '.join(kwarg_bits)))
+        return u'_query_:"{!%s %s}%s"' % (parser_name, Clean(' '.join(kwarg_bits)), query_string)
 
     def build_params(self, spelling_query=None, **kwargs):
         search_kwargs = {


### PR DESCRIPTION
query "Assassin's Creed" generates the following request
`q=(_query_:"{!edismax v='Assassin's Creed'}")`

Solr can't parse this request.
I changed haystack to generate a query like this:
`q=(_query_:"{!edismax}Assassin's Creed")`
