### PR TITLE
Fix incorrect construction of datetime object in elasticsearch_backend module

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -686,7 +686,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 for dk, dv in date_values.items():
                     date_values[dk] = int(dv)
 
-                return datetime(
+                return datetime.datetime(
                     date_values['year'], date_values['month'],
                     date_values['day'], date_values['hour'],
                     date_values['minute'], date_values['second'])


### PR DESCRIPTION
The datetime module is introduced into the local namespace directly; the module itself is not a callable and datetime construction should use 'datetime.datetime'.

Execution of this line raises a TypeError.
