### PR TITLE
Fix bug in SearchMixin that prevents SearchView classes from setting initial form values

### DIFF
--- a/haystack/generic_views.py
+++ b/haystack/generic_views.py
@@ -58,7 +58,7 @@ class SearchMixin(MultipleObjectMixin, FormMixin):
         Returns the keyword arguments for instantiating the form.
         """
         kwargs = {'initial': self.get_initial()}
-        if self.request.method == 'GET':
+        if self.request.method == 'GET' and self.request.GET:
             kwargs.update({
                 'data': self.request.GET,
             })


### PR DESCRIPTION
When `SearchView` instantiates its associated form (using its `form_class` attribute), this form is always bound. This behavior is a result of the logic in `get_form_kwargs()` (from the `SearchMixin`), which provides a `data` argument for _any_ GET request. Per the [Django API](https://docs.djangoproject.com/en/1.9/ref/forms/api/#django.forms.Form.is_bound), even an empty data argument binds a form.

Bound forms do not use available initial values (if set), so this form instance ignores any `initial` attribute or `get_initial()` method defined in a class inheriting from `SearchView`. This patch requires that a form be bound only if the GET request is not empty (i.e. a user has added values to the form).