### PR TITLE
Fix typo in SearchResult documentation

### DIFF
--- a/docs/searchresult_api.rst
+++ b/docs/searchresult_api.rst
@@ -24,7 +24,7 @@ The class exposes the following useful attributes/properties:
 * ``model`` - The model class.
 * ``verbose_name`` - A prettier version of the model's class name for display.
 * ``verbose_name_plural`` -  A prettier version of the model's *plural* class name for display.
-* ``search_index`` - Returns the ``SearchIndex`` class associated with this
+* ``searchindex`` - Returns the ``SearchIndex`` class associated with this
   result.
 * ``distance`` - On geo-spatial queries, this returns a ``Distance`` object
   representing the distance the result was from the focused point.


### PR DESCRIPTION
[SearchResult defines searchindex, not search_index](https://github.com/django-haystack/django-haystack/blob/fcb1568c320628c2dea1f90038597a3468f7c529/haystack/models.py#L66-L70)

```python
def _get_searchindex(self):
        from haystack import connections
        return connections['default'].get_unified_index().get_index(self.model)

searchindex = property(_get_searchindex)
```