### PR TITLE
Add python 3.5 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 2.7
     - 3.3
     - 3.4
+    - 3.5
     - pypy
 
 cache:
@@ -55,6 +56,10 @@ matrix:
          env: DJANGO_VERSION=">=1.7,<1.8"
        - python: 2.6
          env: DJANGO_VERSION=">=1.8,<1.9"
+       - python: 3.5
+         env: DJANGO_VERSION=">=1.6,<1.7"
+       - python: 3.5
+         env: DJANGO_VERSION=">=1.7,<1.8"
 
 services:
     - elasticsearch

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist = docs,
         py34-django1.6,
         py34-django1.7,
         py34-django1.8,
+        py35-django1.8,
         pypy-django1.6,
         pypy-django1.7,
         pypy-django1.8,
@@ -98,6 +99,12 @@ deps =
 
 [testenv:py34-django1.8]
 basepython = python3.4
+deps =
+    {[django1.8]deps}
+    {[base]deps}
+
+[testenv:py35-django1.8]
+basepython = python3.5
 deps =
     {[django1.8]deps}
     {[base]deps}


### PR DESCRIPTION
Django 1.8 supports python 3.5
see: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django