### PR TITLE
Fix queryset slicing and code duplication

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -218,11 +218,19 @@ class SearchQuerySet(object):
     def _fill_cache(self, start, end, **kwargs):
         # Tell the query where to start from and how many we'd like.
         self.query._reset()
-        self.query.set_limits(start, end)
-        results = self.query.get_results(**kwargs)
 
         if start is None:
             start = 0
+
+        query_start = start
+        query_start += self._ignored_result_count
+        query_end = end
+        if query_end is not None:
+            query_end += self._ignored_result_count
+
+        self.query.set_limits(query_start, query_end)
+        results = self.query.get_results(**kwargs)
+
 
         if results is None or len(results) == 0:
             # trim missing stuff from the result cache

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -231,7 +231,6 @@ class SearchQuerySet(object):
         self.query.set_limits(query_start, query_end)
         results = self.query.get_results(**kwargs)
 
-
         if results is None or len(results) == 0:
             # trim missing stuff from the result cache
             self._result_cache = self._result_cache[:start]
@@ -267,11 +266,10 @@ class SearchQuerySet(object):
                 self.query.set_limits(fill_start, fill_end)
                 results = self.query.get_results()
 
-                if results == None or len(results) == 0:
+                if results is None or len(results) == 0:
                     # No more results. Trim missing stuff from the result cache
                     self._result_cache = self._result_cache[:cache_start]
                     break
-
             else:
                 break
 

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -164,36 +164,6 @@ class SearchQuerySet(object):
             if not self._fill_cache(current_position, current_position + ITERATOR_LOAD_PER_QUERY):
                 raise StopIteration
 
-    def _fill_cache(self, start, end, **kwargs):
-        # Tell the query where to start from and how many we'd like.
-        self.query._reset()
-        self.query.set_limits(start, end)
-        results = self.query.get_results(**kwargs)
-
-        if results is None or len(results) == 0:
-            return False
-
-        # Setup the full cache now that we know how many results there are.
-        # We need the ``None``s as placeholders to know what parts of the
-        # cache we have/haven't filled.
-        # Using ``None`` like this takes up very little memory. In testing,
-        # an array of 100,000 ``None``s consumed less than .5 Mb, which ought
-        # to be an acceptable loss for consistent and more efficient caching.
-        if len(self._result_cache) == 0:
-            self._result_cache = [None] * self.query.get_count()
-
-        if start is None:
-            start = 0
-
-        if end is None:
-            end = self.query.get_count()
-
-        to_cache = self.post_process_results(results)
-
-        # Assign by slice.
-        self._result_cache[start:start + len(to_cache)] = to_cache
-        return True
-
     def post_process_results(self, results):
         to_cache = []
 
@@ -238,6 +208,107 @@ class SearchQuerySet(object):
             to_cache.append(result)
 
         return to_cache
+
+    def _load_model_objects(self, model, pks):
+        try:
+            ui = connections[self.query._using].get_unified_index()
+            index = ui.get_index(model)
+            objects = index.read_queryset(using=self.query._using)
+            return objects.in_bulk(pks)
+        except NotHandled:
+            self.log.warning("Model '%s' not handled by the routers.", model)
+            # Revert to old behaviour
+            return model._default_manager.in_bulk(pks)
+
+    def _fill_cache(self, start, end, **kwargs):
+        # Tell the query where to start from and how many we'd like.
+        self.query._reset()
+        self.query.set_limits(start, end)
+        results = self.query.get_results(**kwargs)
+
+        if start is None:
+            start = 0
+
+        if results is None or len(results) == 0:
+            # trim missing stuff from the result cache
+            self._result_cache = self._result_cache[:start]
+            return False
+
+        # Setup the full cache now that we know how many results there are.
+        # We need the ``None``s as placeholders to know what parts of the
+        # cache we have/haven't filled.
+        # Using ``None`` like this takes up very little memory. In testing,
+        # an array of 100,000 ``None``s consumed less than .5 Mb, which ought
+        # to be an acceptable loss for consistent and more efficient caching.
+        if len(self._result_cache) == 0:
+            self._result_cache = [None] * self.query.get_count()
+
+        fill_start, fill_end = start, end
+        if fill_end is None:
+            fill_end = self.query.get_count()
+        cache_start = fill_start
+
+        stop = False
+        while not stop:
+            # Check if we wish to load all objects.
+            if self._load_all:
+                models_pks = {}
+                loaded_objects = {}
+
+                # Remember the search position for each result so we don't have to resort later.
+                for result in results:
+                    models_pks.setdefault(result.model, []).append(result.pk)
+
+                # Load the objects for each model in turn.
+                for model in models_pks:
+                    loaded_objects[model] = self._load_model_objects(model, models_pks[model])
+
+            to_cache = []
+
+            for result in results:
+                if self._load_all:
+                    # We have to deal with integer keys being cast from strings
+                    model_objects = loaded_objects.get(result.model, {})
+                    if result.pk not in model_objects:
+                        try:
+                            result.pk = int(result.pk)
+                        except ValueError:
+                            pass
+                    try:
+                        result._object = model_objects[result.pk]
+                    except KeyError:
+                        # The object was either deleted since we indexed or should
+                        # be ignored; fail silently.
+                        self._ignored_result_count += 1
+
+                        # avoid an unfilled None at the end of the result cache
+                        self._result_cache.pop()
+                        continue
+
+                to_cache.append(result)
+
+            # Assign by slice.
+            self._result_cache[cache_start:cache_start + len(to_cache)] = to_cache
+
+            if None in self._result_cache[start:end]:
+                fill_start = fill_end
+                fill_end += ITERATOR_LOAD_PER_QUERY
+                cache_start += len(to_cache)
+
+                # Tell the query where to start from and how many we'd like.
+                self.query._reset()
+                self.query.set_limits(fill_start, fill_end)
+                results = self.query.get_results()
+
+                if results == None or len(results) == 0:
+                    # trim missing stuff from the result cache
+                    self._result_cache = self._result_cache[:cache_start]
+                    break
+
+            else:
+                break
+
+        return True
 
     def __getitem__(self, k):
         """
@@ -675,10 +746,6 @@ class ValuesSearchQuerySet(ValuesListSearchQuerySet):
 class RelatedSearchQuerySet(SearchQuerySet):
     """
     A variant of the SearchQuerySet that can handle `load_all_queryset`s.
-
-    This is predominantly different in the `_fill_cache` method, as it is
-    far less efficient but needs to fill the cache before it to maintain
-    consistency.
     """
 
     def __init__(self, *args, **kwargs):
@@ -686,140 +753,23 @@ class RelatedSearchQuerySet(SearchQuerySet):
         self._load_all_querysets = {}
         self._result_cache = []
 
-    def _cache_is_full(self):
-        return len(self._result_cache) >= len(self)
-
-    def _manual_iter(self):
-        # If we're here, our cache isn't fully populated.
-        # For efficiency, fill the cache as we go if we run out of results.
-        # Also, this can't be part of the __iter__ method due to Python's rules
-        # about generator functions.
-        current_position = 0
-        current_cache_max = 0
-
-        while True:
-            current_cache_max = len(self._result_cache)
-
-            while current_position < current_cache_max:
-                yield self._result_cache[current_position]
-                current_position += 1
-
-            if self._cache_is_full():
-                raise StopIteration
-
-            # We've run out of results and haven't hit our limit.
-            # Fill more of the cache.
-            start = current_position + self._ignored_result_count
-
-            if not self._fill_cache(start, start + ITERATOR_LOAD_PER_QUERY):
-                raise StopIteration
-
-    def _fill_cache(self, start, end):
-        # Tell the query where to start from and how many we'd like.
-        self.query._reset()
-        self.query.set_limits(start, end)
-        results = self.query.get_results()
-
-        if len(results) == 0:
-            return False
-
-        if start is None:
-            start = 0
-
-        if end is None:
-            end = self.query.get_count()
-
-        # Check if we wish to load all objects.
-        if self._load_all:
-            models_pks = {}
-            loaded_objects = {}
-
-            # Remember the search position for each result so we don't have to resort later.
-            for result in results:
-                models_pks.setdefault(result.model, []).append(result.pk)
-
-            # Load the objects for each model in turn.
-            for model in models_pks:
-                if model in self._load_all_querysets:
-                    # Use the overriding queryset.
-                    loaded_objects[model] = self._load_all_querysets[model].in_bulk(models_pks[model])
-                else:
-                    # Check the SearchIndex for the model for an override.
-                    try:
-                        index = connections[self.query._using].get_unified_index().get_index(model)
-                        qs = index.load_all_queryset()
-                        loaded_objects[model] = qs.in_bulk(models_pks[model])
-                    except NotHandled:
-                        # The model returned doesn't seem to be handled by the
-                        # routers. We should silently fail and populate
-                        # nothing for those objects.
-                        loaded_objects[model] = []
-
-        if len(results) + len(self._result_cache) < len(self) and len(results) < ITERATOR_LOAD_PER_QUERY:
-            self._ignored_result_count += ITERATOR_LOAD_PER_QUERY - len(results)
-
-        for result in results:
-            if self._load_all:
-                # We have to deal with integer keys being cast from strings; if this
-                # fails we've got a character pk.
-                try:
-                    result.pk = int(result.pk)
-                except ValueError:
-                    pass
-                try:
-                    result._object = loaded_objects[result.model][result.pk]
-                except (KeyError, IndexError):
-                    # The object was either deleted since we indexed or should
-                    # be ignored; fail silently.
-                    self._ignored_result_count += 1
-                    continue
-
-            self._result_cache.append(result)
-
-        return True
-
-    def __getitem__(self, k):
-        """
-        Retrieves an item or slice from the set of results.
-        """
-        if not isinstance(k, (slice, six.integer_types)):
-            raise TypeError
-
-        assert ((not isinstance(k, slice) and (k >= 0))
-                or (isinstance(k, slice) and (k.start is None or k.start >= 0)
-                    and (k.stop is None or k.stop >= 0))), \
-                "Negative indexing is not supported."
-
-        # Remember if it's a slice or not. We're going to treat everything as
-        # a slice to simply the logic and will `.pop()` at the end as needed.
-        if isinstance(k, slice):
-            is_slice = True
-            start = k.start
-
-            if k.stop is not None:
-                bound = int(k.stop)
-            else:
-                bound = None
+    def _load_model_objects(self, model, pks):
+        if model in self._load_all_querysets:
+            # Use the overriding queryset.
+            return self._load_all_querysets[model].in_bulk(pks)
         else:
-            is_slice = False
-            start = k
-            bound = k + 1
+            # Check the SearchIndex for the model for an override.
 
-        # We need check to see if we need to populate more of the cache.
-        if len(self._result_cache) <= 0 or not self._cache_is_full():
             try:
-                while len(self._result_cache) < bound and not self._cache_is_full():
-                    current_max = len(self._result_cache) + self._ignored_result_count
-                    self._fill_cache(current_max, current_max + ITERATOR_LOAD_PER_QUERY)
-            except StopIteration:
-                # There's nothing left, even though the bound is higher.
-                pass
-
-        # Cache should be full enough for our needs.
-        if is_slice:
-            return self._result_cache[start:bound]
-        else:
-            return self._result_cache[start]
+                ui = connections[self.query._using].get_unified_index()
+                index = ui.get_index(model)
+                qs = index.load_all_queryset()
+                return qs.in_bulk(pks)
+            except NotHandled:
+                # The model returned doesn't seem to be handled by the
+                # routers. We should silently fail and populate
+                # nothing for those objects.
+                return {}
 
     def load_all_queryset(self, model, queryset):
         """
@@ -834,11 +784,6 @@ class RelatedSearchQuerySet(SearchQuerySet):
         return clone
 
     def _clone(self, klass=None):
-        if klass is None:
-            klass = self.__class__
-
-        query = self.query._clone()
-        clone = klass(query=query)
-        clone._load_all = self._load_all
+        clone = super(RelatedSearchQuerySet, self)._clone(klass=klass)
         clone._load_all_querysets = self._load_all_querysets
         return clone

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -895,26 +895,26 @@ class LiveElasticsearchSearchQuerySetTestCase(TestCase):
         sqs = self.rsqs.all()
         results = set([int(result.pk) for result in sqs])
         self.assertEqual(results, set([2, 7, 12, 17, 1, 6, 11, 16, 23, 5, 10, 15, 22, 4, 9, 14, 19, 21, 3, 8, 13, 18, 20]))
-        self.assertEqual(len(connections['elasticsearch'].queries), 4)
+        self.assertEqual(len(connections['elasticsearch'].queries), 3)
 
     def test_related_slice(self):
         reset_search_queries()
         self.assertEqual(len(connections['elasticsearch'].queries), 0)
         results = self.rsqs.all().order_by('pub_date')
         self.assertEqual([int(result.pk) for result in results[1:11]], [3, 2, 4, 5, 6, 7, 8, 9, 10, 11])
-        self.assertEqual(len(connections['elasticsearch'].queries), 3)
+        self.assertEqual(len(connections['elasticsearch'].queries), 1)
 
         reset_search_queries()
         self.assertEqual(len(connections['elasticsearch'].queries), 0)
         results = self.rsqs.all().order_by('pub_date')
         self.assertEqual(int(results[21].pk), 22)
-        self.assertEqual(len(connections['elasticsearch'].queries), 4)
+        self.assertEqual(len(connections['elasticsearch'].queries), 1)
 
         reset_search_queries()
         self.assertEqual(len(connections['elasticsearch'].queries), 0)
         results = self.rsqs.all().order_by('pub_date')
         self.assertEqual(set([int(result.pk) for result in results[20:30]]), set([21, 22, 23]))
-        self.assertEqual(len(connections['elasticsearch'].queries), 4)
+        self.assertEqual(len(connections['elasticsearch'].queries), 1)
 
     def test_related_manual_iter(self):
         results = self.rsqs.all()
@@ -923,7 +923,7 @@ class LiveElasticsearchSearchQuerySetTestCase(TestCase):
         self.assertEqual(len(connections['elasticsearch'].queries), 0)
         results = sorted([int(result.pk) for result in results._manual_iter()])
         self.assertEqual(results, list(range(1, 24)))
-        self.assertEqual(len(connections['elasticsearch'].queries), 4)
+        self.assertEqual(len(connections['elasticsearch'].queries), 3)
 
     def test_related_fill_cache(self):
         reset_search_queries()
@@ -945,7 +945,7 @@ class LiveElasticsearchSearchQuerySetTestCase(TestCase):
         results = self.rsqs.all()
         fire_the_iterator_and_fill_cache = [result for result in results]
         self.assertEqual(results._cache_is_full(), True)
-        self.assertEqual(len(connections['elasticsearch'].queries), 5)
+        self.assertEqual(len(connections['elasticsearch'].queries), 3)
 
     def test_quotes_regression(self):
         sqs = self.sqs.auto_query(u"44°48'40''N 20°28'32''E")

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -1027,35 +1027,34 @@ class LiveSolrSearchQuerySetTestCase(TestCase):
         sqs = self.rsqs.all()
         results = [int(result.pk) for result in sqs]
         self.assertEqual(results, list(range(1, 24)))
-        self.assertEqual(len(connections['solr'].queries), 4)
+        self.assertEqual(len(connections['solr'].queries), 3)
 
     def test_related_slice(self):
         reset_search_queries()
         self.assertEqual(len(connections['solr'].queries), 0)
         results = self.rsqs.all()
         self.assertEqual([int(result.pk) for result in results[1:11]], [2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
-        self.assertEqual(len(connections['solr'].queries), 3)
+        self.assertEqual(len(connections['solr'].queries), 1)
 
         reset_search_queries()
         self.assertEqual(len(connections['solr'].queries), 0)
         results = self.rsqs.all()
         self.assertEqual(int(results[21].pk), 22)
-        self.assertEqual(len(connections['solr'].queries), 4)
+        self.assertEqual(len(connections['solr'].queries), 1)
 
         reset_search_queries()
         self.assertEqual(len(connections['solr'].queries), 0)
         results = self.rsqs.all()
         self.assertEqual([int(result.pk) for result in results[20:30]], [21, 22, 23])
-        self.assertEqual(len(connections['solr'].queries), 4)
+        self.assertEqual(len(connections['solr'].queries), 1)
 
     def test_related_manual_iter(self):
         results = self.rsqs.all()
-
         reset_search_queries()
         self.assertEqual(len(connections['solr'].queries), 0)
         results = [int(result.pk) for result in results._manual_iter()]
         self.assertEqual(results, list(range(1, 24)))
-        self.assertEqual(len(connections['solr'].queries), 4)
+        self.assertEqual(len(connections['solr'].queries), 3)
 
     def test_related_fill_cache(self):
         reset_search_queries()
@@ -1077,7 +1076,7 @@ class LiveSolrSearchQuerySetTestCase(TestCase):
         results = self.rsqs.all()
         fire_the_iterator_and_fill_cache = [result for result in results]
         self.assertEqual(results._cache_is_full(), True)
-        self.assertEqual(len(connections['solr'].queries), 5)
+        self.assertEqual(len(connections['solr'].queries), 3)
 
     def test_quotes_regression(self):
         sqs = self.sqs.auto_query(u"44°48'40''N 20°28'32''E")

--- a/test_haystack/test_query.py
+++ b/test_haystack/test_query.py
@@ -413,43 +413,6 @@ class SearchQuerySetTestCase(TestCase):
 
         connections['default']._index = old_ui
 
-    def test_fill_cache(self):
-        reset_search_queries()
-        self.assertEqual(len(connections['default'].queries), 0)
-        results = self.msqs.all()
-        self.assertEqual(len(results._result_cache), 0)
-        self.assertEqual(len(connections['default'].queries), 0)
-        results._fill_cache(0, 10)
-        self.assertEqual(len([result for result in results._result_cache if result is not None]), 10)
-        self.assertEqual(len(connections['default'].queries), 1)
-        results._fill_cache(10, 20)
-        self.assertEqual(len([result for result in results._result_cache if result is not None]), 20)
-        self.assertEqual(len(connections['default'].queries), 2)
-
-        reset_search_queries()
-        self.assertEqual(len(connections['default'].queries), 0)
-
-        # Test to ensure we properly fill the cache, even if we get fewer
-        # results back (not a handled model) than the hit count indicates.
-        sqs = SearchQuerySet().all()
-        sqs.query.backend = MixedMockSearchBackend('default')
-        results = sqs
-        self.assertEqual(len([result for result in results._result_cache if result is not None]), 0)
-        self.assertEqual([int(result.pk) for result in results._result_cache if result is not None], [])
-        self.assertEqual(len(connections['default'].queries), 0)
-        results._fill_cache(0, 10)
-        self.assertEqual(len([result for result in results._result_cache if result is not None]), 9)
-        self.assertEqual([int(result.pk) for result in results._result_cache if result is not None], [1, 2, 3, 4, 5, 6, 7, 8, 10])
-        self.assertEqual(len(connections['default'].queries), 2)
-        results._fill_cache(10, 20)
-        self.assertEqual(len([result for result in results._result_cache if result is not None]), 17)
-        self.assertEqual([int(result.pk) for result in results._result_cache if result is not None], [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 15, 16, 17, 18, 19, 20])
-        self.assertEqual(len(connections['default'].queries), 4)
-        results._fill_cache(20, 30)
-        self.assertEqual(len([result for result in results._result_cache if result is not None]), 20)
-        self.assertEqual([int(result.pk) for result in results._result_cache if result is not None], [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21, 22, 23])
-        self.assertEqual(len(connections['default'].queries), 6)
-
     def test_cache_is_full(self):
         reset_search_queries()
         self.assertEqual(len(connections['default'].queries), 0)


### PR DESCRIPTION
Now to get to `?page=100`, you don't have to iterate all 100 pages from the backend. Also removes a lot of duplicate code from RelatedSearchQuerySet.

Fixes #370.

replaces #960, which was my previous attempt at solving this but it's ancient now and I never bothered to get all the tests passing (and there were a couple of bugs.)

I've removed the `_fill_cache` test because I couldn't see a way to get it working, and no code actually calls `_fill_cache` in the manner the test does, so it seemed a bit irrelevant. Plus it's called by methods that are covered by other tests anyway.

One thing - if you're using a `load_all_queryset` and some of the results from the search backend are not in the `load_all_queryset`, some of the results at page 100 may end up being the same as those at page 99. That's because the page 99 will skip those results and fill the gaps by loading some more instead (and they'll be the same ones that page 100 will load). If you have a _lot_ of this happening, you'll probably notice a lot of dupe results.

However, IMHO it beats the previous behaviour of never actually loading page 100 (because RelatedSearchQuerySet spent ages iterating 100 pages of results first, eventually causing a page timeout.)