### PR TITLE
Allow threaded autotest to work

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -122,7 +122,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         else:
             global LOCALS
 
-            if LOCALS.RAM_STORE is None:
+            if not hasattr(LOCALS, 'RAM_STORE') or LOCALS.RAM_STORE is None:
                 LOCALS.RAM_STORE = RamStorage()
 
             self.storage = LOCALS.RAM_STORE


### PR DESCRIPTION
When using django-autotest-command 1.4, the threading object doesn't have the RAM_STORE variable. This fix works locally and shouldn't affect anything else.