### PR TITLE
Use compatible get_model util to support new django versions

### DIFF
--- a/haystack/forms.py
+++ b/haystack/forms.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django import forms
-from django.db import models
 from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 
@@ -11,6 +10,7 @@ from haystack import connections
 from haystack.constants import DEFAULT_ALIAS
 from haystack.query import EmptySearchQuerySet, SearchQuerySet
 from haystack.utils import get_model_ct
+from haystack.utils.app_loading import haystack_get_model
 
 try:
     from django.utils.encoding import smart_text
@@ -107,7 +107,7 @@ class ModelSearchForm(SearchForm):
 
         if self.is_valid():
             for model in self.cleaned_data['models']:
-                search_models.append(models.get_model(*model.split('.')))
+                search_models.append(haystack_get_model(*model.split('.')))
 
         return search_models
 

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import models
 from django.utils import six
 from django.utils.text import capfirst
 

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -11,6 +11,7 @@ from django.utils.text import capfirst
 
 from haystack.exceptions import NotHandled, SpatialError
 from haystack.utils import log as logging
+from haystack.utils.app_loading import haystack_get_model
 
 try:
     from django.utils.encoding import force_text
@@ -100,7 +101,7 @@ class SearchResult(object):
     def _get_model(self):
         if self._model is None:
             try:
-                self._model = models.get_model(self.app_label, self.model_name)
+                self._model = haystack_get_model(self.app_label, self.model_name)
             except LookupError:
                 # this changed in change 1.7 to throw an error instead of
                 # returning None when the model isn't found. So catch the

--- a/haystack/templatetags/more_like_this.py
+++ b/haystack/templatetags/more_like_this.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django import template
-from django.db import models
+from haystack.utils.app_loading import haystack_get_model
 
 from haystack.query import SearchQuerySet
 
@@ -31,7 +31,7 @@ class MoreLikeThisNode(template.Node):
                 search_models = []
 
                 for model in for_types:
-                    model_class = models.get_model(*model.split('.'))
+                    model_class = haystack_get_model(*model.split('.'))
 
                     if model_class:
                         search_models.append(model_class)


### PR DESCRIPTION
For the Django 1.9 version it fails to load the model property in the Result Class, this due`model.get_model` is deprecated in favor of the new `app.get_model`.

As django-haystack already haves a compat method to load model classes I'm just reusing this.