### PR TITLE
Fixes breaking bug if no suggested spelling results were returned.

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -575,10 +575,10 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         if result_class is None:
             result_class = SearchResult
 
-        raw_suggest = raw_results['suggest'].get('suggest')
-        if raw_suggest:
-            raw_suggest = raw_results['suggest']['suggest']
-            spelling_suggestion = ' '.join([word['text'] if len(word['options']) == 0 else word['options'][0]['text'] for word in raw_suggest])
+        if self.include_spelling and 'suggest' in raw_results:
+            raw_suggest = raw_results['suggest'].get('suggest')
+            if raw_suggest:
+                spelling_suggestion = ' '.join([word['text'] if len(word['options']) == 0 else word['options'][0]['text'] for word in raw_suggest])
 
         if 'facets' in raw_results:
             facets = {


### PR DESCRIPTION
Just a small fix - in cases where no spelling suggest results were returned, it was possible for a KeyError exception to be thrown (and happened to me).

Good description of the crash case is here.  http://stackoverflow.com/questions/18961894/haystack-keyerror-in-the-elasticsearch-backend-module

Verified working here.  Thanks for the great work on django-haystack!
