### PR TITLE
Use a faster implementation of this cache.

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -175,7 +175,7 @@ class SearchQuerySet(object):
         # an array of 100,000 ``None``s consumed less than .5 Mb, which ought
         # to be an acceptable loss for consistent and more efficient caching.
         if len(self._result_cache) == 0:
-            self._result_cache = [None for i in range(self.query.get_count())]
+            self._result_cache = [None] * self.query.get_count()
 
         if start is None:
             start = 0


### PR DESCRIPTION
In my tests this new implementation runs much faster and uses far less memory.

Compare the following two:
```
# Takes about a second to run:
sys.getsizeof([None]*pow(10,8))
# Takes much longer and sometimes gets memory errors
sys.getsizeof([None for i in range(pow(10, 8))])
```

This PR simply uses the first implementation instead of the second.