### PR TITLE
Specify distance units in elasticsearch dwithin queries

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -436,7 +436,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             lng, lat = dwithin['point'].get_coords()
             dwithin_filter = {
                 "geo_distance": {
-                    "distance": dwithin['distance'].km,
+                    "distance": "%fkm" % dwithin['distance'].km,
                     dwithin['field']: {
                         "lat": lat,
                         "lon": lng


### PR DESCRIPTION
ElasticSearch uses meters as the default unit if not specified, so the current use of Kilometers for `dwithin` queries means that incorrect results are given.
