### PR TITLE
Fix to remove process in update_index command

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -217,7 +217,7 @@ class Command(LabelCommand):
             qs = index.build_queryset(using=using, start_date=self.start_date,
                                       end_date=self.end_date)
 
-            total = SearchQuerySet(using=backend.connection_alias).models(model).count()
+            total = qs.count()
 
             if self.verbosity >= 1:
                 print(u"Indexing %d %s" % (total, force_text(model._meta.verbose_name_plural)))

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -217,7 +217,7 @@ class Command(LabelCommand):
             qs = index.build_queryset(using=using, start_date=self.start_date,
                                       end_date=self.end_date)
 
-            total = qs.count()
+            total = SearchQuerySet(using=backend.connection_alias).models(model).count()
 
             if self.verbosity >= 1:
                 print(u"Indexing %d %s" % (total, force_text(model._meta.verbose_name_plural)))
@@ -246,10 +246,10 @@ class Command(LabelCommand):
                     # all pks. Rebuild the list with everything.
                     qs = index.index_queryset().values_list('pk', flat=True)
                     pks_seen = set(smart_bytes(pk) for pk in qs)
-
-                    total = len(pks_seen)
                 else:
                     pks_seen = set(smart_bytes(pk) for pk in qs.values_list('pk', flat=True))
+
+                total = SearchQuerySet(using=backend.connection_alias).models(model).count()
 
                 if self.workers > 0:
                     ghetto_queue = []


### PR DESCRIPTION
Currently there is a problem with *total* value in update_index command. This *total* represents the number of elements from database and should represents the number of elements from index. If there is the same number of elements on database and index this is not a problem, but when you execute this command with **--remove** flag those numbers could be different and you could be in three possible cases:
 1. Elems on database > on index engine: new items will be added to the index.
 2. Elems on database = on index engine: index elements will be updated.
 3. Elems on database < on index engine: it's necessary to remove some of them on index engine.

If we are on third case (suppose *n* elements on database and m elements on index engine with n* < *m*) and we iterate until *n*, then some of those elements from index engine will not be checked (*m*-*n* last elements). With this change, all elements will be checked in all three cases.