### PR TITLE
Correct regex for DateField

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -11,7 +11,7 @@ class NOT_PROVIDED:
 
 
 DATETIME_REGEX = re.compile('^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})(T|\s+)(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2}).*?$')
-DATE_REGEX = re.compile('^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})')
+DATE_REGEX = re.compile('^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2}).*?$')
 
 
 # All the SearchFields variants.


### PR DESCRIPTION
`DateField` was using `DATETIME_REGEX` to make the match. Because of that, date values were raising `SearchFieldError` for values, like u'1987-05-22'.

I created `DATE_REGEX` to make the match for `DateField` at #L306
