### PR TITLE
Fix model query generation for ElasticSearch

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -224,7 +224,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 models_to_delete = []
 
                 for model in models:
-                    models_to_delete.append("%s:%s.%s" % (DJANGO_CT, model._meta.app_label, model._meta.module_name))
+                    models_to_delete.append('%s:"%s.%s"' % (DJANGO_CT, model._meta.app_label, model._meta.module_name))
 
                 # Delete by query in Elasticsearch asssumes you're dealing with
                 # a ``query`` root object. :/
@@ -408,7 +408,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             if narrow_queries is None:
                 narrow_queries = set()
 
-            narrow_queries.add('%s:(%s)' % (DJANGO_CT, ' OR '.join(model_choices)))
+            narrow_queries.add('%s:("%s")' % (DJANGO_CT, '" OR "'.join(model_choices)))
 
         if narrow_queries:
             kwargs['query'].setdefault('filtered', {})


### PR DESCRIPTION
Useful when we have several models in the same app and one of the
models has the same name as the app.

For example if we have the app "album" containing the models "Album" and "Track".

They will have "album.album" and "album.track" respectively for their django_ct.

Then we search for albums, the query is `django_ct:(album.album)` which will match tracks. Instead it now generates `django_ct:("album.album")` which only matches albums.
