### PR TITLE
Update views_and_forms.rst

### DIFF
--- a/docs/views_and_forms.rst
+++ b/docs/views_and_forms.rst
@@ -184,7 +184,7 @@ Upgrading from basic usage of the old-style views to new-style views is usually 
 #. Move all parameters of your old-style views from your ``urls.py`` to attributes on
    your new views. This will require renaming ``searchqueryset`` to ``queryset`` and
    ``template`` to ``template_name``
-#. Review your templates and replace the ``page`` variable with ``page_object``
+#. Review your templates and replace the ``page`` variable with ``page_obj``
 
 Here's an example::
 


### PR DESCRIPTION
After breaking my head for an hour, I realized the instructions to upgrade to class based views is incorrect. It should indicate that switch from `page` to `page_obj` and not `page_object`