### PR TITLE
Fix failure to filter by boolean field for Elasticsearch

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -752,6 +752,8 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             if isinstance(value, six.string_types):
                 # It's not an ``InputType``. Assume ``Clean``.
                 value = Clean(value)
+            elif isinstance(value, bool):
+                value = PythonData('true' if value else 'false')
             else:
                 value = PythonData(value)
 


### PR DESCRIPTION
For Elasticsearch, I failed to filter by boolean field,
because boolean value expression for Elasticsearch is not 'True' but 'true'.
