### PR TITLE
Add support for prefetch_related and select_related when updating index.

### DIFF
--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -179,6 +179,18 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
         # nullable `ForeignKey` as well as what seems like other cases.
         return index_qs.filter(**extra_lookup_kwargs).order_by(model._meta.pk.name)
 
+    def get_select_related_fields(self):
+        """
+        Return a tuple of related models that should be selected (within batches) for speed optimisation.
+        """
+        return ()
+
+    def get_prefetch_related_fields(self):
+        """
+        Return a tuple of related models that should be prefetched (within batches) for speed optimisation.
+        """
+        return ()
+
     def prepare(self, obj):
         """
         Fetches and adds/alters data before indexing.

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -79,6 +79,14 @@ def do_update(backend, index, qs, start, end, total, verbosity=1):
     small_cache_qs = qs.all()
     current_qs = small_cache_qs[start:end]
 
+    select_related_fields = index.get_select_related_fields()
+    if select_related_fields:
+        current_qs = current_qs.select_related(*select_related_fields)
+
+    prefetch_related_fields = index.get_prefetch_related_fields()
+    if prefetch_related_fields:
+        current_qs = current_qs.prefetch_related(*prefetch_related_fields)
+
     if verbosity >= 2:
         if hasattr(os, 'getppid') and os.getpid() == os.getppid():
             print("  indexed %s - %d of %d." % (start + 1, end, total))


### PR DESCRIPTION
There seems to be no support for https://docs.djangoproject.com/en/dev/ref/models/querysets/#django.db.models.query.QuerySet.select_related at the moment, and when im rebuilding an index of about 1M objects that have several related model fields pulled into them for the index, it's just spamming the DB. This should at least improve the situation somewhat (or 1000-fold if you like) :).

I know you guys want tests, but I'm not sure how to test that it's actually executing the select/prefetch_related queries from haystack since nothing visible would change even it wouldn't..

Let me know what changes I need to make as usual.

Cheers
