### PR TITLE
Upsert instead of overwrite during indexing

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -181,7 +181,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 })
 
         if upsert:
-            self.conn.bulk_update(self.index_name, 'modelresult', prepped_docs, id_field=ID)
+            self.conn.bulk_update(self.index_name, 'modelresult', prepped_docs, id_field=ID, upsert=True)
         else:
             self.conn.bulk_index(self.index_name, 'modelresult', prepped_docs, id_field=ID)
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -143,7 +143,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 
         self.setup_complete = True
 
-    def update(self, index, iterable, commit=True):
+    def update(self, index, iterable, commit=True, upsert=False):
         if not self.setup_complete:
             try:
                 self.setup()
@@ -180,7 +180,10 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     }
                 })
 
-        self.conn.bulk_index(self.index_name, 'modelresult', prepped_docs, id_field=ID)
+        if upsert:
+            self.conn.bulk_update(self.index_name, 'modelresult', prepped_docs, id_field=ID)
+        else:
+            self.conn.bulk_index(self.index_name, 'modelresult', prepped_docs, id_field=ID)
 
         if commit:
             self.conn.refresh(index=self.index_name)


### PR DESCRIPTION
Hi there, this is not a complete patch but a proof of concept that works obviously. The idea is that a document in ES might be written to by several systems, and you don't necessarily want it to be fully replaced each time update_index is run from within Django.

Support for bulk_update on the pyelasticsearch side will hopefully be added soon via https://github.com/rhec/pyelasticsearch/pull/133

So this is basically something to consider, and hopefully agree that it is a good thing - then we can talk about making the PR more complete.

Cheers