### PR TITLE
Django 19 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
 env:
     matrix:
         - DJANGO_VERSION=">=1.8,<1.9"
+        - DJANGO_VERSION=">=1.9,<1.10"
 
 matrix:
     allow_failures:

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -134,7 +134,7 @@ class SearchField(object):
             template_names = ['search/indexes/%s/%s_%s.txt' % (app_label, model_name, self.instance_name)]
 
         t = loader.select_template(template_names)
-        return t.render(Context({'object': obj}))
+        return t.render({'object': obj})
 
     def convert(self, value):
         """

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import re
 
-from django.template import Context, loader
+from django.template import loader
 from django.utils import datetime_safe, six
 
 from haystack.exceptions import SearchFieldError

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -15,7 +15,17 @@ class NOT_PROVIDED:
     pass
 
 
-DATETIME_REGEX = re.compile('^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})(T|\s+)(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2}).*?$')
+DATETIME_REGEX = re.compile('''
+^
+(?P<year>\d{4})-
+(?P<month>\d{2})-
+(?P<day>\d{2})
+(T|\s+)              # Time flag or an space
+(?P<hour>\d{2}):
+(?P<minute>\d{2}):
+(?P<second>\d{2}).*?
+$
+''', flags=re.VERBOSE)
 
 if DJANGO_VERSION >= (1, 8):
     def make_context(context):

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -22,8 +22,10 @@ if DJANGO_VERSION >= (1, 8):
         return context
 else:
     from django.template.context import Context
+
     def make_context(context):
         return Context(context)
+
 
 # All the SearchFields variants.
 

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import re
 
+from django import VERSION as DJANGO_VERSION
 from django.template import loader
 from django.utils import datetime_safe, six
 
@@ -16,6 +17,13 @@ class NOT_PROVIDED:
 
 DATETIME_REGEX = re.compile('^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})(T|\s+)(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2}).*?$')
 
+if DJANGO_VERSION >= (1, 8):
+    def make_context(context):
+        return context
+else:
+    from django.template.context import Context
+    def make_context(context):
+        return Context(context)
 
 # All the SearchFields variants.
 
@@ -134,7 +142,7 @@ class SearchField(object):
             template_names = ['search/indexes/%s/%s_%s.txt' % (app_label, model_name, self.instance_name)]
 
         t = loader.select_template(template_names)
-        return t.render({'object': obj})
+        return t.render(make_context({'object': obj}))
 
     def convert(self, value):
         """

--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -1,27 +1,25 @@
 # encoding: utf-8
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 from optparse import make_option
-
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 from django.template import Context, loader
-
 from haystack import constants
 from haystack.backends.solr_backend import SolrSearchBackend
 
 
 class Command(BaseCommand):
     help = "Generates a Solr schema that reflects the indexes."
-    base_options = (
-        make_option("-f", "--filename", action="store", type="string", dest="filename",
-                    help='If provided, directs output to a file instead of stdout.'),
-        make_option("-u", "--using", action="store", type="string", dest="using", default=constants.DEFAULT_ALIAS,
-                    help='If provided, chooses a connection to work with.'),
-    )
-    option_list = BaseCommand.option_list + base_options
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-f", "--filename", action="store", type="string", dest="filename",
+            help='If provided, directs output to a file instead of stdout.')
+        parser.add_argument(
+            "-u", "--using", action="store", type="string", dest="using", default=constants.DEFAULT_ALIAS,
+            help='If provided, chooses a connection to work with.')
 
     def handle(self, **options):
         """Generates a Solr schema that reflects the indexes."""

--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-import sys
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 from django.template import Context, loader
@@ -53,13 +52,13 @@ class Command(BaseCommand):
         return t.render(c)
 
     def print_stdout(self, schema_xml):
-        sys.stderr.write("\n")
-        sys.stderr.write("\n")
-        sys.stderr.write("\n")
-        sys.stderr.write("Save the following output to 'schema.xml' and place it in your Solr configuration directory.\n")
-        sys.stderr.write("--------------------------------------------------------------------------------------------\n")
-        sys.stderr.write("\n")
-        print(schema_xml)
+        self.stderr.write("\n")
+        self.stderr.write("\n")
+        self.stderr.write("\n")
+        self.stderr.write("Save the following output to 'schema.xml' and place it in your Solr configuration directory.\n")
+        self.stderr.write("--------------------------------------------------------------------------------------------\n")
+        self.stderr.write("\n")
+        self.stdout.write(schema_xml)
 
     def write_file(self, filename, schema_xml):
         schema_file = open(filename, 'w')

--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
-from optparse import make_option
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 from django.template import Context, loader

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
-from optparse import make_option
 from django.core.management.base import BaseCommand
 from django.utils import six
 

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -1,30 +1,30 @@
 # encoding: utf-8
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 from optparse import make_option
-
 from django.core.management.base import BaseCommand
 from django.utils import six
 
 
 class Command(BaseCommand):
     help = "Clears out the search index completely."
-    base_options = (
-        make_option('--noinput', action='store_false', dest='interactive', default=True,
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--noinput', action='store_false', dest='interactive', default=True,
             help='If provided, no prompts will be issued to the user and the data will be wiped out.'
-        ),
-        make_option("-u", "--using", action="append", dest="using",
+        )
+        parser.add_argument(
+            "-u", "--using", action="append", dest="using",
             default=[],
             help='Update only the named backend (can be used multiple times). '
                  'By default all backends will be updated.'
-        ),
-        make_option('--nocommit', action='store_false', dest='commit',
+        )
+        parser.add_argument(
+            '--nocommit', action='store_false', dest='commit',
             default=True, help='Will pass commit=False to the backend.'
-        ),
-    )
-    option_list = BaseCommand.option_list + base_options
+        )
 
     def handle(self, **options):
         """Clears out the search index completely."""

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -32,27 +32,29 @@ class Command(BaseCommand):
         self.commit = options.get('commit', True)
 
         using = options.get('using')
+
         if not using:
             using = connections.connections_info.keys()
 
         if options.get('interactive', True):
-            print()
-            print("WARNING: This will irreparably remove EVERYTHING from your search index in connection '%s'." % "', '".join(using))
-            print("Your choices after this are to restore from backups or rebuild via the `rebuild_index` command.")
+            self.stdout.write("WARNING: This will irreparably remove EVERYTHING "
+                              "from your search index in connection '%s'." % "', '".join(using))
+
+            self.stdout.write("Your choices after this are to restore from "
+                              "backups or rebuild via the `rebuild_index` command.")
 
             yes_or_no = six.moves.input("Are you sure you wish to continue? [y/N] ")
-            print
 
             if not yes_or_no.lower().startswith('y'):
-                print("No action taken.")
+                self.stdout.write("No action taken.")
                 sys.exit()
 
         if self.verbosity >= 1:
-            print("Removing all documents from your index because you said so.")
+            self.stdout.write("Removing all documents from your index because you said so.")
 
         for backend_name in using:
             backend = connections[backend_name].get_backend()
             backend.clear(commit=self.commit)
 
         if self.verbosity >= 1:
-            print("All documents removed.")
+            self.stdout.write("All documents removed.")

--- a/haystack/management/commands/haystack_info.py
+++ b/haystack/management/commands/haystack_info.py
@@ -1,20 +1,20 @@
 # encoding: utf-8
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+from django.core.management.base import BaseCommand
 
-from django.core.management.base import NoArgsCommand
 
-
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Provides feedback about the current Haystack setup."
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         """Provides feedback about the current Haystack setup."""
         from haystack import connections
 
         unified_index = connections['default'].get_unified_index()
         indexed = unified_index.get_indexed_models()
         index_count = len(indexed)
+
         print("Number of handled %s index(es)." % index_count)
 
         for index in indexed:

--- a/haystack/management/commands/rebuild_index.py
+++ b/haystack/management/commands/rebuild_index.py
@@ -3,8 +3,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
-from haystack.management.commands.clear_index import Command as ClearCommand
-from haystack.management.commands.update_index import Command as UpdateCommand
 
 __all__ = ['Command']
 

--- a/haystack/management/commands/rebuild_index.py
+++ b/haystack/management/commands/rebuild_index.py
@@ -1,25 +1,37 @@
 # encoding: utf-8
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
-
 from haystack.management.commands.clear_index import Command as ClearCommand
 from haystack.management.commands.update_index import Command as UpdateCommand
 
 __all__ = ['Command']
 
-_combined_options = list(BaseCommand.option_list)
-_combined_options.extend(option for option in UpdateCommand.base_options
-                         if option.get_opt_string() not in [i.get_opt_string() for i in _combined_options])
-_combined_options.extend(option for option in ClearCommand.base_options
-                         if option.get_opt_string() not in [i.get_opt_string() for i in _combined_options])
-
 
 class Command(BaseCommand):
     help = "Completely rebuilds the search index by removing the old data and then updating."
-    option_list = _combined_options
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--noinput', action='store_false', dest='interactive', default=True,
+            help='If provided, no prompts will be issued to the user and the data will be wiped out.'
+        )
+        parser.add_argument(
+            '-u', '--using', action='append', dest='using',
+            default=[],
+            help='Update only the named backend (can be used multiple times). '
+                 'By default all backends will be updated.'
+        )
+        parser.add_argument(
+            '-k', '--workers', action='store', dest='workers',
+            default=0, type=int,
+            help='Allows for the use multiple workers to parallelize indexing. Requires multiprocessing.'
+        )
+        parser.add_argument(
+            '--nocommit', action='store_false', dest='commit',
+            default=True, help='Will pass commit=False to the backend.'
+        )
 
     def handle(self, **options):
         call_command('clear_index', **options)

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -5,7 +5,6 @@ import os
 import sys
 import warnings
 from datetime import timedelta
-from optparse import make_option
 
 try:
     from django.db import close_old_connections

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 import logging
 import os
 import sys
@@ -14,9 +13,8 @@ except ImportError:
     # This can be removed when we drop support for Django 1.7 and earlier:
     from django.db import close_connection as close_old_connections
 
-from django.core.management.base import LabelCommand
+from django.core.management.base import BaseCommand
 from django.db import reset_queries
-
 from haystack import connections as haystack_connections
 from haystack.query import SearchQuerySet
 from haystack.utils.app_loading import haystack_get_models, haystack_load_apps
@@ -35,8 +33,8 @@ try:
     from django.utils.timezone import now
 except ImportError:
     from datetime import datetime
-    now = datetime.now
 
+    now = datetime.now
 
 DEFAULT_BATCH_SIZE = None
 DEFAULT_AGE = None
@@ -56,7 +54,7 @@ def worker(bits):
             try:
                 close_old_connections()
                 if isinstance(connections._connections, dict):
-                    del(connections._connections[alias])
+                    del (connections._connections[alias])
                 else:
                     delattr(connections._connections, alias)
             except KeyError:
@@ -99,44 +97,56 @@ def do_update(backend, index, qs, start, end, total, verbosity=1, commit=True):
     reset_queries()
 
 
-class Command(LabelCommand):
+class Command(BaseCommand):
     help = "Freshens the index for the given app(s)."
-    base_options = (
-        make_option('-a', '--age', action='store', dest='age',
-            default=DEFAULT_AGE, type='int',
+    label = 'items'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-a', '--age', action='store', dest='age',
+            default=DEFAULT_AGE, type=int,
             help='Number of hours back to consider objects new.'
-        ),
-        make_option('-s', '--start', action='store', dest='start_date',
-            default=None, type='string',
+        )
+        parser.add_argument(
+            '-s', '--start', action='store', dest='start_date',
+            default=None,
             help='The start date for indexing within. Can be any dateutil-parsable string, recommended to be YYYY-MM-DDTHH:MM:SS.'
-        ),
-        make_option('-e', '--end', action='store', dest='end_date',
-            default=None, type='string',
+        )
+        parser.add_argument(
+            '-e', '--end', action='store', dest='end_date',
+            default=None,
             help='The end date for indexing within. Can be any dateutil-parsable string, recommended to be YYYY-MM-DDTHH:MM:SS.'
-        ),
-        make_option('-b', '--batch-size', action='store', dest='batchsize',
-            default=None, type='int',
+        )
+        parser.add_argument(
+            '-b', '--batch-size', action='store', dest='batchsize',
+            default=None, type=int,
             help='Number of items to index at once.'
-        ),
-        make_option('-r', '--remove', action='store_true', dest='remove',
-            default=False, help='Remove objects from the index that are no longer present in the database.'
-        ),
-        make_option("-u", "--using", action="append", dest="using",
+        )
+        parser.add_argument(
+            '-r', '--remove', action='store_true', dest='remove',
+            default=False,
+            help='Remove objects from the index that are no longer present in the database.'
+        )
+        parser.add_argument(
+            '-u', '--using', action='append', dest='using',
             default=[],
             help='Update only the named backend (can be used multiple times). '
                  'By default all backends will be updated.'
-        ),
-        make_option('-k', '--workers', action='store', dest='workers',
-            default=0, type='int',
+        )
+        parser.add_argument(
+            '-k', '--workers', action='store', dest='workers',
+            default=0, type=int,
             help='Allows for the use multiple workers to parallelize indexing. Requires multiprocessing.'
-        ),
-        make_option('--nocommit', action='store_false', dest='commit',
+        )
+        parser.add_argument(
+            '--nocommit', action='store_false', dest='commit',
             default=True, help='Will pass commit=False to the backend.'
-        ),
-    )
-    option_list = LabelCommand.option_list + base_options
+        )
+        parser.add_argument(
+            'app_label', nargs='?',
+            help='App label of an application to update the search index.')
 
-    def handle(self, *items, **options):
+    def handle(self, *args, **options):
         self.verbosity = int(options.get('verbosity', 1))
         self.batchsize = options.get('batchsize', DEFAULT_BATCH_SIZE)
         self.start_date = None
@@ -177,10 +187,15 @@ class Command(LabelCommand):
             except ValueError:
                 pass
 
-        if not items:
-            items = haystack_load_apps()
+        if not args:
+            args = haystack_load_apps()
 
-        return super(Command, self).handle(*items, **options)
+        output = []
+        for label in args:
+            label_output = self.handle_label(label, **options)
+            if label_output:
+                output.append(label_output)
+        return '\n'.join(output)
 
     def handle_label(self, label, **options):
         for using in self.backends:
@@ -232,7 +247,8 @@ class Command(LabelCommand):
                 if self.workers == 0:
                     do_update(backend, index, qs, start, end, total, verbosity=self.verbosity, commit=self.commit)
                 else:
-                    ghetto_queue.append(('do_update', model, start, end, total, using, self.start_date, self.end_date, self.verbosity, self.commit))
+                    ghetto_queue.append(('do_update', model, start, end, total, using, self.start_date, self.end_date,
+                                         self.verbosity, self.commit))
 
             if self.workers > 0:
                 pool = multiprocessing.Pool(self.workers)

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -53,7 +53,7 @@ def worker(bits):
             try:
                 close_old_connections()
                 if isinstance(connections._connections, dict):
-                    del (connections._connections[alias])
+                    del connections._connections[alias]
                 else:
                     delattr(connections._connections, alias)
             except KeyError:

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -601,13 +601,9 @@ class EmptySearchQuerySet(SearchQuerySet):
         return {}
 
 
-class ValuesListSearchQuerySet(SearchQuerySet):
-    """
-    A ``SearchQuerySet`` which returns a list of field values as tuples, exactly
-    like Django's ``ValuesListQuerySet``.
-    """
+class BaseValuesSearchQueryset(SearchQuerySet):
     def __init__(self, *args, **kwargs):
-        super(ValuesListSearchQuerySet, self).__init__(*args, **kwargs)
+        super(BaseValuesSearchQueryset, self).__init__(*args, **kwargs)
         self._flat = False
         self._fields = []
 
@@ -616,19 +612,26 @@ class ValuesListSearchQuerySet(SearchQuerySet):
         # an immediate priority:
         self._internal_fields = ['id', 'django_ct', 'django_id', 'score']
 
-    def _clone(self, klass=None):
-        clone = super(ValuesListSearchQuerySet, self)._clone(klass=klass)
-        clone._fields = self._fields
-        clone._flat = self._flat
-        return clone
-
-    def _fill_cache(self, start, end):
+    def _fill_cache(self, start, end, **kwargs):
         query_fields = set(self._internal_fields)
         query_fields.update(self._fields)
         kwargs = {
             'fields': query_fields
         }
-        return super(ValuesListSearchQuerySet, self)._fill_cache(start, end, **kwargs)
+        return super(BaseValuesSearchQueryset, self)._fill_cache(start, end, **kwargs)
+
+    def _clone(self, klass=None):
+        clone = super(BaseValuesSearchQueryset, self)._clone(klass=klass)
+        clone._fields = self._fields
+        clone._flat = self._flat
+        return clone
+
+
+class ValuesListSearchQuerySet(BaseValuesSearchQueryset):
+    """
+    A ``SearchQuerySet`` which returns a list of field values as tuples, exactly
+    like Django's ``ValuesListQuerySet``.
+    """
 
     def post_process_results(self, results):
         to_cache = []
@@ -644,19 +647,12 @@ class ValuesListSearchQuerySet(SearchQuerySet):
         return to_cache
 
 
-class ValuesSearchQuerySet(ValuesListSearchQuerySet):
+class ValuesSearchQuerySet(BaseValuesSearchQueryset):
     """
     A ``SearchQuerySet`` which returns a list of dictionaries, each containing
     the key/value pairs for the result, exactly like Django's
     ``ValuesQuerySet``.
     """
-    def _fill_cache(self, start, end):
-        query_fields = set(self._internal_fields)
-        query_fields.update(self._fields)
-        kwargs = {
-            'fields': query_fields
-        }
-        return super(ValuesSearchQuerySet, self)._fill_cache(start, end, **kwargs)
 
     def post_process_results(self, results):
         to_cache = []

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -656,7 +656,7 @@ class ValuesSearchQuerySet(ValuesListSearchQuerySet):
         kwargs = {
             'fields': query_fields
         }
-        return super(ValuesListSearchQuerySet, self)._fill_cache(start, end, **kwargs)
+        return super(ValuesSearchQuerySet, self)._fill_cache(start, end, **kwargs)
 
     def post_process_results(self, results):
         to_cache = []

--- a/haystack/urls.py
+++ b/haystack/urls.py
@@ -1,16 +1,13 @@
 # encoding: utf-8
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 from haystack.views import SearchView
 
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
-
-
-urlpatterns = patterns('haystack.views',
+urlpatterns = [
     url(r'^$', SearchView(), name='haystack_search'),
-)
+]

--- a/test_haystack/mocks.py
+++ b/test_haystack/mocks.py
@@ -2,7 +2,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from django.db.models.loading import get_model
+try:
+    from django.db.models.loading import get_model
+except ImportError:
+     from django.apps import apps
+     get_model = apps.get_model
 
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query
 from haystack.models import SearchResult

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,10 @@ envlist = docs,
         py34-django1.8,
         py35-django1.8,
         pypy-django1.8,
+        py27-django1.9,
+        py34-django1.9,
+        py35-django1.9,
+        pypy-django1.9,
 
 [base]
 deps = requests
@@ -11,6 +15,10 @@ deps = requests
 [django1.8]
 deps =
     Django>=1.8,<1.9
+
+[django1.9]
+deps =
+    Django>=1.9,<1.10
 
 [testenv]
 commands =
@@ -38,6 +46,29 @@ deps =
 basepython = python3.5
 deps =
     {[django1.8]deps}
+    {[base]deps}
+
+[testenv:pypy-django1.9]
+deps =
+    {[django1.9]deps}
+    {[base]deps}
+
+[testenv:py27-django1.9]
+basepython = python2.7
+deps =
+    {[django1.9]deps}
+    {[base]deps}
+
+[testenv:py34-django1.9]
+basepython = python3.4
+deps =
+    {[django1.9]deps}
+    {[base]deps}
+
+[testenv:py35-django1.9]
+basepython = python3.5
+deps =
+    {[django1.9]deps}
     {[base]deps}
 
 [testenv:docs]


### PR DESCRIPTION
Django 1.9 support.

Based on #1277 (no news from the author) : 

> Remove django.conf.urls.patterns, since they already have been removed from the doc and will be removed in Django 2.0
> 
> This removes in Django 1.9 the warning:

> RemovedInDjango110Warning: django.conf.urls.patterns()
> is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of
> django.conf.urls.url() instances instead.
>   name='redactor_upload_file'),

> Also Updates the command update_index to match new arguments parser in Django

Fix : 

- #1282
- #1293
- #1291
