### PR TITLE
Allow SearchField objects to set Solr field type

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -458,13 +458,16 @@ class SolrSearchBackend(BaseSearchBackend):
                 field_data['type'] = 'edge_ngram'
             elif field_class.field_type == 'location':
                 field_data['type'] = 'location'
-
+            elif field_class.explicit_field_type:
+                field_data['type'] = field_class.explicit_field_type
+                
             if field_class.is_multivalued:
                 field_data['multi_valued'] = 'true'
 
             if field_class.stored is False:
                 field_data['stored'] = 'false'
-
+            elif field_class.explicit_field_type:
+                field_data['type'] = field_class.explicit_field_type
             # Do this last to override `text` fields.
             if field_class.indexed is False:
                 field_data['indexed'] = 'false'

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -458,8 +458,6 @@ class SolrSearchBackend(BaseSearchBackend):
                 field_data['type'] = 'edge_ngram'
             elif field_class.field_type == 'location':
                 field_data['type'] = 'location'
-            elif field_class.solr_explicit_field_type:
-                field_data['type'] = field_class.solr_explicit_field_type
                 
             if field_class.is_multivalued:
                 field_data['multi_valued'] = 'true'
@@ -481,6 +479,16 @@ class SolrSearchBackend(BaseSearchBackend):
                 if field_data['type'] == 'text_en':
                     field_data['type'] = 'string'
 
+            # update `field_data` with user-specified parameters
+            # these are used in `add_field()` to change the schema
+            if field_class.solr_field_params:
+                overlap = field_class.solr_field_params.viewkeys() & field_data.viewkeys()
+                if overlap:
+                    import warnings
+                    warnings.warn("""Overwriting Haystack-defined field parameters with user definitions.
+                                     Changed parameters for %s: %s""" % (field_class.index_fieldname, overlap))
+                field_data.update(field_class.solr_field_params)
+                
             schema_fields.append(field_data)
 
         return (content_field_name, schema_fields)

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -466,8 +466,6 @@ class SolrSearchBackend(BaseSearchBackend):
 
             if field_class.stored is False:
                 field_data['stored'] = 'false'
-            elif field_class.explicit_field_type:
-                field_data['type'] = field_class.explicit_field_type
             # Do this last to override `text` fields.
             if field_class.indexed is False:
                 field_data['indexed'] = 'false'

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -458,8 +458,8 @@ class SolrSearchBackend(BaseSearchBackend):
                 field_data['type'] = 'edge_ngram'
             elif field_class.field_type == 'location':
                 field_data['type'] = 'location'
-            elif field_class.explicit_field_type:
-                field_data['type'] = field_class.explicit_field_type
+            elif field_class.solr_explicit_field_type:
+                field_data['type'] = field_class.solr_explicit_field_type
                 
             if field_class.is_multivalued:
                 field_data['multi_valued'] = 'true'

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -26,7 +26,7 @@ class SearchField(object):
     def __init__(self, model_attr=None, use_template=False, template_name=None,
                  document=False, indexed=True, stored=True, faceted=False,
                  default=NOT_PROVIDED, null=False, index_fieldname=None,
-                 facet_class=None, boost=1.0, weight=None, solr_explicit_field_type=''):
+                 facet_class=None, boost=1.0, weight=None, solr_explicit_field_type=None):
         # Track what the index thinks this field is called.
         self.instance_name = None
         self.model_attr = model_attr

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -26,7 +26,7 @@ class SearchField(object):
     def __init__(self, model_attr=None, use_template=False, template_name=None,
                  document=False, indexed=True, stored=True, faceted=False,
                  default=NOT_PROVIDED, null=False, index_fieldname=None,
-                 facet_class=None, boost=1.0, weight=None, solr_explicit_field_type=None):
+                 facet_class=None, boost=1.0, weight=None, solr_field_params=None):
         # Track what the index thinks this field is called.
         self.instance_name = None
         self.model_attr = model_attr
@@ -42,17 +42,16 @@ class SearchField(object):
         self.boost = weight or boost
         self.is_multivalued = False
         
-        self.solr_explicit_field_type = solr_explicit_field_type
-        if self.solr_explicit_field_type:
+        if solr_field_params:
             from haystack.utils import loading
             from haystack.exceptions import MissingDependency
             try:
                 loading.load_backend('haystack.backends.solr_backend.SolrEngine')
             except MissingDependency:
-                raise NotImplementedError("""The solr_explicit_field_type attribute 
+                raise NotImplementedError("""The solr_field_params attribute 
                                            requires a configured Solr search backend.""")
             else:
-                self.field_type = self.solr_explicit_field_type
+                self.solr_field_params = self.solr_field_params
             
         # We supply the facet_class for making it easy to create a faceted
         # field based off of this field.

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -26,7 +26,7 @@ class SearchField(object):
     def __init__(self, model_attr=None, use_template=False, template_name=None,
                  document=False, indexed=True, stored=True, faceted=False,
                  default=NOT_PROVIDED, null=False, index_fieldname=None,
-                 facet_class=None, boost=1.0, weight=None, explicit_field_type=''):
+                 facet_class=None, boost=1.0, weight=None, solr_explicit_field_type=''):
         # Track what the index thinks this field is called.
         self.instance_name = None
         self.model_attr = model_attr
@@ -42,9 +42,17 @@ class SearchField(object):
         self.boost = weight or boost
         self.is_multivalued = False
         
-        self.explicit_field_type = explicit_field_type
-        if self.explicit_field_type:
-            self.field_type = self.explicit_field_type
+        self.solr_explicit_field_type = solr_explicit_field_type
+        if self.solr_explicit_field_type:
+            from haystack.utils import loading
+            from haystack.exceptions import MissingDependency
+            try:
+22	            loading.load_backend('haystack.backends.solr_backend.SolrEngine')
+            except MissingDependency:
+                raise MissingDependency("""The solr_explicit_field_type attribute 
+                                           requires a configured Solr search backend.""")
+            else:
+                self.field_type = self.solr_explicit_field_type
             
         # We supply the facet_class for making it easy to create a faceted
         # field based off of this field.

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -47,7 +47,7 @@ class SearchField(object):
             from haystack.utils import loading
             from haystack.exceptions import MissingDependency
             try:
-22	            loading.load_backend('haystack.backends.solr_backend.SolrEngine')
+                loading.load_backend('haystack.backends.solr_backend.SolrEngine')
             except MissingDependency:
                 raise MissingDependency("""The solr_explicit_field_type attribute 
                                            requires a configured Solr search backend.""")

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -42,6 +42,9 @@ class SearchField(object):
         self.boost = weight or boost
         self.is_multivalued = False
         
+        # `solr_field_params` should be a dict containing additional 
+        # field arguments to be used in the Solr schema
+        # e.g. {'termVectors': 'true'}.
         if solr_field_params:
             from haystack.utils import loading
             from haystack.exceptions import MissingDependency

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -26,7 +26,7 @@ class SearchField(object):
     def __init__(self, model_attr=None, use_template=False, template_name=None,
                  document=False, indexed=True, stored=True, faceted=False,
                  default=NOT_PROVIDED, null=False, index_fieldname=None,
-                 facet_class=None, boost=1.0, weight=None):
+                 facet_class=None, boost=1.0, weight=None, explicit_field_type=''):
         # Track what the index thinks this field is called.
         self.instance_name = None
         self.model_attr = model_attr
@@ -41,7 +41,11 @@ class SearchField(object):
         self.index_fieldname = index_fieldname
         self.boost = weight or boost
         self.is_multivalued = False
-
+        
+        self.explicit_field_type = explicit_field_type
+        if self.explicit_field_type:
+            self.field_type = self.explicit_field_type
+            
         # We supply the facet_class for making it easy to create a faceted
         # field based off of this field.
         self.facet_class = facet_class

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -49,7 +49,7 @@ class SearchField(object):
             try:
                 loading.load_backend('haystack.backends.solr_backend.SolrEngine')
             except MissingDependency:
-                raise MissingDependency("""The solr_explicit_field_type attribute 
+                raise NotImplementedError("""The solr_explicit_field_type attribute 
                                            requires a configured Solr search backend.""")
             else:
                 self.field_type = self.solr_explicit_field_type

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -45,7 +45,8 @@ class SearchField(object):
         # `solr_field_params` should be a dict containing additional 
         # field arguments to be used in the Solr schema
         # e.g. {'termVectors': 'true'}.
-        if solr_field_params:
+        self.solr_field_params = solr_field_params
+        if self.solr_field_params:
             from haystack.utils import loading
             from haystack.exceptions import MissingDependency
             try:
@@ -53,8 +54,6 @@ class SearchField(object):
             except MissingDependency:
                 raise NotImplementedError("""The solr_field_params attribute 
                                            requires a configured Solr search backend.""")
-            else:
-                self.solr_field_params = self.solr_field_params
             
         # We supply the facet_class for making it easy to create a faceted
         # field based off of this field.


### PR DESCRIPTION
Currently there's no easy way for a given `SearchField` object to explicitly set its Field Type in the Solr Schema. Obviously, this can be changed from within the Solr Admin page, but I feel that an integrated solution is preferable.

This is particularly useful for indexed fields that need not be tokenized and should support sorting (e.g., ID numbers, emails, etc.).