### PR TITLE
Bug in query.py if using passed at the time of initialization of SQS object

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -36,10 +36,10 @@ class SearchQuerySet(object):
     def _determine_backend(self):
         # A backend has been manually selected. Use it instead.
         if self._using is not None:
-            return self._using
+            self.query = connections[self._using].get_query()
+            return
 
         # No backend, so rely on the routers to figure out what's right.
-        from haystack import connections
         hints = {}
 
         if self.query:


### PR DESCRIPTION
Fix bug where if using is passed at the time of initializing the SQS object then it leads to error as self.query is never assigned and remains None.

AttributeError: 'NoneType' object has no attribute '_clone'
