### PR TITLE
Added setting for controlling number of solr spellcheck suggestions returned

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -184,6 +184,20 @@ No default is provided. Haystack automatically falls back to the default
 implementation.
 
 
+``HAYSTACK_SPELLING_SUGGESTIONS_COUNT``
+====================================
+
+**Optional**
+
+This setting controls the number of spelling suggestions that are returned.
+
+An example::
+
+    HAYSTACK_SPELLING_SUGGESTIONS_COUNT = 8
+
+Defaults to ``1``.
+
+
 ``HAYSTACK_ITERATOR_LOAD_PER_QUERY``
 ====================================
 

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -178,7 +178,7 @@ class SolrSearchBackend(BaseSearchBackend):
         if self.include_spelling is True:
             kwargs['spellcheck'] = 'true'
             kwargs['spellcheck.collate'] = 'true'
-            kwargs['spellcheck.count'] = 1
+            kwargs['spellcheck.count'] = getattr(settings, 'HAYSTACK_SPELLING_SUGGESTIONS_COUNT', 1)
 
             if spelling_query:
                 kwargs['spellcheck.q'] = spelling_query


### PR DESCRIPTION
Used only with SOLR backend. It was hardcoded to 1 so far.
