### PR TITLE
Add --locale flag to Management commands

### DIFF
--- a/docs/multiple_index.rst
+++ b/docs/multiple_index.rst
@@ -199,3 +199,8 @@ the items to avoid sending the wrong content to the search engine::
 
         def index_queryset(self, using=None):
             return Post.objects.filter(language=using)
+
+Management commands that manipulate data accept a ``--locale`` flag to specify
+locale to activate before indexing. For example::
+
+    ./manage.py rebuild_index --noinput --using=de --locale=de

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import LabelCommand
 from django.db import reset_queries
+from django.utils import translation
 
 from haystack import connections as haystack_connections
 from haystack.query import SearchQuerySet
@@ -140,6 +141,9 @@ class Command(LabelCommand):
             default=0, type='int',
             help='Allows for the use multiple workers to parallelize indexing. Requires multiprocessing.'
         ),
+        make_option('--locale', '-l', default=None, dest='locale',
+            help='Activates given locale before indexing  (e.g. pt_BR).'),
+
     )
     option_list = LabelCommand.option_list + base_options
 
@@ -150,6 +154,10 @@ class Command(LabelCommand):
         self.end_date = None
         self.remove = options.get('remove', False)
         self.workers = int(options.get('workers', 0))
+        self.locale = options.get('locale')
+
+        if self.locale:
+            translation.activate(self.locale)
 
         self.backends = options.get('using')
         if not self.backends:
@@ -192,6 +200,8 @@ class Command(LabelCommand):
                     # No models, no problem.
                     pass
 
+        if self.locale:
+            translation.deactivate()
         return super(Command, self).handle(*items, **options)
 
     def is_app_or_model(self, label):


### PR DESCRIPTION
Management commands that manipulate data accept a `--locale` flag
to specify locale to activate before indexing.

References #745
