### PR TITLE
Add preceding dots to hyperlink target

### DIFF
--- a/docs/searchqueryset_api.rst
+++ b/docs/searchqueryset_api.rst
@@ -1,4 +1,4 @@
-_ref-searchqueryset-api:
+.. _ref-searchqueryset-api:
 
 ======================
 ``SearchQuerySet`` API


### PR DESCRIPTION
Fixes issue #754 by adding `..` back to the beginning of the hyperlink target.
