### PR TITLE
fixes #1074

### DIFF
--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -158,7 +158,10 @@ class UnifiedIndex(object):
         indexes = []
 
         for app in settings.INSTALLED_APPS:
-            mod = importlib.import_module(app)
+            try:
+                mod = importlib.import_module(app)
+            except ImportError:
+                continue  # simply ignore, when assumption that each INSTALLED_APP is module is faulty
 
             try:
                 search_index_module = importlib.import_module("%s.search_indexes" % app)


### PR DESCRIPTION
Fixes issue #1074 - tolerates INSTALLED_APPS entries that aren't importable by catching ImportError and skipping. 

(Django-debug-toolbar, in its recommended 'quick setup' for Django >=1.7 http://django-debug-toolbar.readthedocs.org/en/1.2/installation.html#quick-setup, is not a module like Haystack expects.)
