### PR TITLE
Fix deprecation warnings in Django 1.6.X

### DIFF
--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -65,7 +65,7 @@ def _lookup_identifier_method():
 get_identifier = _lookup_identifier_method()
 
 
-if django.VERSION >= (1, 7):
+if django.VERSION >= (1, 6):
     def get_model_ct_tuple(model):
         return (model._meta.app_label, model._meta.model_name)
 else:


### PR DESCRIPTION
Options.model_name was introduced in Django 1.6 together with a deprecation warning:
https://github.com/django/django/commit/ec469ade2b04b94bfeb59fb0fc7d9300470be615