### PR TITLE
django.models.get_model moved to django.apps.apps.get_model in 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ env:
     - TOX_ENV=py34-django1.6
     - TOX_ENV=py34-django1.7
     - TOX_ENV=py34-django1.8
+    - TOX_ENV=py34-django1.9a1
     - TOX_ENV=pypy-django1.6
     - TOX_ENV=pypy-django1.7
     - TOX_ENV=pypy-django1.8

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -23,6 +23,13 @@ try:
 except ImportError:
     geopy_distance = None
 
+try:
+    get_model = models.get_model
+except AttributeError:
+    # django 1.9 compat
+    from django.apps import apps
+    get_model = apps.get_model
+
 
 # Not a Django model, but tightly tied to them and there doesn't seem to be a
 # better spot in the tree.
@@ -101,7 +108,7 @@ class SearchResult(object):
     def _get_model(self):
         if self._model is None:
             try:
-                self._model = models.get_model(self.app_label, self.model_name)
+                self._model = get_model(self.app_label, self.model_name)
             except LookupError:
                 # this changed in change 1.7 to throw an error instead of
                 # returning None when the model isn't found. So catch the

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,17 @@ envlist = docs,
         py34-django1.6,
         py34-django1.7,
         py34-django1.8,
+        py34-django1.9a1,
         pypy-django1.6,
         pypy-django1.7,
         pypy-django1.8,
 
 [base]
 deps = requests
+
+[django1.9a1]
+deps =
+    Django==1.9a1
 
 [django1.8]
 deps =
@@ -100,6 +105,12 @@ deps =
 basepython = python3.4
 deps =
     {[django1.8]deps}
+    {[base]deps}
+
+[testenv:py34-django1.9a1]
+basepython = python3.4
+deps =
+    {[django1.9a1]deps}
     {[base]deps}
 
 [testenv:docs]


### PR DESCRIPTION
fixes compatibility with django 1.9a1