### PR TITLE
I don't remember doing this.

### DIFF
--- a/haystack/management/commands/haystack_info.py
+++ b/haystack/management/commands/haystack_info.py
@@ -16,4 +16,4 @@ class Command(NoArgsCommand):
         print("Number of handled %s index(es)." % index_count)
 
         for index in indexed:
-            print("  - Model: %s by Index: %s" % (index.__name__, unified_index.indexes[index]))
+            print("  - Model: %s by Index: %s" % (index.__name__, unified_index.get_indexes()[index]))


### PR DESCRIPTION
I think back when I started to kick the tires on Haystack2 I ran into this and made this commit, but never followed through with a PR. Unfortunately I can't remember if that's because there's a problem with the fix, or what. Need to take a closer look before submitting a PR back to the main project.

"Added an accessor for the indexes property because without it external callers would find an empty dict if they happened to call before something like get_indexed_models() had been called."
