### PR TITLE
Add array as a field type mapping

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -719,6 +719,8 @@ FIELD_MAPPINGS = {
     'float':      {'type': 'float'},
     'long':       {'type': 'long'},
     'integer':    {'type': 'long'},
+
+    'array':    {'type': 'array'},
 }
 
 


### PR DESCRIPTION
I've added the array type as a acceptable mapping type. Should we add the other types elasticsearch allows for?
