### PR TITLE
Fixed get_model and models.loading deprecation warnings for Django 1.8

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -8,7 +8,6 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models.loading import get_model
 from django.utils import six
 
 import haystack
@@ -19,6 +18,7 @@ from haystack.inputs import Clean, Exact, PythonData, Raw
 from haystack.models import SearchResult
 from haystack.utils import log as logging
 from haystack.utils import get_identifier, get_model_ct
+from haystack.utils.app_loading import haystack_get_model
 
 try:
     import elasticsearch
@@ -597,7 +597,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             source = raw_result['_source']
             app_label, model_name = source[DJANGO_CT].split('.')
             additional_fields = {}
-            model = get_model(app_label, model_name)
+            model = haystack_get_model(app_label, model_name)
 
             if model and model in indexed_models:
                 for key, value in source.items():

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -6,7 +6,6 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models.loading import get_model
 from django.utils import six
 
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, EmptyResults, log_query
@@ -16,6 +15,7 @@ from haystack.inputs import Clean, Exact, PythonData, Raw
 from haystack.models import SearchResult
 from haystack.utils import log as logging
 from haystack.utils import get_identifier, get_model_ct
+from haystack.utils.app_loading import haystack_get_model
 
 try:
     from pysolr import Solr, SolrError
@@ -378,7 +378,7 @@ class SolrSearchBackend(BaseSearchBackend):
         for raw_result in raw_results.docs:
             app_label, model_name = raw_result[DJANGO_CT].split('.')
             additional_fields = {}
-            model = get_model(app_label, model_name)
+            model = haystack_get_model(app_label, model_name)
 
             if model and model in indexed_models:
                 index = unified_index.get_index(model)

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -10,7 +10,6 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models.loading import get_model
 from django.utils import six
 from django.utils.datetime_safe import datetime
 
@@ -21,6 +20,7 @@ from haystack.inputs import Clean, Exact, PythonData, Raw
 from haystack.models import SearchResult
 from haystack.utils import log as logging
 from haystack.utils import get_identifier, get_model_ct
+from haystack.utils.app_loading import haystack_get_model
 
 try:
     import json
@@ -609,7 +609,7 @@ class WhooshSearchBackend(BaseSearchBackend):
             score = raw_page.score(doc_offset) or 0
             app_label, model_name = raw_result[DJANGO_CT].split('.')
             additional_fields = {}
-            model = get_model(app_label, model_name)
+            model = haystack_get_model(app_label, model_name)
 
             if model and model in indexed_models:
                 for key, value in raw_result.items():

--- a/haystack/utils/app_loading.py
+++ b/haystack/utils/app_loading.py
@@ -28,6 +28,8 @@ if DJANGO_VERSION >= (1, 7):
             app_mod = apps.get_app_config(label)
             return app_mod.get_models()
         except LookupError:
+            if '.' not in label:
+                raise ImproperlyConfigured('Unknown application label {}'.format(label))
             app_label, model_name = label.rsplit('.', 1)
             return [apps.get_model(app_label, model_name)]
         except ImproperlyConfigured:

--- a/haystack/utils/app_loading.py
+++ b/haystack/utils/app_loading.py
@@ -4,17 +4,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models.loading import get_app, get_model, get_models
 
 from haystack.utils import importlib
 
-
 __all__ = ['haystack_get_models', 'haystack_load_apps']
-
 
 APP = 'app'
 MODEL = 'model'
-
 
 if DJANGO_VERSION >= (1, 7):
     from django.apps import apps
@@ -29,19 +25,20 @@ if DJANGO_VERSION >= (1, 7):
 
     def haystack_get_models(label):
         try:
-            app_mod = get_app(label)
-            if app_mod is not None:
-                return get_models(app_mod=app_mod)
+            app_mod = apps.get_app_config(label)
+            return app_mod.get_models()
+        except LookupError:
+            app_label, model_name = label.rsplit('.', 1)
+            return [apps.get_model(app_label, model_name)]
         except ImproperlyConfigured:
             pass
 
-        if '.' not in label:
-            raise ImproperlyConfigured("No installed application has the label %s" % label)
-
-        app_label, model_name = label.rsplit('.', 1)
-        return [get_model(app_label, model_name)]
+    def haystack_get_model(app_label, model_name):
+        return apps.get_model(app_label, model_name)
 
 else:
+    from django.db.models.loading import get_app, get_model, get_models
+
     def is_app_or_model(label):
         label_bits = label.split('.')
 
@@ -54,7 +51,8 @@ else:
                 return APP
             return MODEL
         else:
-            raise ImproperlyConfigured("'%s' isn't recognized as an app (<app_label>) or model (<app_label>.<model_name>)." % label)
+            raise ImproperlyConfigured(
+                "'%s' isn't recognized as an app (<app_label>) or model (<app_label>.<model_name>)." % label)
 
     def haystack_get_app_modules():
         """Return the Python module for each installed app"""
@@ -85,3 +83,6 @@ else:
         else:
             app_label, model_name = label.rsplit('.', 1)
             return [get_model(app_label, model_name)]
+
+    def haystack_get_model(app_label, model_name):
+        return get_model(app_label, model_name)


### PR DESCRIPTION
- Backends were still using `get_model` from `django.db.models.loading`. Since Django 1.7 this has been deprecated in favor of the new `apps.get_model`. The old version will be deprecated in Django 1.9 and currently gives deprecation warnings. This replaces that with a shadow function that returns the correct function based on the django version used.

- `haystack_get_models` was still using the `django.db.models.loading.get_model` in the Django > 1.7 explicit block, thus creating warnings.
I've replaced this with code that only uses the apps variant. 

- Imports for Django < 1.7 were giving deprecation warnings in Django > 1.7. Imports have been moved down to the appropriate block
