### PR TITLE
Added support for random ordering with elasticsearch backend.

### DIFF
--- a/docs/backend_support.rst
+++ b/docs/backend_support.rst
@@ -50,6 +50,7 @@ Elasticsearch
 * Stored (non-indexed) fields
 * Highlighting
 * Spatial search
+* Random ordering with seed support
 * Requires: elasticsearch-py 0.4.3+ & Elasticsearch 0.17.7+
 
 Whoosh

--- a/docs/searchqueryset_api.rst
+++ b/docs/searchqueryset_api.rst
@@ -212,6 +212,13 @@ string with a ``-``::
 
     SearchQuerySet().filter(content='foo').order_by('-pub_date')
 
+Random ordering is achieved by passing a '?' argument to order_by. Optionally,
+an integer can be appended to the '?' to be used as the seed for the random
+number generator. (ElasticSearch backend only.)
+
+    SearchQuerySet().filter(content='foo').order_by('?')
+    SearchQuerySet().filter(content='foo').order_by('?123456789')
+
 .. note::
 
     In general, ordering is locale-specific. Haystack makes no effort to try to


### PR DESCRIPTION
order_by('?') will randomize the order when using elasticsearch. order_by('?#'), replacing # with an integer, will send a seed to elasticsearch to be used for random number generation.
