### PR TITLE
Added _version_ field definition

### DIFF
--- a/haystack/templates/search_configuration/solr.xml
+++ b/haystack/templates/search_configuration/solr.xml
@@ -130,6 +130,7 @@
 
   <fields>
     <!-- general -->
+    <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
     <field name="{{ ID }}" type="string" indexed="true" stored="true" multiValued="false" required="true"/>
     <field name="{{ DJANGO_CT }}" type="string" indexed="true" stored="true" multiValued="false"/>
     <field name="{{ DJANGO_ID }}" type="string" indexed="true" stored="true" multiValued="false"/>


### PR DESCRIPTION
Adding the `_version_` field definition allows a config.xml file generated with Haystack’s `build_solr_schema` command to work out-of-the-box with the “example” server in the Solr 4.2.0 distribution.

Omitting `_version_` will cause the stock “example” Solr server to start in an unusable state – for details, see:
- http://stackoverflow.com/a/15581292/298171
- http://lucene.472066.n3.nabble.com/Error-version-field-must-exist-in-schema-td4014352.html
- http://wiki.apache.org/solr/SolrCloud#Required_Config
