### PR TITLE
Added a new setting, HAYSTACK_IDENTIFIER_METHOD, which will allow a cust...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,3 +70,4 @@ Thanks to
     * Erik Rose (erikrose) for a quick pyelasticsearch-compatibility patch
     * Stefan Wehrmeyer (stefanw) for a simple search filter fix
     * Dan Watson (dcwatson) for various patches.
+    * Andrew Schoen (andrewschoen) for the addition of ``HAYSTACK_IDENTIFIER_METHOD``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -268,3 +268,20 @@ An example::
     HAYSTACK_DJANGO_ID_FIELD = 'my_django_id'
 
 Default is ``django_id``.
+
+
+``HAYSTACK_IDENTIFIER_METHOD``
+==============================
+
+**Optional**
+
+This setting allows you to provide a custom method for
+``haystack.utils.get_identifier``. Useful when the default identifier
+pattern of <app.label>.<object_name>.<pk> isn't suited to your
+needs.
+
+An example::
+
+    HAYSTACK_IDENTIFIER_METHOD = 'my_app.module.get_identifier'
+
+Default is ``haystack.utils.default_get_identifier``.

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -1,33 +1,77 @@
 import re
+
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID
 from haystack.utils.highlighting import Highlighter
 
 
+from django.conf import settings
+
+try:
+    from django.utils import importlib
+except ImportError:
+    import importlib
+
 IDENTIFIER_REGEX = re.compile('^[\w\d_]+\.[\w\d_]+\.\d+$')
+
+
+def default_get_identifier(obj_or_string):
+    """
+    Get an unique identifier for the object or a string representing the
+    object.
+
+    If not overridden, uses <app_label>.<object_name>.<pk>.
+    """
+    if isinstance(obj_or_string, basestring):
+        if not IDENTIFIER_REGEX.match(obj_or_string):
+            raise AttributeError(u"Provided string '%s' is not a valid identifier." % obj_or_string)
+
+        return obj_or_string
+
+    return u"%s.%s.%s" % (
+        obj_or_string._meta.app_label,
+        obj_or_string._meta.module_name,
+        obj_or_string._get_pk_val()
+    )
+
+
+def _lookup_identifier_method():
+    """
+    If the user has set HAYSTACK_IDENTIFIER_METHOD, import it and return the method uncalled.
+    If HAYSTACK_IDENTIFIER_METHOD is not defined, return haystack.utils.default_get_identifier.
+
+    This always runs at module import time.  We keep the code in a function
+    so that it can be called from unit tests, in order to simulate the re-loading
+    of this module.
+    """
+    if not hasattr(settings, 'HAYSTACK_IDENTIFIER_METHOD'):
+        return default_get_identifier
+
+    module_path, method_name = settings.HAYSTACK_IDENTIFIER_METHOD.rsplit(".", 1)
+
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError:
+        raise ImportError(u"Unable to import module '%s' provided for HAYSTACK_IDENTIFIER_METHOD." % module_path)
+
+    identifier_method = getattr(module, method_name, None)
+
+    if not identifier_method:
+        raise AttributeError(
+            u"Provided method '%s' for HAYSTACK_IDENTIFIER_METHOD does not exist in '%s'." % (method_name, module_path)
+        )
+
+    return identifier_method
+
+
+get_identifier = _lookup_identifier_method()
 
 
 def get_model_ct(model):
     return "%s.%s" % (model._meta.app_label, model._meta.module_name)
 
 
-def get_identifier(obj_or_string):
-    """
-    Get an unique identifier for the object or a string representing the
-    object.
-    
-    If not overridden, uses <app_label>.<object_name>.<pk>.
-    """
-    if isinstance(obj_or_string, basestring):
-        if not IDENTIFIER_REGEX.match(obj_or_string):
-            raise AttributeError("Provided string '%s' is not a valid identifier." % obj_or_string)
-        
-        return obj_or_string
-    
-    return u"%s.%s.%s" % (obj_or_string._meta.app_label, obj_or_string._meta.module_name, obj_or_string._get_pk_val())
-
-
 def get_facet_field_name(fieldname):
     if fieldname in [ID, DJANGO_ID, DJANGO_CT]:
         return fieldname
-    
+
     return "%s_exact" % fieldname

--- a/tests/core/custom_identifier.py
+++ b/tests/core/custom_identifier.py
@@ -1,0 +1,7 @@
+
+def get_identifier_method(key):
+    """
+    Custom get_identifier method used for testing the
+    setting HAYSTACK_IDENTIFIER_MODULE
+    """
+    return key


### PR DESCRIPTION
...om method to be provided for `haystack.utils.get_identifier`.

Hey guys, I'm going to be needing this at work sometime soon so I thought I'd contribute it here first to get some feedback.  We're in a situation where we need the identifier to be globally unique, so this patch allows us to do that by providing a new method for `haystack.utils.get_identifer`.

I owed Daniel a pull request anyway for that commit bit he gave me.
- Andrew
