### PR TITLE
Remove boost which is now unsupported

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -135,10 +135,6 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         current_mapping = {
             'modelresult': {
                 'properties': field_mapping,
-                '_boost': {
-                    'name': 'boost',
-                    'null_value': 1.0
-                }
             }
         }
 


### PR DESCRIPTION
In Elasticsearch >2.0, boost is no longer a support meta-data:

https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_mapping_changes.html#migration-meta-fields

See: http://stackoverflow.com/questions/35443179/django-haystack-locationfield-created-as-string-instead-of-geo-point-in-elastics