### PR TITLE
On update, check if object is include in index_queryset

### DIFF
--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -198,7 +198,12 @@ class SearchIndex(threading.local):
         """
         # Check to make sure we want to index this first.
         if self.should_update(instance, **kwargs):
-            self.backend.update(self, [instance])
+            # also check if this should be removed
+            qs = self.index_queryset()
+            if qs.filter(pk=instance.pk).count() > 0:
+                self.backend.update(self, [instance])
+            else:
+                self.backend.remove(instance)
 
     def remove_object(self, instance, **kwargs):
         """


### PR DESCRIPTION
and if not, then remove it.

This is useful when we are excluding some items, eg unpublished items.

This is the haystack 1.2.X version of #936.  Even if 1.2.X is no longer maintained, it means other people can find it if they need it.
