### PR TITLE
Fix Simple Score field collision

### DIFF
--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -71,7 +71,7 @@ class SimpleSearchBackend(BaseSearchBackend):
                 hits += len(qs)
 
                 for match in qs:
-                    del(match.__dict__['score'])
+                    match.__dict__.pop('score', None)
                     result = result_class(match._meta.app_label, match._meta.module_name, match.pk, 0, **match.__dict__)
                     # For efficiency.
                     result._model = match.__class__

--- a/tests/core/fixtures/bulk_data.json
+++ b/tests/core/fixtures/bulk_data.json
@@ -251,5 +251,12 @@
       "author": "daniel3",
       "pub_date": "2009-07-17 22:30:00"
     }
+  },
+  {
+    "pk": 1,
+    "model": "core.ScoreMockModel",
+    "fields": {
+      "score": "42"
+    }
   }
 ]

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -12,11 +12,10 @@ class MockModel(models.Model):
     foo = models.CharField(max_length=255, blank=True)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
     tag = models.ForeignKey(MockTag)
-    score = models.CharField(max_length=10, blank=True)
 
     def __unicode__(self):
         return self.author
-    
+
     def hello(self):
         return 'World!'
 
@@ -24,7 +23,7 @@ class MockModel(models.Model):
 class AnotherMockModel(models.Model):
     author = models.CharField(max_length=255)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
-    
+
     def __unicode__(self):
         return self.author
 
@@ -42,7 +41,7 @@ class AFourthMockModel(models.Model):
     author = models.CharField(max_length=255)
     editor = models.CharField(max_length=255)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
-    
+
     def __unicode__(self):
         return self.author
 
@@ -69,3 +68,9 @@ class ASixthMockModel(models.Model):
 
     def __unicode__(self):
         return self.name
+
+class ScoreMockModel(models.Model):
+    score = models.CharField(max_length=10)
+
+    def __unicode__(self):
+        return self.score

--- a/tests/simple_tests/search_indexes.py
+++ b/tests/simple_tests/search_indexes.py
@@ -1,12 +1,18 @@
 from haystack import indexes
-from core.models import MockModel
+from core.models import MockModel, ScoreMockModel
 
 
 class SimpleMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     name = indexes.CharField(model_attr='author')
     pub_date = indexes.DateField(model_attr='pub_date')
-    score = indexes.CharField(model_attr='score')
 
     def get_model(self):
         return MockModel
+
+class SimpleMockScoreIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, use_template=True)
+    score = indexes.CharField(model_attr='score')
+
+    def get_model(self):
+        return ScoreMockModel


### PR DESCRIPTION
Previous commit 0a9c919 broke the simple backend for models that
didn't have an indexed score field.  Added a test to cover regression.
