### PR TITLE
Handle `ElasticsearchSearchBackend` index exceptions the way it should

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,3 +86,4 @@ Thanks to
     * Revolution Systems & The Python Software Foundation for funding a significant portion of the port to Python 3!
     * Artem Kostiuk (postatum) for patch allowing to search for slash character in ElasticSearch since Lucene 4.0.
     * Luis Barrueco (luisbarrueco) for a simple fix regarding updating indexes using multiple backends.
+    * Pierre Dulac (dulaccc) for a simple fix allowing better exception handling in the ElasticSearch backend 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -172,6 +172,9 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     raise
                 self.log.error(inst)
 
+        # Wait for cluster to be ready before running any bulk indexing on it
+        self.conn.health(self.index_name, wait_for_status='yellow')
+
         self.setup_complete = True
 
     def update(self, index, iterable, commit=True):

--- a/tests/elasticsearch_tests/tests/test_elasticsearch_backend.py
+++ b/tests/elasticsearch_tests/tests/test_elasticsearch_backend.py
@@ -1380,3 +1380,31 @@ class ElasticsearchFacetingTestCase(TestCase):
         self.assertEqual(counts['dates']['pub_date'], [
             (datetime.datetime(2013, 9, 1), 9),
         ])
+
+class ElasticsearchSearchBackendNonSilentTestCase(TestCase):
+    def setUp(self):
+        super(ElasticsearchSearchBackendNonSilentTestCase, self).setUp()
+
+        # Wipe it clean.
+        clear_elasticsearch_index()
+
+        # Stow.
+        self.old_ui = connections['default'].get_unified_index()
+        self.ui = UnifiedIndex()
+        self.smmi = ElasticsearchMockSearchIndex()
+        self.ui.build(indexes=[self.smmi])
+        connections['default']._index = self.ui
+        self.sb = connections['default'].backend('default', SILENTLY_FAIL=False, **settings.HAYSTACK_CONNECTIONS['default'])
+
+    def tearDown(self):
+        connections['default']._index = self.old_ui
+        super(ElasticsearchSearchBackendNonSilentTestCase, self).tearDown()
+
+    def test_no_initial_mapping_exception(self):
+        """Shouldn't raise a `pyelasticsearch.ElasticHttpNotFoundError` 404 exception"""
+        self.sb.setup()
+
+    def test_setup_an_already_existing_index_exception(self):
+        """Shouldn't raise a `pyelasticsearch.ElasticHttpNotFoundError` 404 exception"""
+        self.sb.setup()  # first time create the mapping and the index
+        self.sb.setup()  # second time need to only update the index

--- a/tests/elasticsearch_tests/tests/test_elasticsearch_backend.py
+++ b/tests/elasticsearch_tests/tests/test_elasticsearch_backend.py
@@ -1402,9 +1402,21 @@ class ElasticsearchSearchBackendNonSilentTestCase(TestCase):
 
     def test_no_initial_mapping_exception(self):
         """Shouldn't raise a `pyelasticsearch.ElasticHttpNotFoundError` 404 exception"""
-        self.sb.setup()
+        try:
+            self.sb.setup()
+        except pyelasticsearch.ElasticHttpNotFoundError:
+            self.fail("an ElasticHttpNotFoundError exception is raised whereas it should create the necessary index")
 
     def test_setup_an_already_existing_index_exception(self):
-        """Shouldn't raise a `pyelasticsearch.ElasticHttpNotFoundError` 404 exception"""
-        self.sb.setup()  # first time create the mapping and the index
-        self.sb.setup()  # second time need to only update the index
+        """Shouldn't raise a `pyelasticsearch.IndexAlreadyExistsError` exception"""
+        # first time create the mapping and the index
+        self.sb.setup()
+
+        # second time need to only update the index
+        #
+        # NB: currenlty no need to actually modify the mapping
+        #     since it always diff
+        try:
+            self.sb.setup()
+        except pyelasticsearch.IndexAlreadyExistsError:
+            self.fail("an IndexAlreadyExistsError exception is raised whereas it should setup the index")


### PR DESCRIPTION
For instance, it was nearly impossible to use commands like `update_index` or `rebuild_index` when `silently_fail` was set to False, because of missing exception handling.

Cheers
