### PR TITLE
Only run the query once to update whoosh index

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -175,7 +175,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         self.index = self.index.refresh()
         writer = AsyncWriter(self.index)
 
-        for obj in iterable:
+        for len_iterable, obj in enumerate(iterable, start=1):
             doc = index.full_prepare(obj)
 
             # Really make sure it's unicode, because Whoosh won't have it any
@@ -203,7 +203,7 @@ class WhooshSearchBackend(BaseSearchBackend):
                     }
                 })
 
-        if len(iterable) > 0:
+        if iterable and len_iterable > 0:
             # For now, commit no matter what, as we run into locking issues otherwise.
             writer.commit()
 


### PR DESCRIPTION
Currently, the len(iterable) will cause a second query to be issued to
the database. If you're using a generator, this will fail. For regular
querysets, it's running a second query needlessly.
