### PR TITLE
Simple: removed conflicting score field from raw result objects

### DIFF
--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -71,6 +71,7 @@ class SimpleSearchBackend(BaseSearchBackend):
                 hits += len(qs)
 
                 for match in qs:
+                    del(match.__dict__['score'])
                     result = result_class(match._meta.app_label, match._meta.module_name, match.pk, 0, **match.__dict__)
                     # For efficiency.
                     result._model = match.__class__

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -12,7 +12,8 @@ class MockModel(models.Model):
     foo = models.CharField(max_length=255, blank=True)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
     tag = models.ForeignKey(MockTag)
-    
+    score = models.CharField(max_length=10, blank=True)
+
     def __unicode__(self):
         return self.author
     

--- a/tests/simple_tests/search_indexes.py
+++ b/tests/simple_tests/search_indexes.py
@@ -6,6 +6,7 @@ class SimpleMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     name = indexes.CharField(model_attr='author')
     pub_date = indexes.DateField(model_attr='pub_date')
-    
+    score = indexes.CharField(model_attr='score')
+
     def get_model(self):
         return MockModel

--- a/tests/simple_tests/tests/simple_backend.py
+++ b/tests/simple_tests/tests/simple_backend.py
@@ -7,15 +7,7 @@ from haystack.query import SearchQuerySet
 from haystack.utils.loading import UnifiedIndex
 from core.models import MockModel
 from core.tests.mocks import MockSearchResult
-
-
-class SimpleMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
-    text = indexes.CharField(document=True, use_template=True)
-    name = indexes.CharField(model_attr='author', faceted=True)
-    pub_date = indexes.DateField(model_attr='pub_date')
-
-    def get_model(self):
-        return MockModel
+from simple_tests.search_indexes import SimpleMockSearchIndex
 
 
 class SimpleSearchBackendTestCase(TestCase):


### PR DESCRIPTION
Referring both [Pull Request #721](https://github.com/toastdriven/django-haystack/pull/721) which refers [Issue #482](https://github.com/toastdriven/django-haystack/issues/482)

This keeps consistency with the Solr backend, which resolves this conflict
in the same manner in order to avoid an exception being thrown.

Also removed the redundant mock search index from the simple backend's test suite
