### PR TITLE
Allow overriding SearchChangeList via get_changelist()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -104,3 +104,4 @@ Thanks to
     * Ben Spaulding (@benspaulding) for many updates for Django 1.8 support
     * Troy Grosfield (@troygrosfield) for fixing the test runner for Django 1.8
     * Ilan Steemers (@Koed00) for fixing Django 1.9 deprecation warnings
+    * Mike Hansen (@mwhansen) for allowing subclasses of SearchModelAdmin to use custom SearchChangeList class

--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -75,6 +75,9 @@ class SearchModelAdminMixin(object):
     # haystack connection to use for searching
     haystack_connection = 'default'
 
+    def get_changelist(self, request, **kwargs):
+        return SearchChangeList
+
     @csrf_protect_m
     def changelist_view(self, request, extra_context=None):
         if not self.has_change_permission(request, None):
@@ -114,6 +117,7 @@ class SearchModelAdminMixin(object):
         if hasattr(self, 'list_max_show_all'):
             kwargs['list_max_show_all'] = self.list_max_show_all
 
+        SearchChangeList = self.get_changelist(**kwargs)
         changelist = SearchChangeList(**kwargs)
         formset = changelist.formset = None
         media = self.media


### PR DESCRIPTION
I needed to be able to override SearchChangeList with a subclass in a SearchModelAdmin so I added support for this via Django's ```get_changelist``` method on an Admin class.