### PR TITLE
import connection_router in SearchQuerySet's method rather in header

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -41,7 +41,7 @@ class SearchQuerySet(object):
         self.log = logging.getLogger('haystack')
 
     def _determine_backend(self):
-        from haystack import connections
+        from haystack import connections, connection_router
         # A backend has been manually selected. Use it instead.
         if self._using is not None:
             self.query = connections[self._using].get_query()


### PR DESCRIPTION
import connection_router in SearchQuerySet's method rather in header fix a bug when we use a specific router (if not haystack will use the default router)