### PR TITLE
Fixed an update_index bug when using multiple connections

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,3 +85,4 @@ Thanks to
     * Eric Thurgood (ethurgood) for a import fix in the Elasticssearch backend.
     * Revolution Systems & The Python Software Foundation for funding a significant portion of the port to Python 3!
     * Artem Kostiuk (postatum) for patch allowing to search for slash character in ElasticSearch since Lucene 4.0.
+    * Luis Barrueco (luisbarrueco) for a simple fix regarding updating indexes using multiple backends.

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -96,7 +96,7 @@ def do_remove(backend, index, model, pks_seen, start, upper_bound, verbosity=1):
     # Fetch a list of results.
     # Can't do pk range, because id's are strings (thanks comments
     # & UUIDs!).
-    stuff_in_the_index = SearchQuerySet().models(model)[start:upper_bound]
+    stuff_in_the_index = SearchQuerySet(using=backend.connection_alias).models(model)[start:upper_bound]
 
     # Iterate over those results.
     for result in stuff_in_the_index:


### PR DESCRIPTION
I would get this warning `/usr/local/lib/python2.7/dist-packages/haystack/query.py:340: UserWarning: The model <class 'reclamos.models.Empresa'> is not registered for search.` and the update_index command wouldn't remove objects deleted from the model when using `--remove`, because the management command wasn't taking into account the backend specified with the `--using=` parameter.
