### PR TITLE
Fix for deprecate `Options.module_name` in favor of `model_name`

### DIFF
--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -121,7 +121,7 @@ class SearchModelAdmin(ModelAdmin):
             'All %(total_count)s selected', changelist.result_count)
 
         context = {
-            'module_name': force_text(self.model._meta.verbose_name_plural),
+            'model_name': force_text(self.model._meta.verbose_name_plural),
             'selection_note': selection_note % {'count': len(changelist.result_list)},
             'selection_note_all': selection_note_all % {'total_count': changelist.result_count},
             'title': changelist.title,

--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -192,7 +192,7 @@ class BaseSearchBackend(object):
         models = []
 
         for model in connections[self.connection_alias].get_unified_index().get_indexed_models():
-            models.append(u"%s.%s" % (model._meta.app_label, model._meta.module_name))
+            models.append(u"%s.%s" % (model._meta.app_label, model._meta.model_name))
 
         return models
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -222,7 +222,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 models_to_delete = []
 
                 for model in models:
-                    models_to_delete.append("%s:%s.%s" % (DJANGO_CT, model._meta.app_label, model._meta.module_name))
+                    models_to_delete.append("%s:%s.%s" % (DJANGO_CT, model._meta.app_label, model._meta.model_name))
 
                 # Delete by query in Elasticsearch asssumes you're dealing with
                 # a ``query`` root object. :/
@@ -389,7 +389,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             limit_to_registered_models = getattr(settings, 'HAYSTACK_LIMIT_TO_REGISTERED_MODELS', True)
 
         if models and len(models):
-            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.module_name) for model in models])
+            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.model_name) for model in models])
         elif limit_to_registered_models:
             # Using narrow queries, limit the results to only models handled
             # with the current routers.

--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -79,7 +79,7 @@ class SimpleSearchBackend(BaseSearchBackend):
 
                 for match in qs:
                     match.__dict__.pop('score', None)
-                    result = result_class(match._meta.app_label, match._meta.module_name, match.pk, 0, **match.__dict__)
+                    result = result_class(match._meta.app_label, match._meta.model_name, match.pk, 0, **match.__dict__)
                     # For efficiency.
                     result._model = match.__class__
                     result._object = match

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -96,7 +96,7 @@ class SolrSearchBackend(BaseSearchBackend):
                 models_to_delete = []
 
                 for model in models:
-                    models_to_delete.append("%s:%s.%s" % (DJANGO_CT, model._meta.app_label, model._meta.module_name))
+                    models_to_delete.append("%s:%s.%s" % (DJANGO_CT, model._meta.app_label, model._meta.model_name))
 
                 self.conn.delete(q=" OR ".join(models_to_delete), commit=commit)
 
@@ -215,7 +215,7 @@ class SolrSearchBackend(BaseSearchBackend):
             limit_to_registered_models = getattr(settings, 'HAYSTACK_LIMIT_TO_REGISTERED_MODELS', True)
 
         if models and len(models):
-            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.module_name) for model in models])
+            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.model_name) for model in models])
         elif limit_to_registered_models:
             # Using narrow queries, limit the results to only models handled
             # with the current routers.
@@ -297,7 +297,7 @@ class SolrSearchBackend(BaseSearchBackend):
             limit_to_registered_models = getattr(settings, 'HAYSTACK_LIMIT_TO_REGISTERED_MODELS', True)
 
         if models and len(models):
-            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.module_name) for model in models])
+            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.model_name) for model in models])
         elif limit_to_registered_models:
             # Using narrow queries, limit the results to only models handled
             # with the current routers.

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -235,7 +235,7 @@ class WhooshSearchBackend(BaseSearchBackend):
                 models_to_delete = []
 
                 for model in models:
-                    models_to_delete.append(u"%s:%s.%s" % (DJANGO_CT, model._meta.app_label, model._meta.module_name))
+                    models_to_delete.append(u"%s:%s.%s" % (DJANGO_CT, model._meta.app_label, model._meta.model_name))
 
                 self.index.delete_by_query(q=self.parser.parse(u" OR ".join(models_to_delete)))
         except Exception as e:
@@ -359,7 +359,7 @@ class WhooshSearchBackend(BaseSearchBackend):
             limit_to_registered_models = getattr(settings, 'HAYSTACK_LIMIT_TO_REGISTERED_MODELS', True)
 
         if models and len(models):
-            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.module_name) for model in models])
+            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.model_name) for model in models])
         elif limit_to_registered_models:
             # Using narrow queries, limit the results to only models handled
             # with the current routers.
@@ -485,7 +485,7 @@ class WhooshSearchBackend(BaseSearchBackend):
             limit_to_registered_models = getattr(settings, 'HAYSTACK_LIMIT_TO_REGISTERED_MODELS', True)
 
         if models and len(models):
-            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.module_name) for model in models])
+            model_choices = sorted(['%s.%s' % (model._meta.app_label, model._meta.model_name) for model in models])
         elif limit_to_registered_models:
             # Using narrow queries, limit the results to only models handled
             # with the current routers.

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -126,7 +126,7 @@ class SearchField(object):
             if not isinstance(template_names, (list, tuple)):
                 template_names = [template_names]
         else:
-            template_names = ['search/indexes/%s/%s_%s.txt' % (obj._meta.app_label, obj._meta.module_name, self.instance_name)]
+            template_names = ['search/indexes/%s/%s_%s.txt' % (obj._meta.app_label, obj._meta.model_name, self.instance_name)]
 
         t = loader.select_template(template_names)
         return t.render(Context({'object': obj}))

--- a/haystack/forms.py
+++ b/haystack/forms.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 def model_choices(using=DEFAULT_ALIAS):
-    choices = [("%s.%s" % (m._meta.app_label, m._meta.module_name), capfirst(smart_text(m._meta.verbose_name_plural))) for m in connections[using].get_unified_index().get_indexed_models()]
+    choices = [("%s.%s" % (m._meta.app_label, m._meta.model_name), capfirst(smart_text(m._meta.verbose_name_plural))) for m in connections[using].get_unified_index().get_indexed_models()]
     return sorted(choices, key=lambda x: x[1])
 
 

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -185,7 +185,7 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
         """
         self.prepared_data = {
             ID: get_identifier(obj),
-            DJANGO_CT: "%s.%s" % (obj._meta.app_label, obj._meta.module_name),
+            DJANGO_CT: "%s.%s" % (obj._meta.app_label, obj._meta.model_name),
             DJANGO_ID: force_text(obj.pk),
         }
 

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -30,7 +30,7 @@ def default_get_identifier(obj_or_string):
 
     return u"%s.%s.%s" % (
         obj_or_string._meta.app_label,
-        obj_or_string._meta.module_name,
+        obj_or_string._meta.model_name,
         obj_or_string._get_pk_val()
     )
 
@@ -68,7 +68,7 @@ get_identifier = _lookup_identifier_method()
 
 
 def get_model_ct(model):
-    return "%s.%s" % (model._meta.app_label, model._meta.module_name)
+    return "%s.%s" % (model._meta.app_label, model._meta.model_name)
 
 
 def get_facet_field_name(fieldname):


### PR DESCRIPTION
On Django 1.7, `Options.module_name` was deprecated in favor of `model_name`.
This commit corrects files for this versions of Django.
