### PR TITLE
Fix boolean values for Elasticsearch

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -664,6 +664,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         elif isinstance(value, six.binary_type):
             # TODO: Be stricter.
             return six.text_type(value, errors='replace')
+        elif isinstance(value, bool):
+            return str(value).lower()
         elif isinstance(value, set):
             return list(value)
         return value

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -766,7 +766,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
         prepared_value = value.prepare(self)
 
         if not isinstance(prepared_value, (set, list, tuple)):
-            # Then convert whatever we get back to what pysolr wants if needed.
+            # Then convert whatever we get back to what Elasticsearch wants if needed.
             prepared_value = self.backend._from_python(prepared_value)
 
         # 'content' is a special reserved word, much like 'pk' in

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -1150,6 +1150,16 @@ class LiveElasticsearchRoundTripTestCase(TestCase):
         connections['elasticsearch']._index = self.old_ui
         super(LiveElasticsearchRoundTripTestCase, self).tearDown()
 
+    def test_boolean_is_converted_correctly(self):
+        """Ensure Python boolean values are correctly converted to ES string values."""
+        results = self.sqs.filter(is_active=True)
+        self.assertEqual(sqs.query.build_query(), u'is_active:(true)')
+
+    def test_string_booleans_still_work(self):
+        """Make sure the old way of converting to string first still works."""
+        results = self.sqs.filter(is_active='true')
+        self.assertEqual(sqs.query.build_query(), u'is_active:(true)')
+
     def test_round_trip(self):
         results = self.sqs.filter(id='core.mockmodel.1')
 

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -1150,16 +1150,6 @@ class LiveElasticsearchRoundTripTestCase(TestCase):
         connections['elasticsearch']._index = self.old_ui
         super(LiveElasticsearchRoundTripTestCase, self).tearDown()
 
-    def test_boolean_is_converted_correctly(self):
-        """Ensure Python boolean values are correctly converted to ES string values."""
-        check = self.sqs.filter(is_active=True)
-        self.assertEqual(check.query.build_query(), u'is_active:(true)')
-
-    def test_string_booleans_still_work(self):
-        """Make sure the old way of converting to string first still works."""
-        check = self.sqs.filter(is_active='true')
-        self.assertEqual(check.query.build_query(), u'is_active:(true)')
-
     def test_round_trip(self):
         results = self.sqs.filter(id='core.mockmodel.1')
 

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -1152,13 +1152,13 @@ class LiveElasticsearchRoundTripTestCase(TestCase):
 
     def test_boolean_is_converted_correctly(self):
         """Ensure Python boolean values are correctly converted to ES string values."""
-        results = self.sqs.filter(is_active=True)
-        self.assertEqual(sqs.query.build_query(), u'is_active:(true)')
+        check = self.sqs.filter(is_active=True)
+        self.assertEqual(check.query.build_query(), u'is_active:(true)')
 
     def test_string_booleans_still_work(self):
         """Make sure the old way of converting to string first still works."""
-        results = self.sqs.filter(is_active='true')
-        self.assertEqual(sqs.query.build_query(), u'is_active:(true)')
+        check = self.sqs.filter(is_active='true')
+        self.assertEqual(check.query.build_query(), u'is_active:(true)')
 
     def test_round_trip(self):
         results = self.sqs.filter(id='core.mockmodel.1')

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -26,7 +26,7 @@ class ElasticsearchSearchQueryTestCase(TestCase):
     def test_string_booleans_still_work(self):
         """Make sure the old way of converting to string first still works."""
         self.sq.add_filter(SQ(content='true'))
-        self.assertEqual(check.query.build_query(), '(true)')
+        self.assertEqual(self.sq.build_query(), '(true)')
 
     def test_regression_slash_search(self):
         self.sq.add_filter(SQ(content='hello/'))

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -21,7 +21,12 @@ class ElasticsearchSearchQueryTestCase(TestCase):
 
     def test_build_query_boolean(self):
         self.sq.add_filter(SQ(content=True))
-        self.assertEqual(self.sq.build_query(), '(True)')
+        self.assertEqual(self.sq.build_query(), '(true)')
+
+    def test_string_booleans_still_work(self):
+        """Make sure the old way of converting to string first still works."""
+        self.sq.add_filter(SQ(content='true'))
+        self.assertEqual(check.query.build_query(), '(true)')
 
     def test_regression_slash_search(self):
         self.sq.add_filter(SQ(content='hello/'))


### PR DESCRIPTION
#### What's this PR do?

It makes `ElasticsearchSearchBackend._from_python()` treat boolean values the same way that `pysolr.Solr._from_python()` does.
#### Where should the reviewer start?

With the changes made to `ElasticsearchSearchBackend._from_python()` and the tests. It should be noted I changed one test in the ES test suite to match the Solr one.
#### How should this be manually tested?
1. Load up a shell with `./manage.py shell`
2. Create an `SearchQuerySet` instance and `filter` it by a `BooleanField` for a given model (e.g. `sqs = SearchQuerySet().models(MyModel).filter(my_boolean_field=False)`).
3. The output of `sqs.query.build_query()` should be `my_boolean_field:(false)` and not `my_boolean_field:(False)`.
#### Any background context you want to provide?

This discrepancy meant you had to effectively convert booleans to a string to use filtering on boolean values in Elasticsearch. I'm not sure if this was a conscious decision or not, but I did find it curious that the Solr backend behaved in opposition to how the ES backend did. I also believe this makes for a more Pythonic interface to instances of `SearchQuerySet` backed by the ES backend. 
#### What are the relevant tickets?

This supersedes #979.
#### What gif best describes this PR or how it makes you feel?

![](http://media.giphy.com/media/dmBOWkIej7RAY/giphy.gif)

p.s. I modeled this PR on [a template we use at work I find useful](http://quickleft.com/blog/pull-request-templates-make-code-review-easier).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/django-haystack/django-haystack/1093)

<!-- Reviewable:end -->
