### PR TITLE
'__len__' may never return a value < 0.

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -95,7 +95,7 @@ class SearchQuerySet(object):
                 self._result_count = 0
 
         # This needs to return the actual number of hits, not what's in the cache.
-        return self._result_count - self._ignored_result_count
+        return max([self._result_count - self._ignored_result_count, 0])
 
     def __iter__(self):
         if self._cache_is_full():
@@ -122,7 +122,7 @@ class SearchQuerySet(object):
         if not self.query.has_run():
             return False
 
-        if len(self) <= 0:
+        if len(self) == 0:
             return True
 
         try:


### PR DESCRIPTION
There have been a few issues (#445, #704) and a referenced commit cd06d3be concerning the use of `__len__` in the `haystack.query` module.

In particular, the line:

`if len(self) <= 0`

will always raise a ValueError when `(self._result_count - self._ignored_result_count) < 0`. Although it appears that the referenced commit attempts to treat symptoms of this state, it seems that it is still quite possible that the implementation of `SearchQuerySet.__len__` will produce a negative value.

The attached pull request resolves this issue by ensuring that this method always returns a nonnegative integer.

Alternatively, the calling convention could be altered to avoid being beholden to the semantics bound to the `__len__` builtin:

`if self.__len__() <= 0`

Without more thoroughly reviewing the code paths, I'm unsure which method is a more practical resolution.
