### PR TITLE
adding max_retries to elasticsearch backend

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -99,8 +99,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 
         if not 'INDEX_NAME' in connection_options:
             raise ImproperlyConfigured("You must specify a 'INDEX_NAME' in your settings for connection '%s'." % connection_alias)
-
-        self.conn = pyelasticsearch.ElasticSearch(connection_options['URL'], timeout=self.timeout)
+        max_retries = connection_options.get('MAX_RETRIES', 0)
+        self.conn = pyelasticsearch.ElasticSearch(connection_options['URL'], timeout=self.timeout, max_retries=max_retries)
         self.index_name = connection_options['INDEX_NAME']
         self.log = logging.getLogger('haystack')
         self.setup_complete = False


### PR DESCRIPTION
Allow max_retries to be set on connection creation will which allow requests to be tried on a different cluster node on failure.
