### PR TITLE
Adaptations for Solr 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,12 @@ script:
 
 env:
     matrix:
-        - DJANGO_VERSION=">=1.6,<1.7"
-        - DJANGO_VERSION=">=1.7,<1.8"
-        - DJANGO_VERSION=">=1.8,<1.9"
-        - SOLR_VERSION="4.10.4"
-        - SOLR_VERSION="5.2.1"
+        - DJANGO_VERSION=">=1.6,<1.7" SOLR_VERSION="4.10.4"
+        - DJANGO_VERSION=">=1.7,<1.8" SOLR_VERSION="4.10.4"
+        - DJANGO_VERSION=">=1.8,<1.9" SOLR_VERSION="4.10.4"
+        - DJANGO_VERSION=">=1.6,<1.7" SOLR_VERSION="5.2.1"
+        - DJANGO_VERSION=">=1.7,<1.8" SOLR_VERSION="5.2.1"
+        - DJANGO_VERSION=">=1.8,<1.9" SOLR_VERSION="5.2.1"
 
 matrix:
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,15 @@ before_script:
 
 script:
     - python test_haystack/solr_tests/server/wait-for-solr
-    - python setup.py test
+    - SOLR_SCHEMA="test_haystack/solr_tests/server/solr4/solr/collection1/conf/schema.xml" python setup.py test
 
 env:
     matrix:
         - DJANGO_VERSION=">=1.6,<1.7"
         - DJANGO_VERSION=">=1.7,<1.8"
         - DJANGO_VERSION=">=1.8,<1.9"
+        - SOLR_VERSION="4.10.4"
+        - SOLR_VERSION="5.2.1"
 
 matrix:
     allow_failures:

--- a/docs/installing_search_engines.rst
+++ b/docs/installing_search_engines.rst
@@ -11,8 +11,29 @@ Official Download Location: http://www.apache.org/dyn/closer.cgi/lucene/solr/
 
 Solr is Java but comes in a pre-packaged form that requires very little other
 than the JRE and Jetty. It's very performant and has an advanced featureset.
-Haystack suggests using Solr 3.5+, though it's possible to get it working on
-Solr 1.4 with a little effort. Installation is relatively simple::
+Haystack suggests using Solr 5.0+, though it's possible to get it working on
+Solr 1.4 with a little effort. Installation is relatively simple:
+
+Install the latest version 5.0.0
+----------------------------
+
+::
+
+    curl -LO https://archive.apache.org/dist/lucene/solr/5.0.0/solr-5.0.0.tgz
+    tar xvzf solr-5.0.0.tgz
+    cd solr-5.0.0
+    cd bin/solr start
+
+
+Then you create at least on "cloud" core :
+::
+    sudo -u solr bin/solr create -c mycorename
+
+Your core is now accessible by default at http://localhost:8983/solr/#/mycorename
+    
+Install version 4.10.2
+-----------------------
+::
 
     curl -LO https://archive.apache.org/dist/lucene/solr/4.10.2/solr-4.10.2.tgz
     tar xvzf solr-4.10.2.tgz
@@ -20,21 +41,28 @@ Solr 1.4 with a little effort. Installation is relatively simple::
     cd example
     java -jar start.jar
 
-You'll need to revise your schema. You can generate this from your application
-(once Haystack is installed and setup) by running
-``./manage.py build_solr_schema``. Take the output from that command and place
-it in ``solr-4.10.2/example/solr/collection1/conf/schema.xml``. Then restart Solr.
+Your server is now accessible at http://localhost:8983/solr/
 
-.. note::
-    ``build_solr_schema`` uses a template to generate ``schema.xml``. Haystack
-    provides a default template using some sensible defaults. If you would like
-    to provide your own template, you will need to place it in
-    ``search_configuration/solr.xml``, inside a directory specified by your app's
-    ``TEMPLATE_DIRS`` setting. Examples::
+Update your schema from the indexes
+------------------------------------
 
-        /myproj/myapp/templates/search_configuration/solr.xml
-        # ...or...
-        /myproj/templates/search_configuration/solr.xml
+You can update the schema from your application (once Haystack is installed and setup) by running:
+
+- since Solr 5.0.0 ``./manage.py build_solr_schema``.
+- for previous version (4.10.2) ``./manage.py build_solr_schema --stdout``. or ``./manage.py build_solr_schema --filename schema.xml``
+
+When using the version 5.0.0 of Solr, the command uses the Schema REST API described at https://wiki.apache.org/solr/SchemaRESTAPI
+Solr 5.0.0 provides many default dynamicFields and fieldTypes configured at the Core's creation by default. 
+If you like, these type are customisable using the Schema REST API Core's, or the http admin interface.
+
+When using previous version 4.10.2, please provide --filename schema.xml to export the schema file, and so that you can copy it to your solr installation. 
+build_solr_schema uses a template to generate schema.xml. 
+Haystack provides a default template using some sensible defaults. If you would like to provide your own template, you will need to place it in search_configuration/solr.xml, inside a directory specified by your app's TEMPLATE_DIRS setting. 
+
+Examples:
+/myproj/myapp/templates/search_configuration/solr.xml
+# ...or...
+/myproj/templates/search_configuration/solr.xml
 
 You'll also need a Solr binding, ``pysolr``. The official ``pysolr`` package,
 distributed via PyPI, is the best version to use (2.1.0+). Place ``pysolr.py``
@@ -220,3 +248,4 @@ http://github.com/notanumber/xapian-haystack/tree/master. Installation
 instructions can be found on that page as well. The backend, written
 by David Sauve (notanumber), fully implements the `SearchQuerySet` API and is
 an excellent alternative to Solr.
+

--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 from django.template import Context, loader
 
+
 from haystack import constants
 from haystack.backends.solr_backend import SolrSearchBackend
 
@@ -17,7 +18,9 @@ class Command(BaseCommand):
     help = "Generates a Solr schema that reflects the indexes."
     base_options = (
         make_option("-f", "--filename", action="store", type="string", dest="filename",
-                    help='If provided, directs output to a file instead of stdout.'),
+                help='For Solr version before 5.0.0. If provided, directs output to a XML schema.'),
+        make_option("-s", "--stdout", action="store_true", dest="stdout",
+            help='For Solr version before 5.0.0, print on stdout the schema.xml', default=False),
         make_option("-u", "--using", action="store", type="string", dest="using", default=constants.DEFAULT_ALIAS,
                     help='If provided, chooses a connection to work with.'),
     )
@@ -25,13 +28,35 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         """Generates a Solr schema that reflects the indexes."""
-        using = options.get('using')
-        schema_xml = self.build_template(using=using)
+        from haystack import connections, connection_router
 
-        if options.get('filename'):
-            self.write_file(options.get('filename'), schema_xml)
-        else:
-            self.print_stdout(schema_xml)
+        using = options.get('using')
+        backend = connections[using].get_backend()
+
+        if not isinstance(backend, SolrSearchBackend):
+            raise ImproperlyConfigured("'%s' isn't configured as a SolrEngine)." % backend.connection_alias)
+
+        if options.get('filename') or options.get('stdout'):
+            schema_xml = self.build_template(using=using)
+            if options.get('filename'):
+                self.write_file(options.get('filename'), schema_xml)
+            else:
+                self.print_schema(schema_xml)
+            return
+
+        content_field_name, fields = backend.build_schema(connections[using].get_unified_index().all_searchfields())
+
+        django_fields = [
+            dict(name=constants.ID, type="string", indexed="true", stored="true", multiValued="false", required="true"),
+            dict(name= constants.DJANGO_CT, type="string", indexed="true", stored="true", multiValued="false"),
+            dict(name= constants.DJANGO_ID, type="string", indexed="true", stored="true", multiValued="false"),
+            dict(name="_version_", type="long", indexed="true", stored ="true"),
+        ]
+
+        admin = backend.get_schema_admin()
+        for field in fields + django_fields:
+            resp = admin.add_field(field)
+            self.log(field, resp, backend)
 
     def build_context(self, using):
         from haystack import connections, connection_router
@@ -55,7 +80,12 @@ class Command(BaseCommand):
         c = self.build_context(using=using)
         return t.render(c)
 
-    def print_stdout(self, schema_xml):
+    def write_file(self, filename, schema_xml):
+        schema_file = open(filename, 'w')
+        schema_file.write(schema_xml)
+        schema_file.close()
+
+    def print_schema(self, schema_xml):
         sys.stderr.write("\n")
         sys.stderr.write("\n")
         sys.stderr.write("\n")
@@ -64,7 +94,15 @@ class Command(BaseCommand):
         sys.stderr.write("\n")
         print(schema_xml)
 
-    def write_file(self, filename, schema_xml):
-        schema_file = open(filename, 'w')
-        schema_file.write(schema_xml)
-        schema_file.close()
+    def log(self, field, response, backend):
+        try:
+            message = response.json()
+        except ValueError:
+            raise Exception('unable to decode Solr API, are sure you started Solr and created the configured Core (%s) ?' % backend.conn.url)
+
+        if 'errors' in message:
+            sys.stdout.write("%s.\n" % [" ".join(err.get('errorMessages')) for err in message['errors']])
+        elif 'responseHeader' in message and 'status' in message['responseHeader']:
+            sys.stdout.write("Successfully created the field %s\n" % field['name'])
+        else:
+            sys.stdout.write("%s.\n" % message)

--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         make_option("-f", "--filename", action="store", type="string", dest="filename",
                 help='For Solr version before 5.0.0. If provided, directs output to a XML schema.'),
         make_option("-s", "--stdout", action="store_true", dest="stdout",
-            help='For Solr version before 5.0.0, print on stdout the schema.xml', default=False),
+            help='For Solr version before 5.0.0, print the schema.xml to stdout', default=False),
         make_option("-u", "--using", action="store", type="string", dest="using", default=constants.DEFAULT_ALIAS,
                     help='If provided, chooses a connection to work with.'),
     )

--- a/haystack/templates/search_configuration/solr.xml
+++ b/haystack/templates/search_configuration/solr.xml
@@ -30,10 +30,10 @@
     <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true" sortMissingLast="true" positionIncrementGap="0"/>
     <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" sortMissingLast="true" positionIncrementGap="0"/>
     <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" sortMissingLast="true" positionIncrementGap="0"/>
-    <fieldType name="sint" class="solr.SortableIntField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="slong" class="solr.SortableLongField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="sfloat" class="solr.SortableFloatField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="sdouble" class="solr.SortableDoubleField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="sint" class="solr.TrieIntField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="slong" class="solr.TrieLongField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="sfloat" class="solr.TrieFloatField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="sdouble" class="solr.TrieDoubleField" sortMissingLast="true" omitNorms="true"/>
 
     <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
     <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
@@ -151,7 +151,7 @@
     <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false"/>
 
 {% for field in fields %}
-    <field name="{{ field.field_name }}" type="{{ field.type }}" indexed="{{ field.indexed }}" stored="{{ field.stored }}" multiValued="{{ field.multi_valued }}" />
+    <field name="{{ field.name }}" type="{{ field.type }}" indexed="{{ field.indexed }}" stored="{{ field.stored }}" multiValued="{{ field.multiValued }}" />
 {% endfor %}
   </fields>
 

--- a/test_haystack/solr_tests/server/start-solr-test-server.sh
+++ b/test_haystack/solr_tests/server/start-solr-test-server.sh
@@ -2,12 +2,13 @@
 
 set -e
 
-SOLR_VERSION=4.10.4
+if [ -z ${SOLR_VERSION}  ]; then
+    SOLR_VERSION="4.10.4"
+fi
 
 cd $(dirname $0)
 
 export TEST_ROOT=$(pwd)
-
 export SOLR_ARCHIVE="${SOLR_VERSION}.tgz"
 
 if [ -d "${HOME}/download-cache/" ]; then
@@ -23,35 +24,56 @@ if [ ! -f ${SOLR_ARCHIVE} ]; then
     python get-solr-download-url.py $SOLR_VERSION | xargs curl -Lo $SOLR_ARCHIVE
 fi
 
-echo "Extracting Solr ${SOLR_VERSION} to `pwd`/solr4/"
-rm -rf solr4
-mkdir solr4
-tar -C solr4 -xf ${SOLR_ARCHIVE} --strip-components 2 solr-${SOLR_VERSION}/example
-tar -C solr4 -xf ${SOLR_ARCHIVE} --strip-components 1 solr-${SOLR_VERSION}/dist solr-${SOLR_VERSION}/contrib
+if [ ${SOLR_VERSION} = "4.10.4" ]; then
+    echo "Extracting Solr ${SOLR_VERSION} to `pwd`/solr4/"
+    rm -rf solr4
+    mkdir solr4
+    tar -C solr4 -xf ${SOLR_ARCHIVE} --strip-components 2 solr-${SOLR_VERSION}/example
+    tar -C solr4 -xf ${SOLR_ARCHIVE} --strip-components 1 solr-${SOLR_VERSION}/dist solr-${SOLR_VERSION}/contrib
 
-echo "Changing into solr4"
+    echo "Changing into solr4"
 
-cd solr4
+    cd solr4
 
-echo "Configuring Solr"
+    echo "Configuring Solr"
 
-cp ${TEST_ROOT}/solrconfig.xml solr/collection1/conf/solrconfig.xml
-cp ${TEST_ROOT}/schema.xml solr/collection1/conf/schema.xml
+    cp ${TEST_ROOT}/solrconfig.xml solr/collection1/conf/solrconfig.xml
+    cp ${TEST_ROOT}/schema.xml solr/collection1/conf/schema.xml
 
-# Fix paths for the content extraction handler:
-perl -p -i -e 's|<lib dir="../../../contrib/|<lib dir="../../contrib/|'g solr/*/conf/solrconfig.xml
-perl -p -i -e 's|<lib dir="../../../dist/|<lib dir="../../dist/|'g solr/*/conf/solrconfig.xml
+    # Fix paths for the content extraction handler:
+    perl -p -i -e 's|<lib dir="../../../contrib/|<lib dir="../../contrib/|'g solr/*/conf/solrconfig.xml
+    perl -p -i -e 's|<lib dir="../../../dist/|<lib dir="../../dist/|'g solr/*/conf/solrconfig.xml
 
-# Add MoreLikeThis handler
-perl -p -i -e 's|<!-- A Robust Example|<!-- More like this request handler -->\n  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler" />\n\n\n  <!-- A Robust Example|'g solr/*/conf/solrconfig.xml
+    # Add MoreLikeThis handler
+    perl -p -i -e 's|<!-- A Robust Example|<!-- More like this request handler -->\n  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler" />\n\n\n  <!-- A Robust Example|'g solr/*/conf/solrconfig.xml
 
-echo 'Starting server'
-# We use exec to allow process monitors to correctly kill the
-# actual Java process rather than this launcher script:
-export CMD="java -Djetty.port=9001 -Djava.awt.headless=true -Dapple.awt.UIElement=true -jar start.jar"
+    echo 'Starting server'
+    # We use exec to allow process monitors to correctly kill the
+    # actual Java process rather than this launcher script:
+    export CMD="java -Djetty.port=9001 -Djava.awt.headless=true -Dapple.awt.UIElement=true -jar start.jar"
 
-if [ -z "${BACKGROUND_SOLR}" ]; then
+    if [ -z "${BACKGROUND_SOLR}" ]; then
+        exec $CMD
+    else
+        exec $CMD >/dev/null &
+    fi
+fi
+
+if [ ${SOLR_VERSION} = "5.2.1" ]; then
+    if [ -z ${SOLR_CORENAME}  ]; then
+        SOLR_CORENAME="haystacktestcore"
+    fi
+
+    echo "Extracting Solr ${SOLR_VERSION} to `pwd`/solr-${SOLR_VERSION}/"
+    tar -xf ${SOLR_ARCHIVE}
+    echo "Changing into solr5"
+    cd solr-${SOLR_VERSION}
+
+    # We use exec to allow process monitors to correctly kill the
+    # actual Java process rather than this launcher script:
+    export CMD="sudo bin/solr start -p 9001"
+    echo 'Starting server on port 9001'
     exec $CMD
-else
-    exec $CMD >/dev/null &
+    echo "Configuring Solr 5 Core named ${SOLR_CORENAME}"
+    sudo -u solr bin/solr create -c $SOLR_CORENAME
 fi

--- a/test_haystack/solr_tests/server/start-solr-test-server.sh
+++ b/test_haystack/solr_tests/server/start-solr-test-server.sh
@@ -71,7 +71,7 @@ if [ ${SOLR_VERSION} = "5.2.1" ]; then
 
     # We use exec to allow process monitors to correctly kill the
     # actual Java process rather than this launcher script:
-    export CMD="sudo bin/solr start -p 9001"
+    export CMD="bin/solr start -p 9001"
     echo 'Starting server on port 9001'
     exec $CMD
     echo "Configuring Solr 5 Core named ${SOLR_CORENAME}"

--- a/test_haystack/solr_tests/server/wait-for-solr
+++ b/test_haystack/solr_tests/server/wait-for-solr
@@ -5,13 +5,18 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
 import time
+import os
 
 import requests
 
 max_retries = 100
 retry_count = 0
 retry_delay = 15
-status_url = 'http://localhost:9001/solr/admin/ping'
+
+if int(os.environ.get('SOLR_VERSION', '5')[0]) < 5:
+    status_url = 'http://localhost:9001/solr/admin/ping'
+else:
+    status_url = 'http://localhost:9001/solr'
 
 
 while retry_count < max_retries:

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -510,149 +510,149 @@ class SolrSearchBackendTestCase(TestCase):
     def test_build_schema(self):
         old_ui = connections['solr'].get_unified_index()
 
-        (content_field_name, fields) = self.sb.build_schema(old_ui.all_searchfields())
-        self.assertEqual(content_field_name, 'text')
+        (content_name, fields) = self.sb.build_schema(old_ui.all_searchfields())
+        self.assertEqual(content_name, 'text')
         self.assertEqual(len(fields), 4)
-        self.assertEqual(sorted(fields, key=lambda x: x['field_name']), [
+        self.assertEqual(sorted(fields, key=lambda x: x['name']), [
             {
                 'indexed': 'true',
                 'type': 'text_en',
                 'stored': 'true',
-                'field_name': 'name',
-                'multi_valued': 'false'
+                'name': 'name',
+                'multiValued': 'false'
             },
             {
                 'indexed': 'true',
-                'field_name': 'name_exact',
+                'name': 'name_exact',
                 'stored': 'true',
                 'type': 'string',
-                'multi_valued': 'false'
+                'multiValued': 'false'
             },
             {
                 'indexed': 'true',
                 'type': 'date',
                 'stored': 'true',
-                'field_name': 'pub_date',
-                'multi_valued': 'false'
+                'name': 'pub_date',
+                'multiValued': 'false'
             },
             {
                 'indexed': 'true',
                 'type': 'text_en',
                 'stored': 'true',
-                'field_name': 'text',
-                'multi_valued': 'false'
+                'name': 'text',
+                'multiValued': 'false'
             },
         ])
 
         ui = UnifiedIndex()
         ui.build(indexes=[SolrComplexFacetsMockSearchIndex()])
-        (content_field_name, fields) = self.sb.build_schema(ui.all_searchfields())
-        self.assertEqual(content_field_name, 'text')
+        (content_name, fields) = self.sb.build_schema(ui.all_searchfields())
+        self.assertEqual(content_name, 'text')
         self.assertEqual(len(fields), 15)
-        fields = sorted(fields, key=lambda field: field['field_name'])
+        fields = sorted(fields, key=lambda field: field['name'])
         self.assertEqual(fields, [
             {
-                'field_name': 'average_rating',
+                'name': 'average_rating',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'float'
             },
             {
-                'field_name': 'average_rating_exact',
+                'name': 'average_rating_exact',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'float'
             },
             {
-                'field_name': 'created',
+                'name': 'created',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'date'
             },
             {
-                'field_name': 'created_exact',
+                'name': 'created_exact',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'date'
             },
             {
-                'field_name': 'is_active',
+                'name': 'is_active',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'boolean'
             },
             {
-                'field_name': 'is_active_exact',
+                'name': 'is_active_exact',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'boolean'
             },
             {
-                'field_name': 'name',
+                'name': 'name',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'text_en'
             },
             {
-                'field_name': 'name_exact',
+                'name': 'name_exact',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'string'
             },
             {
-                'field_name': 'post_count',
+                'name': 'post_count',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'long'
             },
             {
-                'field_name': 'post_count_i',
+                'name': 'post_count_i',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'long'
             },
             {
-                'field_name': 'pub_date',
+                'name': 'pub_date',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'date'
             },
             {
-                'field_name': 'pub_date_exact',
+                'name': 'pub_date_exact',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'date'
             },
             {
-                'field_name': 'sites',
+                'name': 'sites',
                 'indexed': 'true',
-                'multi_valued': 'true',
+                'multiValued': 'true',
                 'stored': 'true',
                 'type': 'text_en'
             },
             {
-                'field_name': 'sites_exact',
+                'name': 'sites_exact',
                 'indexed': 'true',
-                'multi_valued': 'true',
+                'multiValued': 'true',
                 'stored': 'true',
                 'type': 'string'
             },
             {
-                'field_name': 'text',
+                'name': 'text',
                 'indexed': 'true',
-                'multi_valued': 'false',
+                'multiValued': 'false',
                 'stored': 'true',
                 'type': 'text_en'
             }

--- a/test_haystack/test_altered_internal_names.py
+++ b/test_haystack/test_altered_internal_names.py
@@ -63,27 +63,27 @@ class AlteredInternalNamesTestCase(TestCase):
         self.assertEqual(context_data['default_operator'], 'AND')
         self.assertEqual(context_data['ID'], 'my_id')
         self.assertEqual(len(context_data['fields']), 3)
-        self.assertEqual(sorted(context_data['fields'], key=lambda x: x['field_name']), [
+        self.assertEqual(sorted(context_data['fields'], key=lambda x: x['name']), [
             {
                 'indexed': 'true',
                 'type': 'text_en',
                 'stored': 'true',
-                'field_name': 'name',
-                'multi_valued': 'false'
+                'name': 'name',
+                'multiValued': 'false'
             },
             {
                 'indexed': 'true',
                 'type': 'date',
                 'stored': 'true',
-                'field_name': 'pub_date',
-                'multi_valued': 'false'
+                'name': 'pub_date',
+                'multiValued': 'false'
             },
             {
                 'indexed': 'true',
                 'type': 'text_en',
                 'stored': 'true',
-                'field_name': 'text',
-                'multi_valued': 'false'
+                'name': 'text',
+                'multiValued': 'false'
             },
         ])
 


### PR DESCRIPTION
Solr 5.0.0 is easy to deploy with cloud Cores with automatic managed-schema and no more schem.xml.
Solr 5.0.0 can edit a core's configuration via with the Schema REST API. 
This is what this pull request does. Along with an updated documentation.

Refers to issue #1147 and try to resolve it...