### PR TITLE
Remove bit about SearchQuerySet.load_all_queryset deprecation

### DIFF
--- a/docs/searchqueryset_api.rst
+++ b/docs/searchqueryset_api.rst
@@ -483,15 +483,6 @@ Example::
 
     SearchQuerySet().filter(content='foo').load_all()
 
-``load_all_queryset``
-~~~~~~~~~~~~~~~~~~~~~
-
-.. method:: SearchQuerySet.load_all_queryset(self, model_class, queryset)
-
-Deprecated for removal before Haystack 1.0-final.
-
-Please see the docs on ``RelatedSearchQuerySet``.
-
 ``auto_query``
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
That method was entirely removed in commit b8048dc0e9e3.

If this looks good to a Haystack dev, it should close #607. Thanks to @bradleyayers for the report.
