### PR TITLE
Solr build_solr_schema: fixed a bug in build_solr_schema. Thanks to mjum...

### DIFF
--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -1,7 +1,10 @@
 from optparse import make_option
 import sys
+
+from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 from django.template import loader, Context
+from haystack.backends.solr_backend import SolrSearchBackend
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID, DEFAULT_OPERATOR, DEFAULT_ALIAS
 
 
@@ -28,6 +31,10 @@ class Command(BaseCommand):
     def build_context(self, using):
         from haystack import connections, connection_router
         backend = connections[using].get_backend()
+
+        if not isinstance(backend, SolrSearchBackend):
+            raise ImproperlyConfigured("'%s' isn't configured as a SolrEngine)." % backend.connection_alias)
+
         content_field_name, fields = backend.build_schema(connections[using].get_unified_index().all_searchfields())
         return Context({
             'content_field_name': content_field_name,

--- a/tests/solr_tests/tests/management_commands.py
+++ b/tests/solr_tests/tests/management_commands.py
@@ -2,6 +2,7 @@ import datetime
 
 from mock import patch
 import pysolr
+from tempfile import mkdtemp
 
 from django import VERSION as DJANGO_VERSION
 from django.conf import settings
@@ -144,6 +145,13 @@ class ManagementCommandTestCase(TestCase):
         call_command('update_index', verbosity=2, workers=2, batchsize=5)
         self.assertEqual(self.solr.search('*:*').hits, 23)
 
+    def test_build_schema_wrong_backend(self):
+
+        settings.HAYSTACK_CONNECTIONS['whoosh'] = {'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+                                                   'PATH': mkdtemp(prefix='dummy-path-'),}
+
+        connections['whoosh']._index = self.ui
+        self.assertRaises(ImproperlyConfigured, call_command, 'build_solr_schema',using='whoosh', interactive=False)
 
 class AppModelManagementCommandTestCase(TestCase):
     fixtures = ['bulk_data.json']


### PR DESCRIPTION
...bewu for the report!

If you tried to run build_solr_schema with a backend that supports
schema building, but was not Solr (like Whoosh), then you would get an
invalid schema.  This fix raises the ImproperlyConfigured exception
with a proper message.

refers [Issue 687](https://github.com/toastdriven/django-haystack/issues/687)
