### PR TITLE
Remove redundant __name__ assignment on SearchView

### DIFF
--- a/docs/views_and_forms.rst
+++ b/docs/views_and_forms.rst
@@ -267,17 +267,14 @@ As with the forms, inheritance is likely your best bet. In this case, the
 ``SearchView``. The complete code for the ``FacetedSearchView`` looks like::
 
     class FacetedSearchView(SearchView):
-        def __name__(self):
-            return "FacetedSearchView"
-            
         def extra_context(self):
             extra = super(FacetedSearchView, self).extra_context()
-            
+
             if self.results == []:
                 extra['facets'] = self.form.search().facet_counts()
             else:
                 extra['facets'] = self.results.facet_counts()
-            
+
             return extra
 
 It updates the name of the class (generally for documentation purposes) and

--- a/haystack/views.py
+++ b/haystack/views.py
@@ -11,7 +11,6 @@ RESULTS_PER_PAGE = getattr(settings, 'HAYSTACK_SEARCH_RESULTS_PER_PAGE', 20)
 
 
 class SearchView(object):
-    __name__ = 'SearchView'
     template = 'search/search.html'
     extra_context = {}
     query = ''
@@ -151,8 +150,6 @@ def search_view_factory(view_class=SearchView, *args, **kwargs):
 
 
 class FacetedSearchView(SearchView):
-    __name__ = 'FacetedSearchView'
-
     def __init__(self, *args, **kwargs):
         # Needed to switch out the default form class.
         if kwargs.get('form_class') is None:


### PR DESCRIPTION
**name** was being explicitly set to a value which was the same as the default
value.

Additionally corrected the obsolete **name** method declaration in the 
documentation which reflected the code prior to SHA:89d8096 in 2010.
