### PR TITLE
Fixed autocomplete() method: spaces in query

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -437,10 +437,11 @@ class SearchQuerySet(object):
         for field_name, query in kwargs.items():
             for word in query.split(' '):
                 bit = clone.query.clean(word.strip())
-                kwargs = {
-                    field_name: bit,
-                }
-                query_bits.append(SQ(**kwargs))
+                if bit:
+                    kwargs = {
+                        field_name: bit,
+                    }
+                    query_bits.append(SQ(**kwargs))
 
         return clone.filter(reduce(operator.__and__, query_bits))
 


### PR DESCRIPTION
`SearchQuerySet().autocomplete(title_auto='mass ')`
generates:
`q=title_auto:mass AND title_auto:`

I didn't try it with other engines, but Solr can't parse this query. I added a check, so it doesn't include empty bits into the query
