### PR TITLE
Analyzer function can be choosen for Whoosh backend

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -83,6 +83,8 @@ Additionally, each backend may have additional options it requires:
 * Whoosh
 
   * ``PATH`` - The filesystem path to where the index data is located.
+  * ``ANALYZER`` - The analyzer function which returns tokens for a unicode
+    string. Default is ``whoosh.analysis.StemmingAnalyzer``.
 
 * Xapian
 


### PR DESCRIPTION
Haystack + Whoosh are not usable for inflectional languages. Standard StemmingAnalyzer is not enough but Whoosh allows to replace the analyzer very easly.

Unfortunately, Haystack hardcodes StemmingAnalyzer as an only analyzer. This patch allows to use own analyzer function.
