### PR TITLE
Search form <input type="search">

### DIFF
--- a/haystack/forms.py
+++ b/haystack/forms.py
@@ -19,7 +19,8 @@ def model_choices(using=DEFAULT_ALIAS):
 
 
 class SearchForm(forms.Form):
-    q = forms.CharField(required=False, label=_('Search'))
+    q = forms.CharField(required=False, label=_('Search'),
+                        widget=forms.TextInput(attrs={'type': 'search'}))
 
     def __init__(self, *args, **kwargs):
         self.searchqueryset = kwargs.pop('searchqueryset', None)


### PR DESCRIPTION
When creating a simple search form for example via:

```
return basic_search(request, template='search.html')
```

... and rendering it in the template like:

```
{{ form.as_p }}
```

It should use a form with `<input type="search" .../>` instead of `<input type="text" .../>`
