### PR TITLE
Using pop(key, None) will remove the item without the risk of a KeyError being thrown

### DIFF
--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -71,7 +71,7 @@ class SimpleSearchBackend(BaseSearchBackend):
                 hits += len(qs)
 
                 for match in qs:
-                    del(match.__dict__['score'])
+                    match.__dict__.pop('score', None)
                     result = result_class(match._meta.app_label, match._meta.module_name, match.pk, 0, **match.__dict__)
                     # For efficiency.
                     result._model = match.__class__


### PR DESCRIPTION
I ran into a key error being thrown when the dict didn't contain 'score'.

Introduced here:
https://github.com/toastdriven/django-haystack/commit/7247f6bb0d762c0ddec1675ccbedca57419475ef

Using pop with a default value will remove the risk of this happening. It could be a configuration issue on my end, but regardless, it's a no-frills change that removes a possible exception that wasn't being caught.
