### PR TITLE
fix 1.8 incompatibility #1167

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -8,7 +8,7 @@ import warnings
 from datetime import timedelta
 from optparse import make_option
 
-from django.db import connection
+from django import db
 from django.core.management.base import LabelCommand
 from django.db import reset_queries
 
@@ -49,7 +49,7 @@ def worker(bits):
         # out connections (via ``... = {}``) destroys in-memory DBs.
         if 'sqlite3' not in info['ENGINE']:
             try:
-                connection.close()
+                db.close_connection()
                 if isinstance(connections._connections, dict):
                     del(connections._connections[alias])
                 else:
@@ -223,7 +223,7 @@ class Command(LabelCommand):
                 # workers resetting connections leads to references to models / connections getting
                 # stale and having their connection disconnected from under them. Resetting before
                 # the loop continues and it accesses the ORM makes it better.
-                connection.close()
+                db.close_connection()
 
             qs = index.build_queryset(using=using, start_date=self.start_date,
                                       end_date=self.end_date)

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -8,7 +8,14 @@ import warnings
 from datetime import timedelta
 from optparse import make_option
 
-from django import db
+try:
+    from django.db import close_old_connections
+except ImportError:
+    from django.db import close_connection as close_old_connections
+
+    warnings.warn('close_connection has been removed from Django 1.8+ '
+                  'See https://docs.djangoproject.com/fr/1.8/releases/1.8/#features-removed-in-1-8')
+
 from django.core.management.base import LabelCommand
 from django.db import reset_queries
 
@@ -49,7 +56,7 @@ def worker(bits):
         # out connections (via ``... = {}``) destroys in-memory DBs.
         if 'sqlite3' not in info['ENGINE']:
             try:
-                db.close_connection()
+                close_old_connections()
                 if isinstance(connections._connections, dict):
                     del(connections._connections[alias])
                 else:
@@ -223,7 +230,7 @@ class Command(LabelCommand):
                 # workers resetting connections leads to references to models / connections getting
                 # stale and having their connection disconnected from under them. Resetting before
                 # the loop continues and it accesses the ORM makes it better.
-                db.close_connection()
+                close_old_connections()
 
             qs = index.build_queryset(using=using, start_date=self.start_date,
                                       end_date=self.end_date)

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -13,8 +13,8 @@ try:
 except ImportError:
     from django.db import close_connection as close_old_connections
 
-    warnings.warn('close_connection has been removed from Django 1.8+ '
-                  'See https://docs.djangoproject.com/fr/1.8/releases/1.8/#features-removed-in-1-8')
+    warnings.warn('close_connection has been removed from Django 1.8+',
+                  DeprecationWarning)
 
 from django.core.management.base import LabelCommand
 from django.db import reset_queries

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -8,7 +8,7 @@ import warnings
 from datetime import timedelta
 from optparse import make_option
 
-from django import db
+from django.db import connection
 from django.core.management.base import LabelCommand
 from django.db import reset_queries
 
@@ -49,7 +49,7 @@ def worker(bits):
         # out connections (via ``... = {}``) destroys in-memory DBs.
         if 'sqlite3' not in info['ENGINE']:
             try:
-                db.close_connection()
+                connection.close()
                 if isinstance(connections._connections, dict):
                     del(connections._connections[alias])
                 else:
@@ -223,7 +223,7 @@ class Command(LabelCommand):
                 # workers resetting connections leads to references to models / connections getting
                 # stale and having their connection disconnected from under them. Resetting before
                 # the loop continues and it accesses the ORM makes it better.
-                db.close_connection()
+                connection.close()
 
             qs = index.build_queryset(using=using, start_date=self.start_date,
                                       end_date=self.end_date)


### PR DESCRIPTION
fix 1.8 incompatibility with deleted db.close_connection() internal API. see #1167 