### PR TITLE
The facets size can be now set via a setting.

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -351,7 +351,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 facet_options = {
                     'terms': {
                         'field': facet_fieldname,
-                        'size': 100,
+                        'size': getattr(settings, 'HAYSTACK_ELASTICSEARCH_FACETS_SIZE', 100),
                     },
                 }
                 # Special cases for options applied at the facet level (not the terms level).


### PR DESCRIPTION
The setting HAYSTACK_ELASTICSEARCH_FACETS_SIZE can be used to set the number of facets to be returned by elasticsearch.