### PR TITLE
Percolator support

### DIFF
--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -188,6 +188,12 @@ class BaseSearchBackend(object):
 
         return models
 
+    def percolator(self, name, query):
+        raise NotImplementedError("Percolators are only available on the elastic search backend.")
+
+    def percolate(self, model_instance):
+        raise NotImplementedError("Percolate is only available on the elastic search backend.")
+
 
 # Alias for easy loading within SearchQuery objects.
 SearchBackend = BaseSearchBackend

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -534,6 +534,19 @@ class SearchQuerySet(object):
         qs._flat = flat
         return qs
 
+    def save_as_percolator(self, name):
+        """
+        Saves the current query as a percolator in the backend, using the name given.
+        """
+        query = self.query.backend.build_search_kwargs(self.query.build_query())
+        self.query.backend.percolator(name, query)
+
+    def percolate(self, model_instance):
+        """
+        Take the model instance given, run it against the percolators and return the matching names
+        """
+        return self.query.backend.percolate(model_instance)
+
     # Utility methods.
 
     def _clone(self, klass=None):

--- a/tests/core/tests/__init__.py
+++ b/tests/core/tests/__init__.py
@@ -10,6 +10,7 @@ from core.tests.indexes import *
 from core.tests.inputs import *
 from core.tests.loading import *
 from core.tests.models import *
+from core.tests.percolators import *
 from core.tests.query import *
 from core.tests.templatetags import *
 from core.tests.views import *

--- a/tests/core/tests/percolators.py
+++ b/tests/core/tests/percolators.py
@@ -1,0 +1,33 @@
+from ..models import MockModel
+from ..tests.indexes import GoodMockSearchIndex
+
+from haystack import connections
+from haystack.utils.loading import UnifiedIndex
+from haystack.query import SearchQuerySet
+
+from django.test import TestCase
+
+class PercolatorTestCase(TestCase):
+    def setUp(self):
+        #set up indexes
+        ui = UnifiedIndex()
+        gmsi = GoodMockSearchIndex()
+        ui.build(indexes=[gmsi])
+        connections['default']._index = ui
+
+        # Update the "index".
+        backend = connections['default'].get_backend()
+        backend.clear()
+        backend.update(gmsi, MockModel.objects.all())
+
+        self.percolator_name = 'search_for_daniel2'
+
+    def test_percolator_and_percolate(self):
+        sqs = SearchQuerySet()
+
+        #create query, create percolator
+        sqs.filter(author='daniel2').save_as_percolator("search_for_daniel2")
+
+        #percolate test object against query
+        self.assertEqual(sqs.percolate(MockModel.objects.filter(author='daniel2')[:1].get())[0], self.percolator_name)
+        self.assertEqual(sqs.percolate(MockModel.objects.exclude(author='daniel2')[:1].get()), [])


### PR DESCRIPTION
Adds percolator support to sqs for elastic search backend.

This has a few issues, which I'm not sure can be addressed cleanly:

1 - Whoosh and Solr don't support the percolator feature, so users will get a NotImplemented exception

2 - Names are not guaranteed to be unique, so saving a percolator can overwrite an existing one

3 - No support for deleting percolators

4 - No support for rebuilding the percolator index.  We'd have to save the sqs in the database somewhere to do that.  It's possible, but that adds a lot of bloat to Haystack (models / south).

5 - Pyelasticsearch would need to accept this pull request:

https://github.com/rhec/pyelasticsearch/pull/73

That all being said, I'd appreciate your feedback on this pull request.  I did it as much to learn as to add a feature to haystack.
