### PR TITLE
Link to 'signal processors'

### DIFF
--- a/docs/searchindex_api.rst
+++ b/docs/searchindex_api.rst
@@ -174,6 +174,8 @@ A third option is to develop a custom ``QueuedSignalProcessor`` that, much like
 updates/deletes. Then writing a management command to consume these messages
 in batches, yielding a nice compromise between the previous two options.
 
+For more information see :doc:`signal processors`.
+
 .. note::
 
     Haystack doesn't ship with a ``QueuedSignalProcessor`` largely because there is


### PR DESCRIPTION
Documentation would be much easier to use if it contained links to follow for more detail on mentioned features/classes.
