### PR TITLE
Add DoNotIndex exception handling for Whoosh, Solr and Elasticsearch backends

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -14,7 +14,7 @@ from django.utils import six
 import haystack
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query
 from haystack.constants import DEFAULT_OPERATOR, DJANGO_CT, DJANGO_ID, ID
-from haystack.exceptions import MissingDependency, MoreLikeThisError
+from haystack.exceptions import DoNotIndex, MissingDependency, MoreLikeThisError
 from haystack.inputs import Clean, Exact, PythonData, Raw
 from haystack.models import SearchResult
 from haystack.utils import log as logging
@@ -172,6 +172,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 final_data['_id'] = final_data[ID]
 
                 prepped_docs.append(final_data)
+            except DoNotIndex:
+                self.log.warn(u"Indexing for object `%s` skipped" % obj)
             except elasticsearch.TransportError as e:
                 if not self.silently_fail:
                     raise

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -173,7 +173,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 
                 prepped_docs.append(final_data)
             except DoNotIndex:
-                self.log.warn(u"Indexing for object `%s` skipped" % obj)
+                self.log.debug(u"Indexing for object `%s` skipped" % obj)
             except elasticsearch.TransportError as e:
                 if not self.silently_fail:
                     raise

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -55,7 +55,7 @@ class SolrSearchBackend(BaseSearchBackend):
             try:
                 docs.append(index.full_prepare(obj))
             except DoNotIndex:
-                self.log.warn(u"Indexing for object `%s` skipped" % obj)
+                self.log.debug(u"Indexing for object `%s` skipped" % obj)
             except UnicodeDecodeError:
                 if not self.silently_fail:
                     raise

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -11,7 +11,7 @@ from django.utils import six
 
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, EmptyResults, log_query
 from haystack.constants import DJANGO_CT, DJANGO_ID, ID
-from haystack.exceptions import MissingDependency, MoreLikeThisError
+from haystack.exceptions import DoNotIndex,  MissingDependency, MoreLikeThisError
 from haystack.inputs import Clean, Exact, PythonData, Raw
 from haystack.models import SearchResult
 from haystack.utils import log as logging
@@ -54,6 +54,8 @@ class SolrSearchBackend(BaseSearchBackend):
         for obj in iterable:
             try:
                 docs.append(index.full_prepare(obj))
+            except DoNotIndex:
+                self.log.warn(u"Indexing for object `%s` skipped" % obj)
             except UnicodeDecodeError:
                 if not self.silently_fail:
                     raise

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -195,7 +195,7 @@ class WhooshSearchBackend(BaseSearchBackend):
             try:
                 doc = index.full_prepare(obj)
             except DoNotIndex:
-                self.log.warn(u"Indexing for object `%s` skipped" % obj)
+                self.log.debug(u"Indexing for object `%s` skipped" % obj)
             else:
                 # Really make sure it's unicode, because Whoosh won't have it any
                 # other way.

--- a/haystack/exceptions.py
+++ b/haystack/exceptions.py
@@ -7,34 +7,47 @@ class HaystackError(Exception):
     """A generic exception for all others to extend."""
     pass
 
+
 class SearchBackendError(HaystackError):
     """Raised when a backend can not be found."""
     pass
+
 
 class SearchFieldError(HaystackError):
     """Raised when a field encounters an error."""
     pass
 
+
 class MissingDependency(HaystackError):
     """Raised when a library a backend depends on can not be found."""
     pass
+
 
 class NotHandled(HaystackError):
     """Raised when a model is not handled by the router setup."""
     pass
 
+
 class MoreLikeThisError(HaystackError):
     """Raised when a model instance has not been provided for More Like This."""
     pass
+
 
 class FacetingError(HaystackError):
     """Raised when incorrect arguments have been provided for faceting."""
     pass
 
+
 class SpatialError(HaystackError):
     """Raised when incorrect arguments have been provided for spatial."""
     pass
 
+
 class StatsError(HaystackError):
     "Raised when incorrect arguments have been provided for stats"
+    pass
+
+
+class DoNotIndex(HaystackError):
+    """Raised when a object should be skipped when updating"""
     pass

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -350,27 +350,12 @@ class ElasticsearchSearchBackendTestCase(TestCase):
         self.sb.update(self.smmidni, self.sample_objs)
 
         # Check what Elasticsearch thinks is there.
-        self.assertEqual(self.raw_search('*:*')['hits']['total'], 2)
-        self.assertEqual(sorted([res['_source'] for res in self.raw_search('*:*')['hits']['hits']], key=lambda x: x['id']), [
-            {
-                'django_id': '1',
-                'django_ct': 'core.mockmodel',
-                'name': 'daniel1',
-                'name_exact': 'daniel1',
-                'text': 'Indexed!\n1',
-                'pub_date': '2009-02-24T00:00:00',
-                'id': 'core.mockmodel.1'
-            },
-            {
-                'django_id': '2',
-                'django_ct': 'core.mockmodel',
-                'name': 'daniel2',
-                'name_exact': 'daniel2',
-                'text': 'Indexed!\n2',
-                'pub_date': '2009-02-23T00:00:00',
-                'id': 'core.mockmodel.2'
-            }
-        ])
+        res = self.raw_search('*:*')['hits']
+        self.assertEqual(res['total'], 2)
+        self.assertListEqual(
+            sorted([x['_source']['id'] for x in res['hits']]),
+            ['core.mockmodel.1', 'core.mockmodel.2']
+        )
 
 
     def test_remove(self):

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -13,6 +13,7 @@ from django.test.utils import override_settings
 from django.utils import unittest
 
 from haystack import connections, indexes, reset_search_queries
+from haystack.exceptions import DoNotIndex
 from haystack.inputs import AutoQuery
 from haystack.models import SearchResult
 from haystack.query import RelatedSearchQuerySet, SearchQuerySet, SQ
@@ -55,6 +56,14 @@ class ElasticsearchMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return MockModel
+
+
+class ElasticsearchMockSearchIndexWithDoNotIndex(ElasticsearchMockSearchIndex):
+
+    def prepare_text(self, obj):
+        if obj.author == 'daniel3':
+            raise DoNotIndex
+        return u"Indexed!\n%s" % obj.id
 
 
 class ElasticsearchMockSpellingIndex(indexes.SearchIndex, indexes.Indexable):
@@ -207,6 +216,7 @@ class ElasticsearchSpatialSearchIndex(indexes.SearchIndex, indexes.Indexable):
 
 
 class TestSettings(TestCase):
+
     def test_kwargs_are_passed_on(self):
         from haystack.backends.elasticsearch_backend import ElasticsearchSearchBackend
         backend = ElasticsearchSearchBackend('alias', **{
@@ -230,6 +240,7 @@ class ElasticsearchSearchBackendTestCase(TestCase):
         self.old_ui = connections['elasticsearch'].get_unified_index()
         self.ui = UnifiedIndex()
         self.smmi = ElasticsearchMockSearchIndex()
+        self.smmidni = ElasticsearchMockSearchIndexWithDoNotIndex()
         self.smtmmi = ElasticsearchMaintainTypeMockSearchIndex()
         self.ui.build(indexes=[self.smmi])
         connections['elasticsearch']._index = self.ui
@@ -334,6 +345,33 @@ class ElasticsearchSearchBackendTestCase(TestCase):
                 'id': 'core.mockmodel.3'
             }
         ])
+
+    def test_update_with_donotindex_raised(self):
+        self.sb.update(self.smmidni, self.sample_objs)
+
+        # Check what Elasticsearch thinks is there.
+        self.assertEqual(self.raw_search('*:*')['hits']['total'], 2)
+        self.assertEqual(sorted([res['_source'] for res in self.raw_search('*:*')['hits']['hits']], key=lambda x: x['id']), [
+            {
+                'django_id': '1',
+                'django_ct': 'core.mockmodel',
+                'name': 'daniel1',
+                'name_exact': 'daniel1',
+                'text': 'Indexed!\n1',
+                'pub_date': '2009-02-24T00:00:00',
+                'id': 'core.mockmodel.1'
+            },
+            {
+                'django_id': '2',
+                'django_ct': 'core.mockmodel',
+                'name': 'daniel2',
+                'name_exact': 'daniel2',
+                'text': 'Indexed!\n2',
+                'pub_date': '2009-02-23T00:00:00',
+                'id': 'core.mockmodel.2'
+            }
+        ])
+
 
     def test_remove(self):
         self.sb.update(self.smmi, self.sample_objs)

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -14,6 +14,7 @@ from django.utils.unittest import skipIf, skipUnless
 from mock import patch
 
 from haystack import connections, indexes, reset_search_queries
+from haystack.exceptions import DoNotIndex
 from haystack.inputs import AltParser, AutoQuery, Raw
 from haystack.models import SearchResult
 from haystack.query import RelatedSearchQuerySet, SearchQuerySet, SQ
@@ -48,6 +49,14 @@ class SolrMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return MockModel
+
+
+class SolrMockSearchIndexWithDoNotIndex(SolrMockSearchIndex):
+
+        def prepare_text(self, obj):
+            if obj.author == 'daniel3':
+                raise DoNotIndex
+            return u"Indexed!\n%s" % obj.id
 
 
 class SolrMockOverriddenFieldNameSearchIndex(indexes.SearchIndex, indexes.Indexable):
@@ -200,6 +209,7 @@ class SolrSearchBackendTestCase(TestCase):
         self.old_ui = connections['solr'].get_unified_index()
         self.ui = UnifiedIndex()
         self.smmi = SolrMockSearchIndex()
+        self.smmidni = SolrMockSearchIndexWithDoNotIndex()
         self.smtmmi = SolrMaintainTypeMockSearchIndex()
         self.smofnmi = SolrMockOverriddenFieldNameSearchIndex()
         self.ui.build(indexes=[self.smmi])
@@ -282,6 +292,35 @@ class SolrSearchBackendTestCase(TestCase):
                 'text': 'Indexed!\n3',
                 'pub_date': '2009-02-22T00:00:00Z',
                 'id': 'core.mockmodel.3'
+            }
+        ])
+
+    def test_update_with_donotindex_raised(self):
+        self.sb.update(self.smmidni, self.sample_objs)
+
+        results = self.raw_solr.search('*:*')
+        for result in results:
+            del result['_version_']
+        # Check what Solr thinks is there.
+        self.assertEqual(results.hits, 2)
+        self.assertEqual(results.docs, [
+            {
+                'django_id': '1',
+                'django_ct': 'core.mockmodel',
+                'name': 'daniel1',
+                'name_exact': 'daniel1',
+                'text': 'Indexed!\n1',
+                'pub_date': '2009-02-24T00:00:00Z',
+                'id': 'core.mockmodel.1'
+            },
+            {
+                'django_id': '2',
+                'django_ct': 'core.mockmodel',
+                'name': 'daniel2',
+                'name_exact': 'daniel2',
+                'text': 'Indexed!\n2',
+                'pub_date': '2009-02-23T00:00:00Z',
+                'id': 'core.mockmodel.2'
             }
         ])
 

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -298,31 +298,14 @@ class SolrSearchBackendTestCase(TestCase):
     def test_update_with_donotindex_raised(self):
         self.sb.update(self.smmidni, self.sample_objs)
 
-        results = self.raw_solr.search('*:*')
-        for result in results:
-            del result['_version_']
+        res = self.raw_solr.search('*:*')
+
         # Check what Solr thinks is there.
-        self.assertEqual(results.hits, 2)
-        self.assertEqual(results.docs, [
-            {
-                'django_id': '1',
-                'django_ct': 'core.mockmodel',
-                'name': 'daniel1',
-                'name_exact': 'daniel1',
-                'text': 'Indexed!\n1',
-                'pub_date': '2009-02-24T00:00:00Z',
-                'id': 'core.mockmodel.1'
-            },
-            {
-                'django_id': '2',
-                'django_ct': 'core.mockmodel',
-                'name': 'daniel2',
-                'name_exact': 'daniel2',
-                'text': 'Indexed!\n2',
-                'pub_date': '2009-02-23T00:00:00Z',
-                'id': 'core.mockmodel.2'
-            }
-        ])
+        self.assertEqual(res.hits, 2)
+        self.assertListEqual(
+            sorted([x['id'] for x in res.docs]),
+            ['core.mockmodel.1', 'core.mockmodel.2']
+        )
 
     def test_remove(self):
         self.sb.update(self.smmi, self.sample_objs)

--- a/test_haystack/whoosh_tests/test_whoosh_backend.py
+++ b/test_haystack/whoosh_tests/test_whoosh_backend.py
@@ -185,9 +185,13 @@ class WhooshSearchBackendTestCase(WhooshTestCase):
         self.sb.update(self.wmmidni, self.sample_objs)
 
         # Check what Whoosh thinks is there.
-        self.assertEqual(len(self.whoosh_search(u'*')), 14)
+        res = self.whoosh_search(u'*')
+        self.assertEqual(len(res), 14)
         ids = [1, 2, 5, 6, 7, 8, 9, 11, 12, 14, 15, 18, 20, 21]
-        self.assertEqual([doc.fields()['id'] for doc in self.whoosh_search(u'*')], [u'core.mockmodel.%s' % i for i in ids])
+        self.assertListEqual(
+            [doc.fields()['id'] for doc in res],
+            [u'core.mockmodel.%s' % i for i in ids]
+        )
 
     def test_remove(self):
         self.sb.update(self.wmmi, self.sample_objs)

--- a/test_haystack/whoosh_tests/test_whoosh_backend.py
+++ b/test_haystack/whoosh_tests/test_whoosh_backend.py
@@ -15,7 +15,7 @@ from whoosh.fields import BOOLEAN, DATETIME, KEYWORD, NUMERIC, TEXT
 from whoosh.qparser import QueryParser
 
 from haystack import connections, indexes, reset_search_queries
-from haystack.exceptions import SearchBackendError
+from haystack.exceptions import DoNotIndex, SearchBackendError
 from haystack.inputs import AutoQuery
 from haystack.models import SearchResult
 from haystack.query import SearchQuerySet, SQ
@@ -33,6 +33,14 @@ class WhooshMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return MockModel
+
+
+class WhooshMockSearchIndexWithDoNotIndex(WhooshMockSearchIndex):
+
+    def prepare_text(self, obj):
+        if obj.author == 'daniel3':
+            raise DoNotIndex
+        return obj.author
 
 
 class WhooshAnotherMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
@@ -115,6 +123,7 @@ class WhooshSearchBackendTestCase(WhooshTestCase):
         self.old_ui = connections['whoosh'].get_unified_index()
         self.ui = UnifiedIndex()
         self.wmmi = WhooshMockSearchIndex()
+        self.wmmidni = WhooshMockSearchIndexWithDoNotIndex()
         self.wmtmmi = WhooshMaintainTypeMockSearchIndex()
         self.ui.build(indexes=[self.wmmi])
         self.sb = connections['whoosh'].get_backend()
@@ -171,6 +180,14 @@ class WhooshSearchBackendTestCase(WhooshTestCase):
         # Check what Whoosh thinks is there.
         self.assertEqual(len(self.whoosh_search(u'*')), 23)
         self.assertEqual([doc.fields()['id'] for doc in self.whoosh_search(u'*')], [u'core.mockmodel.%s' % i for i in range(1, 24)])
+
+    def test_update_with_donotindex_raised(self):
+        self.sb.update(self.wmmidni, self.sample_objs)
+
+        # Check what Whoosh thinks is there.
+        self.assertEqual(len(self.whoosh_search(u'*')), 14)
+        ids = [1, 2, 5, 6, 7, 8, 9, 11, 12, 14, 15, 18, 20, 21]
+        self.assertEqual([doc.fields()['id'] for doc in self.whoosh_search(u'*')], [u'core.mockmodel.%s' % i for i in ids])
 
     def test_remove(self):
         self.sb.update(self.wmmi, self.sample_objs)


### PR DESCRIPTION
I would like to backport this small feature to 2.3.x because 2.4.x has to many changes and few people would not like to do a version bump (from 2.3 to 2.4). Also, 2.4.x still in dev and backport it to 2.3.x would allow people to use this feature faster and in stable package.

The commit for 2.3.x is at https://github.com/chronossc/django-haystack/commit/5745c0c9a2c6b69b282f1c8765942ef00d1e43bc

Note: There is two tests failing in Master, that is not fixed in this PR. Probably are something with my env:

```
======================================================================
ERROR: test_multiprocessing (test_haystack.solr_tests.test_management_commands.ManagementCommandTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/felipe/projects/django-haystack/django-haystack/test_haystack/solr_tests/test_management_commands.py", line 162, in test_multiprocessing
    call_command('update_index', verbosity=2, workers=2, batchsize=5)
  File "/home/felipe/projects/django-haystack/django-haystack/.tox/py27-django1.6/lib/python2.7/site-packages/django/core/management/__init__.py", line 159, in call_command
    return klass.execute(*args, **defaults)
  File "/home/felipe/projects/django-haystack/django-haystack/.tox/py27-django1.6/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/home/felipe/projects/django-haystack/django-haystack/haystack/management/commands/update_index.py", line 195, in handle
    return super(Command, self).handle(*items, **options)
  File "/home/felipe/projects/django-haystack/django-haystack/.tox/py27-django1.6/lib/python2.7/site-packages/django/core/management/base.py", line 385, in handle
    label_output = self.handle_label(label, **options)
  File "/home/felipe/projects/django-haystack/django-haystack/haystack/management/commands/update_index.py", line 200, in handle_label
    self.update_backend(label, using)
  File "/home/felipe/projects/django-haystack/django-haystack/haystack/management/commands/update_index.py", line 251, in update_backend
    pool.map(worker, ghetto_queue)
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 251, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 558, in get
    raise self._value
IncompleteRead: IncompleteRead(17 bytes read)
-------------------- >> begin captured stdout << ---------------------
Skipping '<class 'django.contrib.admin.models.LogEntry'>' - no index.
Skipping '<class 'django.contrib.admin.models.LogEntry'>' - no index.
Skipping '<class 'django.contrib.admin.models.LogEntry'>' - no index.
Skipping '<class 'django.contrib.admin.models.LogEntry'>' - no index.
Skipping '<class 'django.contrib.admin.models.LogEntry'>' - no index.
Skipping '<class 'django.contrib.admin.models.LogEntry'>' - no index.
Skipping '<class 'django.contrib.auth.models.Permission'>' - no index.
Skipping '<class 'django.contrib.auth.models.Group'>' - no index.
Skipping '<class 'django.contrib.auth.models.User'>' - no index.
Skipping '<class 'django.contrib.auth.models.Permission'>' - no index.
Skipping '<class 'django.contrib.auth.models.Group'>' - no index.
Skipping '<class 'django.contrib.auth.models.User'>' - no index.
Skipping '<class 'django.contrib.auth.models.Permission'>' - no index.
Skipping '<class 'django.contrib.auth.models.Group'>' - no index.
Skipping '<class 'django.contrib.auth.models.User'>' - no index.
Skipping '<class 'django.contrib.auth.models.Permission'>' - no index.
Skipping '<class 'django.contrib.auth.models.Group'>' - no index.
Skipping '<class 'django.contrib.auth.models.User'>' - no index.
Skipping '<class 'django.contrib.auth.models.Permission'>' - no index.
Skipping '<class 'django.contrib.auth.models.Group'>' - no index.
Skipping '<class 'django.contrib.auth.models.User'>' - no index.
Skipping '<class 'django.contrib.auth.models.Permission'>' - no index.
Skipping '<class 'django.contrib.auth.models.Group'>' - no index.
Skipping '<class 'django.contrib.auth.models.User'>' - no index.
Skipping '<class 'django.contrib.contenttypes.models.ContentType'>' - no index.
Skipping '<class 'django.contrib.contenttypes.models.ContentType'>' - no index.
Skipping '<class 'django.contrib.contenttypes.models.ContentType'>' - no index.
Skipping '<class 'django.contrib.contenttypes.models.ContentType'>' - no index.
Skipping '<class 'django.contrib.contenttypes.models.ContentType'>' - no index.
Skipping '<class 'django.contrib.contenttypes.models.ContentType'>' - no index.
Skipping '<class 'django.contrib.sessions.models.Session'>' - no index.
Skipping '<class 'django.contrib.sessions.models.Session'>' - no index.
Skipping '<class 'django.contrib.sessions.models.Session'>' - no index.
Skipping '<class 'django.contrib.sessions.models.Session'>' - no index.
Skipping '<class 'django.contrib.sessions.models.Session'>' - no index.
Skipping '<class 'django.contrib.sessions.models.Session'>' - no index.
Skipping '<class 'django.contrib.sites.models.Site'>' - no index.
Skipping '<class 'django.contrib.sites.models.Site'>' - no index.
Skipping '<class 'django.contrib.sites.models.Site'>' - no index.
Skipping '<class 'django.contrib.sites.models.Site'>' - no index.
Skipping '<class 'django.contrib.sites.models.Site'>' - no index.
Skipping '<class 'django.contrib.sites.models.Site'>' - no index.
Indexing 0 foos
Indexing 0 bars
Indexing 0 foos
Indexing 0 bars
Skipping '<class 'test_haystack.discovery.models.Foo'>' - no index.
Skipping '<class 'test_haystack.discovery.models.Bar'>' - no index.
Skipping '<class 'test_haystack.discovery.models.Foo'>' - no index.
Skipping '<class 'test_haystack.discovery.models.Bar'>' - no index.
Skipping '<class 'test_haystack.discovery.models.Foo'>' - no index.
Skipping '<class 'test_haystack.discovery.models.Bar'>' - no index.
Indexing 0 foos
Indexing 0 bars
Skipping '<class 'test_haystack.core.models.MockTag'>' - no index.
Skipping '<class 'test_haystack.core.models.MockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.AnotherMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.AThirdMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.CharPKMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.AFourthMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.AFifthMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.ASixthMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.ScoreMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.MockTag'>' - no index.
Skipping '<class 'test_haystack.core.models.MockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.AnotherMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.AThirdMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.CharPKMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.AFourthMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.AFifthMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.ASixthMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.ScoreMockModel'>' - no index.
Skipping '<class 'test_haystack.core.models.MockTag'>' - no index.
Indexing 23 mock models

--------------------- >> end captured stdout << ----------------------
-------------------- >> begin captured logging << --------------------
urllib3.util.retry: DEBUG: Converted retries value: False -> Retry(total=False, connect=None, read=None, redirect=0)
urllib3.connectionpool: DEBUG: "DELETE /test_default HTTP/1.1" 404 70
elasticsearch: INFO: DELETE http://127.0.0.1:9200/test_default [status:404 request:0.002s]
elasticsearch: DEBUG: > None
elasticsearch: DEBUG: < {"error":"IndexMissingException[[test_default] missing]","status":404}
elasticsearch.trace: INFO: curl -XDELETE 'http://localhost:9200/test_default?pretty' -d ''
elasticsearch.trace: DEBUG: #[404] (0.002s)
#{
#  "error": "IndexMissingException[[test_default] missing]",
#  "status": 404
#}
pysolr: DEBUG: Starting request to 'http://localhost:9001/solr/update/?commit=true' (post) with body 'u'<delete>'...
requests.packages.urllib3.connectionpool: DEBUG: "POST /solr/update/?commit=true HTTP/1.1" 200 None
pysolr: INFO: Finished 'http://localhost:9001/solr/update/?commit=true' (post) with body 'u'<delete>' in 0.090 seconds.
pysolr: DEBUG: Starting request to 'http://localhost:9001/solr/update/?commit=true' (post) with body 'u'<optimiz'...
requests.packages.urllib3.connectionpool: DEBUG: "POST /solr/update/?commit=true HTTP/1.1" 200 None
pysolr: INFO: Finished 'http://localhost:9001/solr/update/?commit=true' (post) with body 'u'<optimiz' in 0.043 seconds.
pysolr: DEBUG: Starting request to 'http://localhost:9001/solr/select/?q=%2A%3A%2A&wt=json' (get) with body ''...
requests.packages.urllib3.connectionpool: INFO: Starting new HTTP connection (1): localhost
requests.packages.urllib3.connectionpool: DEBUG: "GET /solr/select/?q=%2A%3A%2A&wt=json HTTP/1.1" 200 None
pysolr: INFO: Finished 'http://localhost:9001/solr/select/?q=%2A%3A%2A&wt=json' (get) with body '' in 0.008 seconds.
pysolr: DEBUG: Found '0' search results.
root: ERROR: Error updating core using solr 
Traceback (most recent call last):
  File "/home/felipe/projects/django-haystack/django-haystack/haystack/management/commands/update_index.py", line 200, in handle_label
    self.update_backend(label, using)
  File "/home/felipe/projects/django-haystack/django-haystack/haystack/management/commands/update_index.py", line 251, in update_backend
    pool.map(worker, ghetto_queue)
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 251, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 558, in get
    raise self._value
IncompleteRead: IncompleteRead(17 bytes read)
--------------------- >> end captured logging << ---------------------

======================================================================
FAIL: test_remove (test_haystack.solr_tests.test_management_commands.ManagementCommandTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/felipe/projects/django-haystack/django-haystack/test_haystack/solr_tests/test_management_commands.py", line 84, in test_remove
    self.assertEqual(self.solr.search('*:*').hits, 0)
AssertionError: 3 != 0
-------------------- >> begin captured logging << --------------------
urllib3.util.retry: DEBUG: Converted retries value: False -> Retry(total=False, connect=None, read=None, redirect=0)
urllib3.connectionpool: DEBUG: "DELETE /test_default HTTP/1.1" 404 70
elasticsearch: INFO: DELETE http://127.0.0.1:9200/test_default [status:404 request:0.002s]
elasticsearch: DEBUG: > None
elasticsearch: DEBUG: < {"error":"IndexMissingException[[test_default] missing]","status":404}
elasticsearch.trace: INFO: curl -XDELETE 'http://localhost:9200/test_default?pretty' -d ''
elasticsearch.trace: DEBUG: #[404] (0.002s)
#{
#  "error": "IndexMissingException[[test_default] missing]",
#  "status": 404
#}
pysolr: DEBUG: Starting request to 'http://localhost:9001/solr/update/?commit=true' (post) with body 'u'<delete>'...
requests.packages.urllib3.connectionpool: INFO: Resetting dropped connection: localhost
requests.packages.urllib3.connectionpool: DEBUG: "POST /solr/update/?commit=true HTTP/1.1" 200 None
pysolr: INFO: Finished 'http://localhost:9001/solr/update/?commit=true' (post) with body 'u'<delete>' in 1.006 seconds.
pysolr: DEBUG: Starting request to 'http://localhost:9001/solr/update/?commit=true' (post) with body 'u'<optimiz'...
requests.packages.urllib3.connectionpool: DEBUG: "POST /solr/update/?commit=true HTTP/1.1" 200 None
pysolr: INFO: Finished 'http://localhost:9001/solr/update/?commit=true' (post) with body 'u'<optimiz' in 0.527 seconds.
pysolr: DEBUG: Starting request to 'http://localhost:9001/solr/select/?q=%2A%3A%2A&wt=json' (get) with body ''...
requests.packages.urllib3.connectionpool: INFO: Starting new HTTP connection (1): localhost
requests.packages.urllib3.connectionpool: DEBUG: "GET /solr/select/?q=%2A%3A%2A&wt=json HTTP/1.1" 200 None
pysolr: INFO: Finished 'http://localhost:9001/solr/select/?q=%2A%3A%2A&wt=json' (get) with body '' in 0.008 seconds.
pysolr: DEBUG: Found '3' search results.
--------------------- >> end captured logging << ---------------------
```

This closes #380 .