### PR TITLE
ElasticSearch backend: number of facets should be configurable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,3 +89,4 @@ Thanks to
     * Szymon Teżewski (jasisz) for an update to the bounding-box calculation for spatial queries
     * Chris Wilson (qris) and Orlando Fiol (overflow) for an update allowing the use of multiple order_by()
       fields with Whoosh as long as they share a consistent sort direction
+    * Wiktor Kołodziej (viciu) for ElasticSearch ``FACET_SIZE`` connection option

--- a/docs/backend_support.rst
+++ b/docs/backend_support.rst
@@ -46,7 +46,7 @@ Elasticsearch
 * Automatic query building
 * "More Like This" functionality
 * Term Boosting
-* Faceting (up to 100 facets)
+* Faceting (by default up to 100 facets)
 * Stored (non-indexed) fields
 * Highlighting
 * Spatial search

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -93,6 +93,8 @@ The following options are optional:
 * ``INCLUDE_SPELLING`` - Include spelling suggestions. Default is ``False``
 * ``BATCH_SIZE`` - How many records should be updated at once via the management
   commands. Default is ``1000``.
+* ``FACET_SIZE`` - (ElasticSearch-only) Controls how many facet entries will be returned.
+  Returning too many results may impact performance. Default is ``100``.
 * ``TIMEOUT`` - (Solr and ElasticSearch) How long to wait (in seconds) before
   the connection times out. Default is ``10``.
 * ``STORAGE`` - (Whoosh-only) Which storage engine to use. Accepts ``file`` or

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -99,6 +99,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 
         self.conn = elasticsearch.Elasticsearch(connection_options['URL'], timeout=self.timeout, **connection_options.get('KWARGS', {}))
         self.index_name = connection_options['INDEX_NAME']
+        self.facet_size = connection_options.get('FACET_SIZE', 100)
         self.log = logging.getLogger('haystack')
         self.setup_complete = False
         self.existing_mapping = {}
@@ -334,7 +335,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 facet_options = {
                     'terms': {
                         'field': facet_fieldname,
-                        'size': 100,
+                        'size': self.facet_size,
                     },
                 }
                 # Special cases for options applied at the facet level (not the terms level).


### PR DESCRIPTION
- added optional connection option - FACET_SIZE
- if FACET_SIZE is not specified, default is 100
- documentation updated

References #928
