### PR TITLE
Appeal for doc change and help in one!

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -222,7 +222,9 @@ define the fields you want to store data with and define a ``get_model`` method.
 We'll create the following ``NoteIndex`` to correspond to our ``Note``
 model. This code generally goes in a ``search_indexes.py`` file within the app
 it applies to, though that is not required. This allows
-Haystack to automatically pick it up. The ``NoteIndex`` should look like::
+Haystack to automatically pick it up. [Please insert link to documentation about 
+how to make Haystack discover the SearchIndex subclass elsewhere]. The 
+``NoteIndex`` should look like::
 
     import datetime
     from haystack import indexes


### PR DESCRIPTION
This is obviously not a sensible documentation change. It is actually a plea for help and for a corresponding documentation improvement, rolled into one!

I have failed to figure out how to make Haystack discover my SearchIndex subclass in a location other than the search_indexes.py in an app. There must be a way, but I can't figure it out. Please can you give hints in the documentation? 
