### PR TITLE
Use elasticsearch-py instead of pyelasticsearch.

### DIFF
--- a/docs/backend_support.rst
+++ b/docs/backend_support.rst
@@ -50,7 +50,7 @@ Elasticsearch
 * Stored (non-indexed) fields
 * Highlighting
 * Spatial search
-* Requires: pyelasticsearch 0.4+ & Elasticsearch 0.17.7+
+* Requires: elasticsearch-py 0.4.3+ & Elasticsearch 0.17.7+
 
 Whoosh
 ------

--- a/docs/installing_search_engines.rst
+++ b/docs/installing_search_engines.rst
@@ -152,17 +152,16 @@ locally. Modifications should be done in a YAML file, the stock one being
       logs: /usr/local/var/log
       data: /usr/local/var/data
 
-You'll also need an Elasticsearch binding: pyelasticsearch_ (**NOT**
-``pyes``). Place ``pyelasticsearch`` somewhere on your ``PYTHONPATH``
-(usually ``python setup.py install`` or ``pip install pyelasticsearch``).
+You'll also need an Elasticsearch binding: elasticsearch-py_ (**NOT**
+``pyes``). Place ``elasticsearch`` somewhere on your ``PYTHONPATH``
+(usually ``python setup.py install`` or ``pip install elasticsearch``).
 
-.. _pyelasticsearch: http://pypi.python.org/pypi/pyelasticsearch/
+.. _elasticsearch-py: http://pypi.python.org/pypi/elasticsearch/
 
 .. note::
 
-    ``pyelasticsearch`` has its own dependencies that aren't covered by
-    Haystack. You'll also need ``requests`` & ``simplejson`` for speedier
-    JSON construction/parsing.
+    ``elasticsearch`` has its own dependencies that aren't covered by
+    Haystack. You'll also need ``urllib3``.
 
 
 Whoosh

--- a/docs/python3.rst
+++ b/docs/python3.rst
@@ -25,7 +25,7 @@ The following backends are fully supported under Python 3. However, you may
 need to update these dependencies if you have a pre-existing setup.
 
 * Solr (pysolr>=3.1.0)
-* Elasticsearch (pyelasticsearch>=0.5)
+* Elasticsearch
 
 
 Partially Supported Backends

--- a/tests/core/tests/test_backends.py
+++ b/tests/core/tests/test_backends.py
@@ -27,9 +27,9 @@ class LoadBackendTestCase(TestCase):
 
     def test_load_elasticsearch(self):
         try:
-            import pyelasticsearch
+            import elasticsearch
         except ImportError:
-            warnings.warn("Pyelasticsearch doesn't appear to be installed. Unable to test loading the ElasticSearch backend.")
+            warnings.warn("elasticsearch-py doesn't appear to be installed. Unable to test loading the ElasticSearch backend.")
             return
 
         backend = loading.load_backend('haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine')

--- a/tests/elasticsearch_tests/tests/test_elasticsearch_backend.py
+++ b/tests/elasticsearch_tests/tests/test_elasticsearch_backend.py
@@ -4,8 +4,7 @@ from decimal import Decimal
 import logging as std_logging
 import operator
 
-import pyelasticsearch
-import requests
+import elasticsearch
 from django.conf import settings
 from django.test import TestCase
 from django.utils import unittest
@@ -33,11 +32,11 @@ except ImportError:
 
 def clear_elasticsearch_index():
     # Wipe it clean.
-    raw_es = pyelasticsearch.ElasticSearch(settings.HAYSTACK_CONNECTIONS['default']['URL'])
+    raw_es = elasticsearch.Elasticsearch(settings.HAYSTACK_CONNECTIONS['default']['URL'])
     try:
-        raw_es.delete_index(settings.HAYSTACK_CONNECTIONS['default']['INDEX_NAME'])
-        raw_es.refresh()
-    except (requests.RequestException, pyelasticsearch.ElasticHttpError):
+        raw_es.indices.delete(index=settings.HAYSTACK_CONNECTIONS['default']['INDEX_NAME'])
+        raw_es.indices.refresh()
+    except elasticsearch.TransportError:
         pass
 
 
@@ -204,7 +203,7 @@ class ElasticsearchSearchBackendTestCase(TestCase):
         super(ElasticsearchSearchBackendTestCase, self).setUp()
 
         # Wipe it clean.
-        self.raw_es = pyelasticsearch.ElasticSearch(settings.HAYSTACK_CONNECTIONS['default']['URL'])
+        self.raw_es = elasticsearch.Elasticsearch(settings.HAYSTACK_CONNECTIONS['default']['URL'])
         clear_elasticsearch_index()
 
         # Stow.
@@ -235,8 +234,8 @@ class ElasticsearchSearchBackendTestCase(TestCase):
 
     def raw_search(self, query):
         try:
-            return self.raw_es.search('*:*', index=settings.HAYSTACK_CONNECTIONS['default']['INDEX_NAME'])
-        except (requests.RequestException, pyelasticsearch.ElasticHttpError):
+            return self.raw_es.search(q='*:*', index=settings.HAYSTACK_CONNECTIONS['default']['INDEX_NAME'])
+        except elasticsearch.TransportError:
             return {}
 
     def test_non_silent(self):
@@ -1226,7 +1225,7 @@ class ElasticsearchBoostBackendTestCase(TestCase):
         super(ElasticsearchBoostBackendTestCase, self).setUp()
 
         # Wipe it clean.
-        self.raw_es = pyelasticsearch.ElasticSearch(settings.HAYSTACK_CONNECTIONS['default']['URL'])
+        self.raw_es = elasticsearch.Elasticsearch(settings.HAYSTACK_CONNECTIONS['default']['URL'])
         clear_elasticsearch_index()
 
         # Stow.
@@ -1258,7 +1257,7 @@ class ElasticsearchBoostBackendTestCase(TestCase):
         super(ElasticsearchBoostBackendTestCase, self).tearDown()
 
     def raw_search(self, query):
-        return self.raw_es.search('*:*', index=settings.HAYSTACK_CONNECTIONS['default']['INDEX_NAME'])
+        return self.raw_es.search(q='*:*', index=settings.HAYSTACK_CONNECTIONS['default']['INDEX_NAME'])
 
     def test_boost(self):
         self.sb.update(self.smmi, self.sample_objs)
@@ -1287,7 +1286,7 @@ class ElasticsearchBoostBackendTestCase(TestCase):
 
 class RecreateIndexTestCase(TestCase):
     def setUp(self):
-        self.raw_es = pyelasticsearch.ElasticSearch(
+        self.raw_es = elasticsearch.Elasticsearch(
             settings.HAYSTACK_CONNECTIONS['default']['URL'])
 
     def test_recreate_index(self):
@@ -1297,14 +1296,14 @@ class RecreateIndexTestCase(TestCase):
         sb.silently_fail = True
         sb.setup()
 
-        original_mapping = self.raw_es.get_mapping(sb.index_name)
+        original_mapping = self.raw_es.indices.get_mapping(index=sb.index_name)
 
         sb.clear()
         sb.setup()
 
         try:
-            updated_mapping = self.raw_es.get_mapping(sb.index_name)
-        except pyelasticsearch.ElasticHttpNotFoundError:
+            updated_mapping = self.raw_es.indices.get_mapping(sb.index_name)
+        except elasticsearch.NotFoundError:
             self.fail("There is no mapping after recreating the index")
         self.assertEqual(original_mapping, updated_mapping,
             "Mapping after recreating the index differs from the original one")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ Django==1.4.2
 Whoosh==2.4.1
 httplib2==0.8
 mock==1.0.1
-pyelasticsearch==0.5
+elasticsearch==0.4.3
 pysolr==3.0.6
 pysqlite==2.6.3
 geopy==0.95.1

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     pysolr==3.1.0
     poster
     whoosh==2.5.4
-    pyelasticsearch==0.6
+    elasticsearch==0.4.3
     httplib2==0.8
     python-dateutil
     geopy==0.95.1


### PR DESCRIPTION
elasticsearch-py is the official Python client for Elasticsearch.

Note that this code relies on unreleased version of elasticsearch-py (0.4.3) which contains some fixes and considerations designed for haystack compatibility. Test with master branch or elasticsearch-py and if you decide to merge it I will release the client.

Thanks
