### PR TITLE
remove result via the result's id instead of re-constructing the id

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -108,7 +108,7 @@ def do_remove(backend, index, model, pks_seen, start, upper_bound, verbosity=1, 
             if verbosity >= 2:
                 print("  removing %s." % result.pk)
 
-            backend.remove(".".join([result.app_label, result.model_name, str(result.pk)]), commit=commit)
+            backend.remove(result.id, commit=commit)
 
 
 class Command(LabelCommand):


### PR DESCRIPTION
fixes https://github.com/django-haystack/django-haystack/issues/1185

the --remove logic for update_index is still really messed up, see https://github.com/django-haystack/django-haystack/issues/1186
at least this makes it semi-work with custom identifiers