### PR TITLE
_version_ is required in solr 4

### DIFF
--- a/haystack/templates/search_configuration/solr.xml
+++ b/haystack/templates/search_configuration/solr.xml
@@ -148,7 +148,7 @@
     <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false"/>
 
 {% for field in fields %}
-    {% if field.field_name != ID }}
+    {% if field.field_name != ID %}
     <field name="{{ field.field_name }}" type="{{ field.type }}" indexed="{{ field.indexed }}" stored="{{ field.stored }}" multiValued="{{ field.multi_valued }}" />
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
with solr 4.4 rebuild_index fails because _version_ is a required field.
