### PR TITLE
Fix incorrect end_offset being passed into backend MLT call

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -958,7 +958,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
         }
 
         if self.end_offset is not None:
-            search_kwargs['end_offset'] = self.end_offset - self.start_offset
+            search_kwargs['end_offset'] = self.end_offset
 
         results = self.backend.more_like_this(self._mlt_instance, additional_query_string, **search_kwargs)
         self._results = results.get('results', [])

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -708,7 +708,7 @@ class SolrSearchQuery(BaseSearchQuery):
         }
 
         if self.end_offset is not None:
-            search_kwargs['end_offset'] = self.end_offset - self.start_offset
+            search_kwargs['end_offset'] = self.end_offset
 
         results = self.backend.more_like_this(self._mlt_instance, additional_query_string, **search_kwargs)
         self._results = results.get('results', [])


### PR DESCRIPTION
Issue: The end_offset being passed to `self.backend.more_like_this` is calculated as `self.end_offset - self.start_offset`.

This causes a problem when self.start_offset is non-zero, and `self.backend.more_like_this` does `params['search_size'] = end_offset - start_offset` to calculate search_size, in many cases resulting in`params['search_size']` being negative.

Passing `self.end_offset` as `search_kwargs['end_offset']` fixes the problem.

Related: http://stackoverflow.com/questions/14128593/elasticsearch-exception-with-more-like-this-in-django-haystack
