### PR TITLE
Django 1.8 compatibility

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -126,7 +126,12 @@ class SearchField(object):
             if not isinstance(template_names, (list, tuple)):
                 template_names = [template_names]
         else:
-            template_names = ['search/indexes/%s/%s_%s.txt' % (obj._meta.app_label, obj._meta.module_name, self.instance_name)]
+            try:
+                model_name = obj._meta.model_name
+            except AttributeError:
+                # Django < 1.6
+                model_name = obj._meta.module_name
+            template_names = ['search/indexes/%s/%s_%s.txt' % (obj._meta.app_label, model_name, self.instance_name)]
 
         t = loader.select_template(template_names)
         return t.render(Context({'object': obj}))

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -183,9 +183,15 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
         """
         Fetches and adds/alters data before indexing.
         """
+        try:
+            model_name = obj._meta.model_name
+        except AttributeError:
+            # Django < 1.6
+            model_name = obj._meta.module_name
+
         self.prepared_data = {
             ID: get_identifier(obj),
-            DJANGO_CT: "%s.%s" % (obj._meta.app_label, obj._meta.module_name),
+            DJANGO_CT: "%s.%s" % (obj._meta.app_label, model_name),
             DJANGO_ID: force_text(obj.pk),
         }
 

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -28,9 +28,15 @@ def default_get_identifier(obj_or_string):
 
         return obj_or_string
 
+    try:
+        model_name = obj_or_string._meta.model_name
+    except AttributeError:
+        # Django < 1.6
+        model_name = obj_or_string._meta.module_name
+
     return u"%s.%s.%s" % (
         obj_or_string._meta.app_label,
-        obj_or_string._meta.module_name,
+        model_name,
         obj_or_string._get_pk_val()
     )
 


### PR DESCRIPTION
`Options.module_name` has been deprecated in Django 1.7
See: https://code.djangoproject.com/ticket/19689
