### PR TITLE
Remove space when joining solr sort values (solr_backend.py)

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -645,7 +645,7 @@ class SolrSearchQuery(BaseSearchQuery):
                 else:
                     order_by_list.append('%s asc' % order_by)
 
-            search_kwargs['sort_by'] = ", ".join(order_by_list)
+            search_kwargs['sort_by'] = ",".join(order_by_list)
 
         if self.date_facets:
             search_kwargs['date_facets'] = self.date_facets


### PR DESCRIPTION
Erroneously adds + after comma for multiple values in pysolr when urlencoding, See sort at https://wiki.apache.org/solr/CommonQueryParameters for reference.
