### PR TITLE
Resolve various Django 1.8 deprecations

### DIFF
--- a/haystack/templatetags/highlight.py
+++ b/haystack/templatetags/highlight.py
@@ -5,7 +5,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from django import template
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import importlib, six
+from django.utils import six
+
+from haystack.utils import importlib
+
 
 register = template.Library()
 

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -11,9 +11,12 @@ from haystack.constants import ID, DJANGO_CT, DJANGO_ID
 from haystack.utils.highlighting import Highlighter
 
 try:
-    from django.utils import importlib
-except ImportError:
+    # Introduced in Python 2.7
     import importlib
+except ImportError:
+    # Deprecated in Django 1.8; removed in Django 1.9 (both of which require
+    # at least Python 2.7)
+    from django.utils import importlib
 
 IDENTIFIER_REGEX = re.compile('^[\w\d_]+\.[\w\d_]+\.\d+$')
 

--- a/haystack/utils/app_loading.py
+++ b/haystack/utils/app_loading.py
@@ -5,7 +5,9 @@ from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.loading import get_app, get_model, get_models
-from django.utils.importlib import import_module
+
+from haystack.utils import importlib
+
 
 __all__ = ['haystack_get_models', 'haystack_load_apps']
 
@@ -56,7 +58,7 @@ else:
 
     def haystack_get_app_modules():
         """Return the Python module for each installed app"""
-        return [import_module(i) for i in settings.INSTALLED_APPS]
+        return [importlib.import_module(i) for i in settings.INSTALLED_APPS]
 
     def haystack_load_apps():
         # Do all, in an INSTALLED_APPS sorted order.

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -8,11 +8,11 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import importlib
 from django.utils.datastructures import SortedDict
 from django.utils.module_loading import module_has_submodule
 
 from haystack.exceptions import NotHandled, SearchFieldError
+from haystack.utils import importlib
 from haystack.utils.app_loading import haystack_get_app_modules
 
 

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -8,12 +8,20 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.datastructures import SortedDict
 from django.utils.module_loading import module_has_submodule
 
 from haystack.exceptions import NotHandled, SearchFieldError
 from haystack.utils import importlib
 from haystack.utils.app_loading import haystack_get_app_modules
+
+
+try:
+    # Introduced in Python 2.7
+    from collections import OrderedDict
+except ImportError:
+    # Deprecated in Django 1.8; removed in Django 1.9 (both of which require
+    # at least Python 2.7)
+    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 def import_class(path):
@@ -152,7 +160,7 @@ class UnifiedIndex(object):
     # Used to collect all the indexes into a cohesive whole.
     def __init__(self, excluded_indexes=None):
         self._indexes = {}
-        self.fields = SortedDict()
+        self.fields = OrderedDict()
         self._built = False
         self.excluded_indexes = excluded_indexes or []
         self.excluded_indexes_ids = {}
@@ -192,7 +200,7 @@ class UnifiedIndex(object):
 
     def reset(self):
         self._indexes = {}
-        self.fields = SortedDict()
+        self.fields = OrderedDict()
         self._built = False
         self._fieldnames = {}
         self._facet_fieldnames = {}

--- a/test_haystack/elasticsearch_tests/__init__.py
+++ b/test_haystack/elasticsearch_tests/__init__.py
@@ -4,7 +4,7 @@ import warnings
 
 from django.conf import settings
 
-from ..utils.unittest import SkipTest
+from ..utils import unittest
 
 warnings.simplefilter('ignore', Warning)
 
@@ -12,11 +12,11 @@ def setup():
     try:
         from elasticsearch import Elasticsearch, ElasticsearchException
     except ImportError:
-        raise SkipTest("elasticsearch-py not installed.")
+        raise unittest.SkipTest("elasticsearch-py not installed.")
 
     es = Elasticsearch(settings.HAYSTACK_CONNECTIONS['elasticsearch']['URL'])
     try:
         es.info()
     except ElasticsearchException as e:
-        raise SkipTest("elasticsearch not running on %r" % settings.HAYSTACK_CONNECTIONS['elasticsearch']['URL'], e)
+        raise unittest.SkipTest("elasticsearch not running on %r" % settings.HAYSTACK_CONNECTIONS['elasticsearch']['URL'], e)
 

--- a/test_haystack/elasticsearch_tests/__init__.py
+++ b/test_haystack/elasticsearch_tests/__init__.py
@@ -3,7 +3,8 @@
 import warnings
 
 from django.conf import settings
-from django.utils.unittest import SkipTest
+
+from ..utils.unittest import SkipTest
 
 warnings.simplefilter('ignore', Warning)
 

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -10,7 +10,6 @@ import elasticsearch
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils import unittest
 
 from haystack import connections, indexes, reset_search_queries
 from haystack.inputs import AutoQuery
@@ -22,6 +21,7 @@ from haystack.utils.loading import UnifiedIndex
 
 from ..core.models import AFourthMockModel, AnotherMockModel, ASixthMockModel, MockModel
 from ..mocks import MockSearchResult
+from ..utils import unittest
 
 test_pickling = True
 

--- a/test_haystack/solr_tests/test_management_commands.py
+++ b/test_haystack/solr_tests/test_management_commands.py
@@ -11,13 +11,13 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.test import TestCase
-from django.utils import unittest
 from mock import patch
 
 from haystack import connections, indexes
 from haystack.utils.loading import UnifiedIndex
 
 from ..core.models import MockModel, MockTag
+from ..utils import unittest
 
 
 class SolrMockSearchIndex(indexes.SearchIndex, indexes.Indexable):

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -21,7 +21,7 @@ from haystack.utils.loading import UnifiedIndex
 
 from ..core.models import AFourthMockModel, AnotherMockModel, ASixthMockModel, MockModel
 from ..mocks import MockSearchResult
-from ..utils.unittest import skipIf, skipUnless
+from ..utils import unittest
 
 test_pickling = True
 
@@ -1275,7 +1275,7 @@ class LiveSolrRoundTripTestCase(TestCase):
         self.assertEqual(result.sites, [3, 5, 1])
 
 
-@skipUnless(test_pickling, 'Skipping pickling tests')
+@unittest.skipUnless(test_pickling, 'Skipping pickling tests')
 class LiveSolrPickleTestCase(TestCase):
     fixtures = ['bulk_data.json']
 
@@ -1366,7 +1366,7 @@ class SolrBoostBackendTestCase(TestCase):
         ])
 
 
-@skipIf(pysolr.__version__ < (3, 1, 1), 'content extraction requires pysolr > 3.1.0')
+@unittest.skipIf(pysolr.__version__ < (3, 1, 1), 'content extraction requires pysolr > 3.1.0')
 class LiveSolrContentExtractionTestCase(TestCase):
     def setUp(self):
         super(LiveSolrContentExtractionTestCase, self).setUp()

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -10,7 +10,6 @@ import pysolr
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.unittest import skipIf, skipUnless
 from mock import patch
 
 from haystack import connections, indexes, reset_search_queries
@@ -22,6 +21,7 @@ from haystack.utils.loading import UnifiedIndex
 
 from ..core.models import AFourthMockModel, AnotherMockModel, ASixthMockModel, MockModel
 from ..mocks import MockSearchResult
+from ..utils.unittest import skipIf, skipUnless
 
 test_pickling = True
 

--- a/test_haystack/solr_tests/test_templatetags.py
+++ b/test_haystack/solr_tests/test_templatetags.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import django
 from django.template import Context, Template
 from django.test import TestCase
-from django.utils import unittest
 from mock import call, patch
 
 from ..core.models import MockModel
+from ..utils import unittest
 
 
 @patch("haystack.templatetags.more_like_this.SearchQuerySet")

--- a/test_haystack/test_app_using_appconfig/tests.py
+++ b/test_haystack/test_app_using_appconfig/tests.py
@@ -7,11 +7,11 @@ from django.test import TestCase
 
 
 from .models import MicroBlogPost
-from ..utils.unittest import skipIf
+from ..utils import unittest
 
 
 
-@skipIf(django.VERSION < (1, 7), 'AppConfig tests do not apply to Django versions before 1.7')
+@unittest.skipIf(django.VERSION < (1, 7), 'AppConfig tests do not apply to Django versions before 1.7')
 class AppConfigTests(TestCase):
     def test_index_collection(self):
         from haystack import connections

--- a/test_haystack/test_app_using_appconfig/tests.py
+++ b/test_haystack/test_app_using_appconfig/tests.py
@@ -4,9 +4,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import django
 from django.test import TestCase
-from django.utils.unittest import skipIf
+
 
 from .models import MicroBlogPost
+from ..utils.unittest import skipIf
 
 
 

--- a/test_haystack/test_loading.py
+++ b/test_haystack/test_loading.py
@@ -2,25 +2,16 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from test_haystack.core.models import AnotherMockModel, MockModel
+from test_haystack.utils import unittest
 
 from haystack import indexes
 from haystack.exceptions import NotHandled, SearchFieldError
 from haystack.utils import loading
 
-if not hasattr(unittest, "skipIf"):
-    # We're dealing with Python < 2.7 and we need unittest2, which might be available from Django:
-    try:
-        from django.utils import unittest
-    except ImportError:
-        try:
-            import unittest2 as unittest
-        except ImportError:
-            raise RuntimeError("Tests require unittest2. If you use Django 1.2, install unittest2")
+from .utils import unittest
 
 try:
     import pysolr

--- a/test_haystack/test_models.py
+++ b/test_haystack/test_models.py
@@ -7,7 +7,6 @@ import pickle
 
 import django
 from django.test import TestCase
-from django.utils import unittest
 from test_haystack.core.models import AFifthMockModel, MockModel
 
 from haystack import connections
@@ -17,6 +16,7 @@ from haystack.utils.loading import UnifiedIndex
 
 from .mocks import MockSearchResult
 from .test_indexes import ReadQuerySetTestSearchIndex
+from ..utils import unittest
 
 
 class CaptureHandler(std_logging.Handler):

--- a/test_haystack/test_models.py
+++ b/test_haystack/test_models.py
@@ -16,7 +16,7 @@ from haystack.utils.loading import UnifiedIndex
 
 from .mocks import MockSearchResult
 from .test_indexes import ReadQuerySetTestSearchIndex
-from ..utils import unittest
+from .utils import unittest
 
 
 class CaptureHandler(std_logging.Handler):

--- a/test_haystack/test_query.py
+++ b/test_haystack/test_query.py
@@ -6,8 +6,8 @@ import datetime
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.unittest import skipUnless
 from test_haystack.core.models import AFifthMockModel, AnotherMockModel, CharPKMockModel, MockModel
+from test_haystack.utils.unittest import skipUnless
 
 from haystack import connection_router, connections, indexes, reset_search_queries
 from haystack.backends import BaseSearchQuery, SQ

--- a/test_haystack/test_query.py
+++ b/test_haystack/test_query.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from test_haystack.core.models import AFifthMockModel, AnotherMockModel, CharPKMockModel, MockModel
-from test_haystack.utils.unittest import skipUnless
+from test_haystack.utils import unittest
 
 from haystack import connection_router, connections, indexes, reset_search_queries
 from haystack.backends import BaseSearchQuery, SQ
@@ -848,7 +848,7 @@ class EmptySearchQuerySetTestCase(TestCase):
         self.assertRaises(TypeError, lambda: self.esqs['count'])
 
 
-@skipUnless(test_pickling, 'Skipping pickling tests')
+@unittest.skipUnless(test_pickling, 'Skipping pickling tests')
 @override_settings(DEBUG=True)
 class PickleSearchQuerySetTestCase(TestCase):
     def setUp(self):

--- a/test_haystack/utils.py
+++ b/test_haystack/utils.py
@@ -3,17 +3,26 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.conf import settings
-from django.utils.unittest import SkipTest
+
+import unittest
+
+
+if not hasattr(unittest, 'skipIf'):
+    # Some unittest features we need were introduced in Python 2.7, but we are
+    # dealing with Python 2.6, so we fallback to Django's unittest2. It was
+    # deprecated in Django 1.8; removed in Django 1.9 (both of which require
+    # at least Python 2.7)
+    from django.utils import unittest
 
 
 def check_solr(using='solr'):
     try:
         from pysolr import Solr, SolrError
     except ImportError:
-        raise SkipTest("pysolr  not installed.")
+        raise unittest.SkipTest("pysolr  not installed.")
 
     solr = Solr(settings.HAYSTACK_CONNECTIONS[using]['URL'])
     try:
         solr.search('*:*')
     except SolrError as e:
-        raise SkipTest("solr not running on %r" % settings.HAYSTACK_CONNECTIONS[using]['URL'], e)
+        raise unittest.SkipTest("solr not running on %r" % settings.HAYSTACK_CONNECTIONS[using]['URL'], e)

--- a/test_haystack/whoosh_tests/test_whoosh_backend.py
+++ b/test_haystack/whoosh_tests/test_whoosh_backend.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils import unittest
 from django.utils.datetime_safe import date, datetime
 from whoosh.fields import BOOLEAN, DATETIME, KEYWORD, NUMERIC, TEXT
 from whoosh.qparser import QueryParser
@@ -23,6 +22,7 @@ from haystack.utils.loading import UnifiedIndex
 
 from ..core.models import AFourthMockModel, AnotherMockModel, MockModel
 from ..mocks import MockSearchResult
+from ..utils import unittest
 from .testcases import WhooshTestCase
 
 

--- a/test_haystack/whoosh_tests/testcases.py
+++ b/test_haystack/whoosh_tests/testcases.py
@@ -27,7 +27,7 @@ class WhooshTestCase(TestCase):
             from haystack import connections
             connections[name].get_backend().setup()
 
-        super(TestCase, cls).setUpClass()
+        super(WhooshTestCase, cls).setUpClass()
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This pull request handles the deprecation in Django 1.8 of:

- `django.utils.datastructures.SortedDict`
- `django.utils.importlib`
- `django.utils.unittest`

For each case it prefers code from the Python stdlib, and if that import fails uses the old Django code. You can see individual commit messages for more information on each change.

This should resolve issue #1162 as well as pull request #1137.