### PR TITLE
Using force_text for indexing message

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import LabelCommand
 from django.db import reset_queries
-from django.utils.encoding import smart_str, force_text
+from django.utils.encoding import smart_str, force_unicode
 
 from haystack import connections as haystack_connections
 from haystack.query import SearchQuerySet
@@ -241,7 +241,7 @@ class Command(LabelCommand):
             total = qs.count()
 
             if self.verbosity >= 1:
-                print "Indexing %d %s." % (total, force_text(model._meta.verbose_name_plural))
+                print "Indexing %d %s." % (total, force_unicode(model._meta.verbose_name_plural))
 
             pks_seen = set([smart_str(pk) for pk in qs.values_list('pk', flat=True)])
             batch_size = self.batchsize or backend.batch_size


### PR DESCRIPTION
`verbose_name_plural` can be a functional proxy object as it is possible to use `ugettext_lazy` for it, if you wouldn't use `force_text`, the output would be:

```
All documents removed.
Indexing 203 <django.utils.functional.__proxy__ object at 0x30aed10>.
Indexing 19 <django.utils.functional.__proxy__ object at 0x30a1a50>.
Indexing 999 <django.utils.functional.__proxy__ object at 0x332f650>.
```
