### PR TITLE
Use the `RequestsHttpConnection` connection class to support http auth

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -97,7 +97,10 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         if not 'INDEX_NAME' in connection_options:
             raise ImproperlyConfigured("You must specify a 'INDEX_NAME' in your settings for connection '%s'." % connection_alias)
 
-        self.conn = elasticsearch.Elasticsearch(connection_options['URL'], timeout=self.timeout, **connection_options.get('KWARGS', {}))
+        self.conn = elasticsearch.Elasticsearch(connection_options['URL'],
+                                                connection_class=elasticsearch.RequestsHttpConnection,
+                                                timeout=self.timeout,
+                                                **connection_options.get('KWARGS', {}))
         self.index_name = connection_options['INDEX_NAME']
         self.log = logging.getLogger('haystack')
         self.setup_complete = False


### PR DESCRIPTION
Support url that contains the http auth credentials like `<user>:<password>@<hostname>:<port>`.

Cheers
