### PR TITLE
Django master (and 1.8?) drops a number of relied upon methods/functions

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -6,7 +6,11 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models.loading import get_model
+try:
+    from django.db.models.loading import get_model
+except ImportError:  # Django > 1.8
+    from django.apps import apps
+    get_model = apps.get_model
 from django.utils import six
 
 import haystack

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -4,7 +4,11 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models.loading import get_model
+try:
+    from django.db.models.loading import get_model
+except ImportError:  # Django > 1.8
+    from django.apps import apps
+    get_model = apps.get_model
 from django.utils import six
 
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, EmptyResults, log_query

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -7,7 +7,11 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models.loading import get_model
+try:
+    from django.db.models.loading import get_model
+except ImportError:  # Django > 1.8
+    from django.apps import apps
+    get_model = apps.get_model
 from django.utils import six
 from django.utils.datetime_safe import datetime
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query, EmptyResults

--- a/haystack/forms.py
+++ b/haystack/forms.py
@@ -1,7 +1,11 @@
 from __future__ import unicode_literals
 
 from django import forms
-from django.db import models
+try:
+    from django.db.models.loading import get_model
+except ImportError:  # Django > 1.8
+    from django.apps import apps
+    get_model = apps.get_model
 from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 
@@ -105,7 +109,7 @@ class ModelSearchForm(SearchForm):
 
         if self.is_valid():
             for model in self.cleaned_data['models']:
-                search_models.append(models.get_model(*model.split('.')))
+                search_models.append(get_model(*model.split('.')))
 
         return search_models
 

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -2,7 +2,11 @@
 from __future__ import unicode_literals
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import models
+try:
+    from django.db.models.loading import get_model
+except ImportError:  # Django > 1.8
+    from django.apps import apps
+    get_model = apps.get_model
 from django.utils import six
 from django.utils.text import capfirst
 from haystack.exceptions import NotHandled, SpatialError
@@ -96,7 +100,7 @@ class SearchResult(object):
     def _get_model(self):
         if self._model is None:
             try:
-                self._model = models.get_model(self.app_label, self.model_name)
+                self._model = get_model(self.app_label, self.model_name)
             except LookupError:
                 # this changed in change 1.7 to throw an error instead of
                 # returning None when the model isn't found. So catch the

--- a/haystack/templatetags/highlight.py
+++ b/haystack/templatetags/highlight.py
@@ -2,7 +2,10 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django import template
-from django.utils import importlib
+try:
+    from django.utils import importlib
+except ImportError:  # new Django no longer packages an importlib backport
+    import importlib
 from django.utils import six
 
 

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -4,8 +4,14 @@ import inspect
 import warnings
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.datastructures import SortedDict
-from django.utils import importlib
+try:
+    from django.utils.datastructures import SortedDict
+except ImportError:  # Django > 1.8
+    from collections import OrderedDict as SortedDict
+try:
+    from django.utils import importlib
+except ImportError:  # Django > 1.8
+    import importlib
 from django.utils.module_loading import module_has_submodule
 from haystack.constants import Indexable, DEFAULT_ALIAS
 from haystack.exceptions import NotHandled, SearchFieldError

--- a/test_haystack/mocks.py
+++ b/test_haystack/mocks.py
@@ -1,4 +1,8 @@
-from django.db.models.loading import get_model
+try:
+    from django.db.models.loading import get_model
+except ImportError:  # Django > 1.8
+    from django.apps import apps
+    get_model = apps.get_model
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query
 from haystack.models import SearchResult
 from haystack.routers import BaseRouter


### PR DESCRIPTION
Django 1.8 drops `SortedDict` (in favour of `collections.OrderedDict`), `django.utils.importlib` and `django.db.models.loading.get_model`, all of which prevent haystack from loading.

I've not tested any of this, beyond getting `runserver` to complete and the root URLconf to load sucessfully by hitting a URL, because too many other packages I'm using also need fixing :/