### PR TITLE
Don't tokenize boolean fields in ElasticSearch

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -669,6 +669,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 field_mapping['type'] = 'float'
             elif field_class.field_type == 'boolean':
                 field_mapping['type'] = 'boolean'
+                del field_mapping['index']
             elif field_class.field_type == 'ngram':
                 field_mapping['analyzer'] = "ngram_analyzer"
             elif field_class.field_type == 'edge_ngram':


### PR DESCRIPTION
You can't tokenize a boolean field in ElasticSearch 0.90.5 and it will refuse to accept produced schema. This will in effect result in automatic creation of mapping in ES which will ignore indexed/stored settings and make it impossible to sort on a text field.

This will likely resolve issue #866 and definitely #569 at by enabling indexed/stored workaround.
