### PR TITLE
Make models filter work on simple backend

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,3 +68,4 @@ Thanks to
     * Martin J. Laubach (mjl) for fixing the logic used when combining querysets
     * Eric Holscher (ericholscher) for a docs fix.
     * Erik Rose (erikrose) for a quick pyelasticsearch-compatibility patch
+    * Stefan Wehrmeyer (stefanw) for a simple search filter fix

--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -45,12 +45,16 @@ class SimpleSearchBackend(BaseSearchBackend):
         hits = 0
         results = []
         result_class = SearchResult
+        models = connections[self.connection_alias].get_unified_index().get_indexed_models()
 
         if kwargs.get('result_class'):
             result_class = kwargs['result_class']
 
+        if kwargs.get('models'):
+            models = kwargs['models']
+
         if query_string:
-            for model in connections[self.connection_alias].get_unified_index().get_indexed_models():
+            for model in models:
                 if query_string == '*':
                     qs = model.objects.all()
                 else:

--- a/tests/simple_tests/tests/simple_backend.py
+++ b/tests/simple_tests/tests/simple_backend.py
@@ -71,6 +71,11 @@ class SimpleSearchBackendTestCase(TestCase):
         # Ensure that swapping the ``result_class`` works.
         self.assertTrue(isinstance(self.backend.search(u'index document', result_class=MockSearchResult)['results'][0], MockSearchResult))
 
+    def test_filter_models(self):
+        self.backend.update(self.index, self.sample_objs)
+        self.assertEqual(self.backend.search(u'*', models=set([]))['hits'], 24)
+        self.assertEqual(self.backend.search(u'*', models=set([MockModel]))['hits'], 23)
+
     def test_more_like_this(self):
         self.backend.update(self.index, self.sample_objs)
         self.assertEqual(self.backend.search(u'*')['hits'], 24)


### PR DESCRIPTION
This enables the models filter on the simple backend by searching only the models in the `models` keyword argument if provided, falling back to all models if the keyword argument is empty or does not exist.

This fixes #397.

I license this patch under the BSD-license. I added myself to the AUTHORS file in accordance with the guidelines for contributing code.
