### PR TITLE
Fix handling of slices in RelatedSearchQuerySet.

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -159,36 +159,6 @@ class SearchQuerySet(object):
             if not self._fill_cache(current_position, current_position + ITERATOR_LOAD_PER_QUERY):
                 raise StopIteration
 
-    def _fill_cache(self, start, end, **kwargs):
-        # Tell the query where to start from and how many we'd like.
-        self.query._reset()
-        self.query.set_limits(start, end)
-        results = self.query.get_results(**kwargs)
-
-        if results == None or len(results) == 0:
-            return False
-
-        # Setup the full cache now that we know how many results there are.
-        # We need the ``None``s as placeholders to know what parts of the
-        # cache we have/haven't filled.
-        # Using ``None`` like this takes up very little memory. In testing,
-        # an array of 100,000 ``None``s consumed less than .5 Mb, which ought
-        # to be an acceptable loss for consistent and more efficient caching.
-        if len(self._result_cache) == 0:
-            self._result_cache = [None for i in range(self.query.get_count())]
-
-        if start is None:
-            start = 0
-
-        if end is None:
-            end = self.query.get_count()
-
-        to_cache = self.post_process_results(results)
-
-        # Assign by slice.
-        self._result_cache[start:start + len(to_cache)] = to_cache
-        return True
-
     def post_process_results(self, results):
         to_cache = []
 
@@ -235,6 +205,110 @@ class SearchQuerySet(object):
             to_cache.append(result)
 
         return to_cache
+
+    def _load_model_objects(self, model, pks):
+        try:
+            ui = connections[self.query._using].get_unified_index()
+            index = ui.get_index(model)
+            objects = index.read_queryset()
+            return objects.in_bulk(pks)
+        except NotHandled:
+            self.log.warning("Model '%s.%s' not handled by the routers." % (self.app_label, self.model_name))
+            # Revert to old behaviour
+            return model._default_manager.in_bulk(pks)
+
+    def _fill_cache(self, start, end, **kwargs):
+        # Tell the query where to start from and how many we'd like.
+        self.query._reset()
+        self.query.set_limits(start, end)
+        results = self.query.get_results(**kwargs)
+
+        if start is None:
+            start = 0
+
+        if results == None or len(results) == 0:
+            # trim missing stuff from the result cache
+            self._result_cache = self._result_cache[:start]
+            return False
+
+        # Setup the full cache now that we know how many results there are.
+        # We need the ``None``s as placeholders to know what parts of the
+        # cache we have/haven't filled.
+        # Using ``None`` like this takes up very little memory. In testing,
+        # an array of 100,000 ``None``s consumed less than .5 Mb, which ought
+        # to be an acceptable loss for consistent and more efficient caching.
+        if len(self._result_cache) == 0:
+            self._result_cache = [None for i in xrange(self.query.get_count())]
+
+        fill_start, fill_end = start, end
+        if fill_end is None:
+            fill_end = self.query.get_count()
+        cache_start = fill_start
+
+        stop = False
+        while not stop:
+
+            # Check if we wish to load all objects.
+            if self._load_all:
+                original_results = []
+                models_pks = {}
+                loaded_objects = {}
+
+                # Remember the search position for each result so we don't have to resort later.
+                for result in results:
+                    original_results.append(result)
+                    models_pks.setdefault(result.model, []).append(result.pk)
+
+                # Load the objects for each model in turn.
+                for model in models_pks:
+                    loaded_objects[model] = self._load_model_objects(model, models_pks[model])
+
+            to_cache = []
+
+            for result in results:
+                if self._load_all:
+                    # We have to deal with integer keys being cast from strings
+                    model_objects = loaded_objects.get(result.model, {})
+                    if not result.pk in model_objects:
+                        try:
+                            result.pk = int(result.pk)
+                        except ValueError:
+                            pass
+                    try:
+                        result._object = model_objects[result.pk]
+                    except KeyError:
+                        # The object was either deleted since we indexed or should
+                        # be ignored; fail silently.
+                        self._ignored_result_count += 1
+
+                        # avoid an unfilled None at the end of the result cache
+                        self._result_cache.pop()
+                        continue
+
+                to_cache.append(result)
+
+            # Assign by slice.
+            self._result_cache[cache_start:cache_start + len(to_cache)] = to_cache
+
+            if None in self._result_cache[start:end]:
+                fill_start = fill_end
+                fill_end += ITERATOR_LOAD_PER_QUERY
+                cache_start += len(to_cache)
+
+                # Tell the query where to start from and how many we'd like.
+                self.query._reset()
+                self.query.set_limits(fill_start, fill_end)
+                results = self.query.get_results()
+
+                if results == None or len(results) == 0:
+                    # trim missing stuff from the result cache
+                    self._result_cache = self._result_cache[:cache_start]
+                    break
+
+            else:
+                break
+
+        return True
 
     def __getitem__(self, k):
         """
@@ -669,149 +743,27 @@ class ValuesSearchQuerySet(ValuesListSearchQuerySet):
 class RelatedSearchQuerySet(SearchQuerySet):
     """
     A variant of the SearchQuerySet that can handle `load_all_queryset`s.
-
-    This is predominantly different in the `_fill_cache` method, as it is
-    far less efficient but needs to fill the cache before it to maintain
-    consistency.
     """
     _load_all_querysets = {}
     _result_cache = []
 
-    def _cache_is_full(self):
-        return len(self._result_cache) >= len(self)
-
-    def _manual_iter(self):
-        # If we're here, our cache isn't fully populated.
-        # For efficiency, fill the cache as we go if we run out of results.
-        # Also, this can't be part of the __iter__ method due to Python's rules
-        # about generator functions.
-        current_position = 0
-        current_cache_max = 0
-
-        while True:
-            current_cache_max = len(self._result_cache)
-
-            while current_position < current_cache_max:
-                yield self._result_cache[current_position]
-                current_position += 1
-
-            if self._cache_is_full():
-                raise StopIteration
-
-            # We've run out of results and haven't hit our limit.
-            # Fill more of the cache.
-            start = current_position + self._ignored_result_count
-
-            if not self._fill_cache(start, start + ITERATOR_LOAD_PER_QUERY):
-                raise StopIteration
-
-    def _fill_cache(self, start, end):
-        # Tell the query where to start from and how many we'd like.
-        self.query._reset()
-        self.query.set_limits(start, end)
-        results = self.query.get_results()
-
-        if len(results) == 0:
-            return False
-
-        if start is None:
-            start = 0
-
-        if end is None:
-            end = self.query.get_count()
-
-        # Check if we wish to load all objects.
-        if self._load_all:
-            original_results = []
-            models_pks = {}
-            loaded_objects = {}
-
-            # Remember the search position for each result so we don't have to resort later.
-            for result in results:
-                original_results.append(result)
-                models_pks.setdefault(result.model, []).append(result.pk)
-
-            # Load the objects for each model in turn.
-            for model in models_pks:
-                if model in self._load_all_querysets:
-                    # Use the overriding queryset.
-                    loaded_objects[model] = self._load_all_querysets[model].in_bulk(models_pks[model])
-                else:
-                    # Check the SearchIndex for the model for an override.
-                    try:
-                        index = connections[self.query._using].get_unified_index().get_index(model)
-                        qs = index.load_all_queryset()
-                        loaded_objects[model] = qs.in_bulk(models_pks[model])
-                    except NotHandled:
-                        # The model returned doesn't seem to be handled by the
-                        # routers. We should silently fail and populate
-                        # nothing for those objects.
-                        loaded_objects[model] = []
-
-        if len(results) + len(self._result_cache) < len(self) and len(results) < ITERATOR_LOAD_PER_QUERY:
-            self._ignored_result_count += ITERATOR_LOAD_PER_QUERY - len(results)
-
-        for result in results:
-            if self._load_all:
-                # We have to deal with integer keys being cast from strings; if this
-                # fails we've got a character pk.
-                try:
-                    result.pk = int(result.pk)
-                except ValueError:
-                    pass
-                try:
-                    result._object = loaded_objects[result.model][result.pk]
-                except (KeyError, IndexError):
-                    # The object was either deleted since we indexed or should
-                    # be ignored; fail silently.
-                    self._ignored_result_count += 1
-                    continue
-
-            self._result_cache.append(result)
-
-        return True
-
-    def __getitem__(self, k):
-        """
-        Retrieves an item or slice from the set of results.
-        """
-        if not isinstance(k, (slice, six.integer_types)):
-            raise TypeError
-        assert ((not isinstance(k, slice) and (k >= 0))
-                or (isinstance(k, slice) and (k.start is None or k.start >= 0)
-                    and (k.stop is None or k.stop >= 0))), \
-                "Negative indexing is not supported."
-
-        # Remember if it's a slice or not. We're going to treat everything as
-        # a slice to simply the logic and will `.pop()` at the end as needed.
-        if isinstance(k, slice):
-            is_slice = True
-            start = k.start
-
-            if k.stop is not None:
-                bound = int(k.stop)
-            else:
-                bound = None
+    def _load_model_objects(self, model, pks):
+        if model in self._load_all_querysets:
+            # Use the overriding queryset.
+            return self._load_all_querysets[model].in_bulk(pks)
         else:
-            is_slice = False
-            start = k
-            bound = k + 1
+            # Check the SearchIndex for the model for an override.
 
-        # We need check to see if we need to populate more of the cache.
-        if len(self._result_cache) <= 0 or not self._cache_is_full():
             try:
-                while len(self._result_cache) < bound and not self._cache_is_full():
-                    current_max = len(self._result_cache) + self._ignored_result_count
-                    self._fill_cache(current_max, current_max + ITERATOR_LOAD_PER_QUERY)
-            except StopIteration:
-                # There's nothing left, even though the bound is higher.
-                pass
-
-        # Cache should be full enough for our needs.
-        if is_slice:
-            return self._result_cache[start:bound]
-        else:
-            return self._result_cache[start]
+                ui = connections[self.query._using].get_unified_index()
+                index = ui.get_index(model)
+                qs = index.load_all_queryset()
+                return qs.in_bulk(pks)
+            except NotHandled:
+                # The model returned doesn't seem to be handled by the
+                # routers. We should silently fail and populate
+                # nothing for those objects.
+                return {}
 
     def load_all_queryset(self, model, queryset):
         """
@@ -826,11 +778,6 @@ class RelatedSearchQuerySet(SearchQuerySet):
         return clone
 
     def _clone(self, klass=None):
-        if klass is None:
-            klass = self.__class__
-
-        query = self.query._clone()
-        clone = klass(query=query)
-        clone._load_all = self._load_all
+        clone = super(RelatedSearchQuerySet, self)._clone(klass=klass)
         clone._load_all_querysets = self._load_all_querysets
         return clone


### PR DESCRIPTION
We found whenever you do ?page=100 with RelatedSearchQuerySet, it will load all the results from all 100 pages in multiple solr queries (the exact number of solr queries is dependent on settings.HAYSTACK_ITERATOR_LOAD_PER_QUERY)

Needless to say that's not desired. This fixes the issues, and along the way gets rid of a heap of code duplicated from SearchQuerySet.
