### PR TITLE
Whoosh: reset AsyncWriter during update() exception handling (closes #952)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,3 +89,5 @@ Thanks to
     * Szymon Teżewski (jasisz) for an update to the bounding-box calculation for spatial queries
     * Chris Wilson (qris) and Orlando Fiol (overflow) for an update allowing the use of multiple order_by()
       fields with Whoosh as long as they share a consistent sort direction
+    * J Leadbetter (kamni) for a fix to the Whoosh backend to allow updates to continue when there is an
+      error with a single object

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -202,6 +202,10 @@ class WhooshSearchBackend(BaseSearchBackend):
                         "object": get_identifier(obj)
                     }
                 })
+                
+                # reset the writer so there is no 'start_doc' error from the
+                # previous failed update attempt
+                writer = AsyncWriter(self.index)
 
         if len(iterable) > 0:
             # For now, commit no matter what, as we run into locking issues otherwise.


### PR DESCRIPTION
Does not include tests because the error is already trapped by logging (please see the ticket for more details). The fix is to make sure that the actual error is logged, and not a later error created by django-haystack.
