### PR TITLE
Search results break when indexing with UUID PKs

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -217,16 +217,19 @@ class SearchQuerySet(object):
                     self.log.warning("Model '%s' not handled by the routers", model)
                     # Revert to old behaviour
                     loaded_objects[model] = model._default_manager.in_bulk(models_pks[model])
+                # Convert keys to string so we can also handle UUIDs
+                loaded_objects[model] = {
+                    six.text_type(pk): value
+                    for pk, value
+                    in loaded_objects[model].items()
+                }
 
         for result in results:
             if self._load_all:
-                # We have to deal with integer keys being cast from strings
+                # We have to deal with integer keys
+                # that have to be cast to strings
                 model_objects = loaded_objects.get(result.model, {})
-                if not result.pk in model_objects:
-                    try:
-                        result.pk = int(result.pk)
-                    except ValueError:
-                        pass
+                result.pk = six.text_type(result.pk)
                 try:
                     result._object = model_objects[result.pk]
                 except KeyError:


### PR DESCRIPTION
When using the new UUIDField in Django 1.8, lookups for `result.pk` in the loaded objects during queries fail, returning a QuerySet full of `None`.

Here is the culprit:

[haystack/query.py:233](https://github.com/django-haystack/django-haystack/blob/bd60745ce82318b1819768c9a31db0579228654d/haystack/query.py#L230)
~~~python
try:
	result._object = model_objects[result.pk]
except KeyError:
	# ...
~~~

This fails because, in the incoming search results, UUIDs arrive stringified instead.

~~~python
(Pdb++) result.pk in model_objects
False

(Pdb++) result.pk
u'8d3af2f5-afc4-474f-aa51-19338d5a1ae8'

(Pdb++) model_objects
{
	UUID('0bc1e7c2-eb45-43c5-93b6-6cea1005b6cb'): <ProductVariant: Name>,
	UUID('78de90fc-c63c-4487-bf7b-8f837296d3ba'): <ProductVariant: Name>,
	UUID('99aa9caf-d10b-4325-80ec-2836a84457d6'): <ProductVariant: Name>,
	UUID('452e2e71-188a-4426-8a4d-f5df72d387c0'): <ProductVariant: Name>,
	# ...
}
~~~

This PR works around this issue by stringifying PKs on both sides, so to accept strings, numbers, UUIDs and every other type with a stable string representation.