### PR TITLE
HAYSTACK_ROUTERS don't work with SQS, at all, even with this fix

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -36,7 +36,7 @@ class SearchQuerySet(object):
         self.log = logging.getLogger('haystack')
 
     def _determine_backend(self):
-        from haystack import connections
+        from haystack import connections, connection_router
         # A backend has been manually selected. Use it instead.
         if self._using is not None:
             self.query = connections[self._using].get_query()


### PR DESCRIPTION
connection_router has to be re-imported, otherwise it is still the default old value. But the whole routing mechanism still does not work, at all. Simple example SearchQuerySet().models(SomePreferablyIndexedModelClass) never reaches line 49: hints['models'] = self.query.models. It is sad to see, that setting HAYSTACK_ROUTERS has no test code. Ad hoc, I have no idea, what connection should be used for SearchQuerySet(using="some_search_backend_alias").models(SomePreferablyIndexedModelClass)... some_search_backend_alias or the one proposed by the router that caught SomePreferablyIndexedModelClass?
