### PR TITLE
Updating haystack to test against django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ env:
     - TOX_ENV=py34-django1.5
     - TOX_ENV=py34-django1.6
     - TOX_ENV=py34-django1.7
+    - TOX_ENV=py34-django1.8
     - TOX_ENV=pypy-django1.5
     - TOX_ENV=pypy-django1.6
     - TOX_ENV=pypy-django1.7

--- a/test_haystack/__init__.py
+++ b/test_haystack/__init__.py
@@ -18,8 +18,14 @@ def setup():
     global test_runner
     global old_config
 
-    from django.test.simple import DjangoTestSuiteRunner
-    test_runner = DjangoTestSuiteRunner()
+    try:
+        from django.test.simple import DjangoTestSuiteRunner as TestSuiteRunner
+    except ImportError:
+        # DjangoTestSuiteRunner was deprecated in django 1.8:
+        # https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-8
+        from django.test.runner import DiscoverRunner as TestSuiteRunner
+
+    test_runner = TestSuiteRunner()
     test_runner.setup_test_environment()
     old_config = test_runner.setup_databases()
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist = docs,
         py34-django1.5,
         py34-django1.6,
         py34-django1.7,
+        py34-django1.8,
         pypy-django1.5,
         pypy-django1.6,
         pypy-django1.7,
@@ -18,6 +19,10 @@ envlist = docs,
 [base]
 deps = requests
 
+[django1.8]
+deps =
+    Django>=1.8,<1.9
+    
 [django1.7]
 deps =
     Django>=1.7,<1.8
@@ -114,6 +119,12 @@ deps =
 basepython = python3.4
 deps =
     {[django1.7]deps}
+    {[base]deps}
+
+[testenv:py34-django1.8]
+basepython = python3.4
+deps =
+    {[django1.8]deps}
     {[base]deps}
 
 [testenv:docs]


### PR DESCRIPTION
Get django-haystack to run tests against django 1.8.