### PR TITLE
Load routers lazily (fixes #1034)

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -43,14 +43,13 @@ if DEFAULT_ALIAS not in settings.HAYSTACK_CONNECTIONS:
 # Load the connections.
 connections = loading.ConnectionHandler(settings.HAYSTACK_CONNECTIONS)
 
-# Load the router(s).
-connection_router = loading.ConnectionRouter()
-
+# Just check HAYSTACK_ROUTERS setting validity, routers will be loaded lazily
 if hasattr(settings, 'HAYSTACK_ROUTERS'):
     if not isinstance(settings.HAYSTACK_ROUTERS, (list, tuple)):
         raise ImproperlyConfigured("The HAYSTACK_ROUTERS setting must be either a list or tuple.")
 
-    connection_router = loading.ConnectionRouter(settings.HAYSTACK_ROUTERS)
+# Load the router(s).
+connection_router = loading.ConnectionRouter()
 
 # Setup the signal processor.
 signal_processor_path = getattr(settings, 'HAYSTACK_SIGNAL_PROCESSOR', 'haystack.signals.BaseSignalProcessor')

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -7,7 +7,7 @@ import warnings
 
 from django.utils import six
 
-from haystack import connection_router, connections
+from haystack import connections
 from haystack.backends import SQ
 from haystack.constants import DEFAULT_OPERATOR, ITERATOR_LOAD_PER_QUERY, REPR_OUTPUT_SIZE
 from haystack.exceptions import NotHandled
@@ -41,7 +41,8 @@ class SearchQuerySet(object):
         self.log = logging.getLogger('haystack')
 
     def _determine_backend(self):
-        from haystack import connections
+        from haystack import connection_router, connections
+
         # A backend has been manually selected. Use it instead.
         if self._using is not None:
             self.query = connections[self._using].get_query()

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -125,16 +125,17 @@ class ConnectionHandler(object):
 
 
 class ConnectionRouter(object):
-    def __init__(self, routers_list=None):
-        self.routers_list = routers_list
-        self.routers = []
+    @property
+    def routers(self):
+        if not hasattr(self, '_routers'):
+            default_routers = ['haystack.routers.DefaultRouter']
+            router_list = getattr(settings, 'HAYSTACK_ROUTERS', default_routers)
 
-        if self.routers_list is None:
-            self.routers_list = ['haystack.routers.DefaultRouter']
-
-        for router_path in self.routers_list:
-            router_class = load_router(router_path)
-            self.routers.append(router_class())
+            self._routers = []
+            for router_path in router_list:
+                router_class = load_router(router_path)
+                self._routers.append(router_class())
+        return self._routers
 
     def for_action(self, action, **hints):
         conns = []

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -125,9 +125,12 @@ class ConnectionHandler(object):
 
 
 class ConnectionRouter(object):
+    def __init__(self):
+        self._routers = None
+
     @property
     def routers(self):
-        if not hasattr(self, '_routers'):
+        if self._routers is None:
             default_routers = ['haystack.routers.DefaultRouter']
             router_list = getattr(settings, 'HAYSTACK_ROUTERS', default_routers)
             # in case HAYSTACK_ROUTERS is empty, fallback to default routers

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -130,6 +130,9 @@ class ConnectionRouter(object):
         if not hasattr(self, '_routers'):
             default_routers = ['haystack.routers.DefaultRouter']
             router_list = getattr(settings, 'HAYSTACK_ROUTERS', default_routers)
+            # in case HAYSTACK_ROUTERS is empty, fallback to default routers
+            if not len(router_list):
+                router_list = default_routers
 
             self._routers = []
             for router_path in router_list:

--- a/test_haystack/test_loading.py
+++ b/test_haystack/test_loading.py
@@ -97,6 +97,11 @@ class ConnectionRouterTestCase(TestCase):
         cr = loading.ConnectionRouter()
         self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'haystack.routers.DefaultRouter'>"])
 
+    @override_settings(HAYSTACK_ROUTERS=[])
+    def test_router_override1(self):
+        cr = loading.ConnectionRouter()
+        self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'haystack.routers.DefaultRouter'>"])
+
     @override_settings(HAYSTACK_ROUTERS=['test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
     def test_router_override2(self):
         cr = loading.ConnectionRouter()

--- a/test_haystack/test_loading.py
+++ b/test_haystack/test_loading.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from test_haystack.core.models import AnotherMockModel, MockModel
@@ -88,7 +89,9 @@ class ConnectionHandlerTestCase(TestCase):
 
 
 class ConnectionRouterTestCase(TestCase):
+    @override_settings()
     def test_init(self):
+        del settings.HAYSTACK_ROUTERS
         cr = loading.ConnectionRouter()
         self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'haystack.routers.DefaultRouter'>"])
 
@@ -107,7 +110,9 @@ class ConnectionRouterTestCase(TestCase):
         cr = loading.ConnectionRouter()
         self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'test_haystack.mocks.MockMasterSlaveRouter'>", "<class 'haystack.routers.DefaultRouter'>"])
 
+    @override_settings()
     def test_actions1(self):
+        del settings.HAYSTACK_ROUTERS
         cr = loading.ConnectionRouter()
         self.assertEqual(cr.for_read(), ['default'])
         self.assertEqual(cr.for_write(), ['default'])

--- a/test_haystack/test_loading.py
+++ b/test_haystack/test_loading.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.core.exceptions import ImproperlyConfigured
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from test_haystack.core.models import AnotherMockModel, MockModel
 from test_haystack.utils import unittest
 
@@ -90,15 +90,16 @@ class ConnectionHandlerTestCase(TestCase):
 class ConnectionRouterTestCase(TestCase):
     def test_init(self):
         cr = loading.ConnectionRouter()
-        self.assertEqual(cr.routers_list, ['haystack.routers.DefaultRouter'])
         self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'haystack.routers.DefaultRouter'>"])
 
-        cr = loading.ConnectionRouter(routers_list=['haystack.routers.DefaultRouter'])
-        self.assertEqual(cr.routers_list, ['haystack.routers.DefaultRouter'])
+    @override_settings(HAYSTACK_ROUTERS=['haystack.routers.DefaultRouter'])
+    def test_router_override1(self):
+        cr = loading.ConnectionRouter()
         self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'haystack.routers.DefaultRouter'>"])
 
-        cr = loading.ConnectionRouter(routers_list=['test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
-        self.assertEqual(cr.routers_list, ['test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
+    @override_settings(HAYSTACK_ROUTERS=['test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
+    def test_router_override2(self):
+        cr = loading.ConnectionRouter()
         self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'test_haystack.mocks.MockMasterSlaveRouter'>", "<class 'haystack.routers.DefaultRouter'>"])
 
     def test_for_read(self):

--- a/test_haystack/test_loading.py
+++ b/test_haystack/test_loading.py
@@ -98,43 +98,34 @@ class ConnectionRouterTestCase(TestCase):
         self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'haystack.routers.DefaultRouter'>"])
 
     @override_settings(HAYSTACK_ROUTERS=[])
-    def test_router_override1(self):
+    def test_router_override2(self):
         cr = loading.ConnectionRouter()
         self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'haystack.routers.DefaultRouter'>"])
 
     @override_settings(HAYSTACK_ROUTERS=['test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
-    def test_router_override2(self):
+    def test_router_override3(self):
         cr = loading.ConnectionRouter()
         self.assertEqual([str(route.__class__) for route in cr.routers], ["<class 'test_haystack.mocks.MockMasterSlaveRouter'>", "<class 'haystack.routers.DefaultRouter'>"])
 
-    def test_for_read(self):
+    def test_actions1(self):
         cr = loading.ConnectionRouter()
         self.assertEqual(cr.for_read(), ['default'])
-
-        cr = loading.ConnectionRouter(routers_list=['test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
-        self.assertEqual(cr.for_read(), ['slave', 'default'])
-
-        # Demonstrate pass-through.
-        cr = loading.ConnectionRouter(routers_list=['test_haystack.mocks.MockPassthroughRouter', 'test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
-        self.assertEqual(cr.for_read(), ['slave', 'default'])
-
-        # Demonstrate that hinting can change routing.
-        cr = loading.ConnectionRouter(routers_list=['test_haystack.mocks.MockPassthroughRouter', 'test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
-        self.assertEqual(cr.for_read(pass_through=False), ['pass', 'slave', 'default'])
-
-    def test_for_write(self):
-        cr = loading.ConnectionRouter()
         self.assertEqual(cr.for_write(), ['default'])
 
-        cr = loading.ConnectionRouter(routers_list=['test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
+    @override_settings(HAYSTACK_ROUTERS=['test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
+    def test_actions2(self):
+        cr = loading.ConnectionRouter()
+        self.assertEqual(cr.for_read(), ['slave', 'default'])
         self.assertEqual(cr.for_write(), ['master', 'default'])
 
-        # Demonstrate pass-through.
-        cr = loading.ConnectionRouter(routers_list=['test_haystack.mocks.MockPassthroughRouter', 'test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
+    @override_settings(HAYSTACK_ROUTERS=['test_haystack.mocks.MockPassthroughRouter', 'test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
+    def test_actions3(self):
+        cr = loading.ConnectionRouter()
+        # Demonstrate pass-through
+        self.assertEqual(cr.for_read(), ['slave', 'default'])
         self.assertEqual(cr.for_write(), ['master', 'default'])
-
         # Demonstrate that hinting can change routing.
-        cr = loading.ConnectionRouter(routers_list=['test_haystack.mocks.MockPassthroughRouter', 'test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
+        self.assertEqual(cr.for_read(pass_through=False), ['pass', 'slave', 'default'])
         self.assertEqual(cr.for_write(pass_through=False), ['pass', 'master', 'default'])
 
 


### PR DESCRIPTION
This moves connection_router import in ```SearchQuerySet``` to ```_determine_backend``` (makes it local import) which already fixes the problem. But to make it fail-proof, router loading is now lazy. **HAYSTACK_ROUTERS** setting is still checked for validity in **\__init\__.py**