### PR TITLE
ElasticSearch geo-filters with explicit units.

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -442,7 +442,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             lng, lat = dwithin['point'].get_coords()
             dwithin_filter = {
                 "geo_distance": {
-                    "distance": dwithin['distance'].km,
+                    "distance": "{0:f}km".format(dwithin['distance'].km),
                     dwithin['field']: {
                         "lat": lat,
                         "lon": lng


### PR DESCRIPTION
Fix an issue where distance filtering (using `dwithin`) passed an
ambiguous argument, leading to incorrect distance filtering.

The ElasticSearch backend passed an unlabeled float that was known to
represent the given distance in kilometers. However, ElasticSearch
server's default unit for distance filtering is the meter. Thus, in
deployments with no change to the default unit, these query values were
interpreted as meter values.

An example of this bad behavior is that when a user filtered for items
within 1 kilometer of a query point, she would actually get only items
within 1 meter of the query point.
