### PR TITLE
Fix for SearchModelAdmin under Django 1.5

### DIFF
--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -59,8 +59,10 @@ class SearchChangeList(ChangeList):
 
 
 class SearchModelAdmin(ModelAdmin):
+    changelist = SearchChangeList
+
     def get_changelist(self, request, **kwargs):
         if self.model in connections['default'].get_unified_index().get_indexed_models():
-            return SearchChangeList
+            return self.changelist
         else:
             return super(SearchModelAdmin, self).get_changelist(request, **kwargs)


### PR DESCRIPTION
Some of the boilerplate from Django's admin changelist view changed between 1.4 and 1.5.  This merges the Django change into the Haystack code.

Before the fix:
When searching on a SearchModelAdmin view, the checkboxes to the left of the items would not be visible and it would say "of XX selected" rather than "0 of XX selected".

After the fix:
View when searching via SearchModelAdmin, it now looks identical to the default Django ModelAdmin search view.
