### PR TITLE
Maintenance updates and fixes for v2.3 branch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ MANIFEST
 env
 env3
 *.egg
+.eggs
 .coverage
 
 test_haystack/solr_tests/server/solr-4.6.0.tgz

--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ Documentation
 Build Status
 ============
 
-.. image:: https://travis-ci.org/toastdriven/django-haystack.svg?branch=master
-   :target: https://travis-ci.org/toastdriven/django-haystack
+.. image:: https://travis-ci.org/django-haystack/django-haystack.svg?branch=2.3-maintenance
+   :target: https://travis-ci.org/django-haystack/django-haystack
 
 Requirements
 ============

--- a/example_project/bare_bones_app/models.py
+++ b/example_project/bare_bones_app/models.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 from django.db import models
 
@@ -8,10 +9,10 @@ class Cat(models.Model):
     bio = models.TextField(blank=True)
     created = models.DateTimeField(default=datetime.datetime.now)
     updated = models.DateTimeField(default=datetime.datetime.now)
-    
+
     def __unicode__(self):
         return self.name
-    
+
     @models.permalink
     def get_absolute_url(self):
         return ('cat_detail', [], {'id': self.id})

--- a/example_project/bare_bones_app/search_indexes.py
+++ b/example_project/bare_bones_app/search_indexes.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from haystack import indexes
 from bare_bones_app.models import Cat
 

--- a/example_project/regular_app/models.py
+++ b/example_project/regular_app/models.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 from django.db import models
 
@@ -20,24 +21,24 @@ class Dog(models.Model):
     public = models.BooleanField(default=True)
     created = models.DateTimeField(default=datetime.datetime.now)
     updated = models.DateTimeField(default=datetime.datetime.now)
-    
+
     def __unicode__(self):
         return self.full_name()
-    
+
     @models.permalink
     def get_absolute_url(self):
         return ('dog_detail', [], {'id': self.id})
-    
+
     def full_name(self):
         if self.owner_last_name:
             return u"%s %s" % (self.name, self.owner_last_name)
-        
+
         return self.name
 
 
 class Toy(models.Model):
     dog = models.ForeignKey(Dog, related_name='toys')
     name = models.CharField(max_length=60)
-    
+
     def __unicode__(self):
         return u"%s's %s" % (self.dog.name, self.name)

--- a/example_project/regular_app/search_indexes.py
+++ b/example_project/regular_app/search_indexes.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from haystack import indexes
 from regular_app.models import Dog
 

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # All the normal settings apply. What's included here are the bits you'll have
 # to customize.
 

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 import logging
 from django.conf import settings

--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 
 from django import template

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 
 import datetime

--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 """
 A very basic, ORM-based backend for simple search during tests.
 """

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 
 import warnings

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 import os
 import re

--- a/haystack/constants.py
+++ b/haystack/constants.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 from django.conf import settings
 

--- a/haystack/exceptions.py
+++ b/haystack/exceptions.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 
 

--- a/haystack/forms.py
+++ b/haystack/forms.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 
 from django import forms

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 
 import copy

--- a/haystack/inputs.py
+++ b/haystack/inputs.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 import re
 import warnings

--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import print_function
 from __future__ import unicode_literals
 from optparse import make_option

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import print_function
 from __future__ import unicode_literals
 from optparse import make_option

--- a/haystack/management/commands/haystack_info.py
+++ b/haystack/management/commands/haystack_info.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import print_function
 from __future__ import unicode_literals
 from django.core.management.base import NoArgsCommand

--- a/haystack/management/commands/rebuild_index.py
+++ b/haystack/management/commands/rebuild_index.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 from django.core.management import call_command
 from django.core.management.base import BaseCommand

--- a/haystack/manager.py
+++ b/haystack/manager.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 from haystack.query import SearchQuerySet, EmptySearchQuerySet
 

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # "Hey, Django! Look at me, I'm an app! For Serious!"
 from __future__ import unicode_literals
 from django.conf import settings
@@ -95,7 +96,13 @@ class SearchResult(object):
 
     def _get_model(self):
         if self._model is None:
-            self._model = models.get_model(self.app_label, self.model_name)
+            try:
+                self._model = models.get_model(self.app_label, self.model_name)
+            except LookupError:
+                # this changed in change 1.7 to throw an error instead of
+                # returning None when the model isn't found. So catch the
+                # lookup error and keep self._model == None.
+                pass
 
         return self._model
 
@@ -127,7 +134,7 @@ class SearchResult(object):
             if location_field is None:
                 return None
 
-            lf_lng, lf_lat  = location_field.get_coords()
+            lf_lng, lf_lat = location_field.get_coords()
             self._distance = Distance(km=geopy_distance.distance((po_lat, po_lng), (lf_lat, lf_lng)).km)
 
         # We've either already calculated it or the backend returned it, so

--- a/haystack/panels.py
+++ b/haystack/panels.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 import datetime
 from django.template.loader import render_to_string

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 import operator
 import warnings

--- a/haystack/routers.py
+++ b/haystack/routers.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 from haystack.constants import DEFAULT_ALIAS
 

--- a/haystack/signals.py
+++ b/haystack/signals.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 from django.db import models
 from haystack.exceptions import NotHandled

--- a/haystack/templatetags/highlight.py
+++ b/haystack/templatetags/highlight.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/haystack/templatetags/more_like_this.py
+++ b/haystack/templatetags/more_like_this.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 from django import template
 from django.db import models

--- a/haystack/urls.py
+++ b/haystack/urls.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 
 try:

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from __future__ import unicode_literals
 import re
 

--- a/haystack/utils/decorators.py
+++ b/haystack/utils/decorators.py
@@ -1,4 +1,5 @@
 # Backport of Django 1.2's ``django.utils.decorators``.
+# encoding: utf-8
 from __future__ import unicode_literals
 try:
     from functools import wraps, update_wrapper, WRAPPER_ASSIGNMENTS

--- a/haystack/utils/geo.py
+++ b/haystack/utils/geo.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from __future__ import unicode_literals
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import Distance, D

--- a/haystack/utils/highlighting.py
+++ b/haystack/utils/highlighting.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from __future__ import unicode_literals
 from django.utils.html import strip_tags
 

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from __future__ import unicode_literals
 import copy
 import inspect

--- a/haystack/utils/log.py
+++ b/haystack/utils/log.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from __future__ import absolute_import
 from __future__ import unicode_literals
 

--- a/haystack/views.py
+++ b/haystack/views.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 from django.conf import settings
 from django.core.paginator import Paginator, InvalidPage

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,12 @@ except ImportError:
     from setuptools import setup
 
 install_requires = [
-    'Django',
+    'Django<1.8',
 ]
 
 tests_require = [
-    'elasticsearch',
-    'pysolr>=3.2.0',
+    'elasticsearch>=1.0.0,<2.0.0',
+    'pysolr>=3.3.2',
     'whoosh==2.5.4',
     'lxml==3.2.3',
     'python-dateutil',

--- a/test_haystack/core/admin.py
+++ b/test_haystack/core/admin.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.contrib import admin
 from haystack.admin import SearchModelAdmin
 from .models import MockModel

--- a/test_haystack/core/custom_identifier.py
+++ b/test_haystack/core/custom_identifier.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 
 def get_identifier_method(key):
     """

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # A couple models for Haystack to test with.
 import datetime
 from django.db import models

--- a/test_haystack/core/urls.py
+++ b/test_haystack/core/urls.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.conf.urls import include, patterns, url
 from django.contrib import admin
 

--- a/test_haystack/discovery/models.py
+++ b/test_haystack/discovery/models.py
@@ -1,10 +1,11 @@
+# encoding: utf-8
 from django.db import models
 
 
 class Foo(models.Model):
     title = models.CharField(max_length=255)
     body = models.TextField()
-    
+
     def __unicode__(self):
         return self.title
 
@@ -12,6 +13,6 @@ class Foo(models.Model):
 class Bar(models.Model):
     author = models.CharField(max_length=255)
     content = models.TextField()
-    
+
     def __unicode__(self):
         return self.author

--- a/test_haystack/discovery/search_indexes.py
+++ b/test_haystack/discovery/search_indexes.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from haystack import indexes
 from test_haystack.discovery.models import Foo, Bar
 

--- a/test_haystack/elasticsearch_tests/__init__.py
+++ b/test_haystack/elasticsearch_tests/__init__.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import warnings
 
 from django.conf import settings
@@ -16,4 +17,3 @@ def setup():
         es.info()
     except ElasticsearchException as e:
         raise SkipTest("elasticsearch not running on %r" % settings.HAYSTACK_CONNECTIONS['elasticsearch']['URL'], e)
-

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -211,7 +211,7 @@ class TestSettings(TestCase):
 
     def test_kwargs_are_passed_on(self):
         from haystack.backends.elasticsearch_backend import ElasticsearchSearchBackend
-        backend = ElasticsearchSearchBackend('alias', **{'URL': {}, 'INDEX_NAME': 'testing', 'KWARGS': {'max_retries': 42}})
+        backend = ElasticsearchSearchBackend('alias', **{'URL': settings.HAYSTACK_CONNECTIONS['elasticsearch']['URL'], 'INDEX_NAME': 'testing', 'KWARGS': {'max_retries': 42}})
 
         self.assertEqual(backend.conn.transport.max_retries, 42)
 

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 from django.test import TestCase
 from haystack import connections

--- a/test_haystack/elasticsearch_tests/test_inputs.py
+++ b/test_haystack/elasticsearch_tests/test_inputs.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.test import TestCase
 from haystack import connections
 from haystack import inputs

--- a/test_haystack/mocks.py
+++ b/test_haystack/mocks.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.db.models.loading import get_model
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query
 from haystack.models import SearchResult

--- a/test_haystack/multipleindex/__init__.py
+++ b/test_haystack/multipleindex/__init__.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import haystack
 from haystack.signals import RealtimeSignalProcessor
 
@@ -16,4 +17,3 @@ def teardown():
     haystack.signal_processor = _old_sp
     signals.post_save.receivers = []
     signals.post_delete.receivers = []
-    

--- a/test_haystack/multipleindex/models.py
+++ b/test_haystack/multipleindex/models.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.db import models
 
 

--- a/test_haystack/multipleindex/routers.py
+++ b/test_haystack/multipleindex/routers.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from haystack.routers import BaseRouter
 
 

--- a/test_haystack/multipleindex/search_indexes.py
+++ b/test_haystack/multipleindex/search_indexes.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from haystack import indexes
 from .models import Foo, Bar
 

--- a/test_haystack/results_per_page_urls.py
+++ b/test_haystack/results_per_page_urls.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.conf.urls import patterns, url
 from haystack.views import SearchView
 

--- a/test_haystack/run_tests.py
+++ b/test_haystack/run_tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# encoding: utf-8
 from __future__ import print_function
 
 import sys
@@ -23,5 +24,3 @@ def run_all(argv=None):
 
 if __name__ == '__main__':
     run_all(sys.argv)
-
-

--- a/test_haystack/settings.py
+++ b/test_haystack/settings.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import os
 from tempfile import mkdtemp
 

--- a/test_haystack/simple_tests/__init__.py
+++ b/test_haystack/simple_tests/__init__.py
@@ -1,2 +1,3 @@
+# encoding: utf-8
 import warnings
 warnings.simplefilter('ignore', Warning)

--- a/test_haystack/simple_tests/search_indexes.py
+++ b/test_haystack/simple_tests/search_indexes.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from haystack import indexes
 from ..core.models import MockModel, ScoreMockModel
 

--- a/test_haystack/simple_tests/test_simple_query.py
+++ b/test_haystack/simple_tests/test_simple_query.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.test import TestCase
 from haystack import connections
 from haystack.models import SearchResult
@@ -20,19 +21,18 @@ class SimpleSearchQueryTestCase(TestCase):
         self.sq.add_filter(SQ(name='foo'))
         self.sq.add_filter(SQ(name='bar'))
         self.assertEqual(self.sq.build_query(), 'foo bar')
-    
+
     def test_set_result_class(self):
         # Assert that we're defaulting to ``SearchResult``.
         self.assertTrue(issubclass(self.sq.result_class, SearchResult))
-        
+
         # Custom class.
         class IttyBittyResult(object):
             pass
-        
+
         self.sq.set_result_class(IttyBittyResult)
         self.assertTrue(issubclass(self.sq.result_class, IttyBittyResult))
-        
+
         # Reset to default.
         self.sq.set_result_class(None)
         self.assertTrue(issubclass(self.sq.result_class, SearchResult))
-        

--- a/test_haystack/solr_tests/__init__.py
+++ b/test_haystack/solr_tests/__init__.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import warnings
 warnings.simplefilter('ignore', Warning)
 
@@ -5,4 +6,3 @@ from ..utils import check_solr
 
 def setup():
     check_solr()
-

--- a/test_haystack/solr_tests/server/get-solr-download-url.py
+++ b/test_haystack/solr_tests/server/get-solr-download-url.py
@@ -28,5 +28,8 @@ mirror_response = requests.get("http://www.apache.org/dyn/mirrors/mirrors.cgi/%s
 if mirror_response.ok:
     mirror_data = mirror_response.json()
     download_url = urljoin(mirror_data['preferred'], mirror_data['path_info'])
+    # The Apache mirror script's response format has recently changed to exclude the actual file paths:
+    if not download_url.endswith(tarball):
+        download_url = urljoin(download_url, dist_path)
 
 print(download_url)

--- a/test_haystack/solr_tests/server/start-solr-test-server.sh
+++ b/test_haystack/solr_tests/server/start-solr-test-server.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-SOLR_VERSION=4.7.2
+SOLR_VERSION=4.10.4
 
 cd $(dirname $0)
 

--- a/test_haystack/solr_tests/test_admin.py
+++ b/test_haystack/solr_tests/test_admin.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase

--- a/test_haystack/solr_tests/test_inputs.py
+++ b/test_haystack/solr_tests/test_inputs.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.test import TestCase
 from haystack import connections
 from haystack import inputs

--- a/test_haystack/solr_tests/test_management_commands.py
+++ b/test_haystack/solr_tests/test_management_commands.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 
 from mock import patch

--- a/test_haystack/solr_tests/test_solr_query.py
+++ b/test_haystack/solr_tests/test_solr_query.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 from django.test import TestCase
 from haystack import connections

--- a/test_haystack/spatial/__init__.py
+++ b/test_haystack/spatial/__init__.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from ..utils import check_solr
 
 def setup():

--- a/test_haystack/spatial/models.py
+++ b/test_haystack/spatial/models.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 from django.db import models
 

--- a/test_haystack/spatial/search_indexes.py
+++ b/test_haystack/spatial/search_indexes.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from haystack import indexes
 from .models import Checkin
 

--- a/test_haystack/spatial/test_spatial.py
+++ b/test_haystack/spatial/test_spatial.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import httplib2
 import warnings
 from django.conf import settings

--- a/test_haystack/test_altered_internal_names.py
+++ b/test_haystack/test_altered_internal_names.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.conf import settings
 from django.test import TestCase
 from haystack import connections, connection_router

--- a/test_haystack/test_app_without_models/urls.py
+++ b/test_haystack/test_app_without_models/urls.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.conf.urls import patterns, url
 
 from .views import simple_view

--- a/test_haystack/test_app_without_models/views.py
+++ b/test_haystack/test_app_without_models/views.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import unicode_literals
 
 from django.http import HttpResponse

--- a/test_haystack/test_backends.py
+++ b/test_haystack/test_backends.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import warnings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase

--- a/test_haystack/test_discovery.py
+++ b/test_haystack/test_discovery.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.conf import settings
 from django.test import TestCase
 

--- a/test_haystack/test_fields.py
+++ b/test_haystack/test_fields.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 from decimal import Decimal
 from django.template import TemplateDoesNotExist

--- a/test_haystack/test_indexes.py
+++ b/test_haystack/test_indexes.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 from threading import Thread
 import time

--- a/test_haystack/test_inputs.py
+++ b/test_haystack/test_inputs.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.test import TestCase
 from haystack import connections
 from haystack import inputs

--- a/test_haystack/test_loading.py
+++ b/test_haystack/test_loading.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from haystack.exceptions import SearchFieldError, NotHandled

--- a/test_haystack/test_management_commands.py
+++ b/test_haystack/test_management_commands.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from mock import patch, call
 
 from django.conf import settings

--- a/test_haystack/test_managers.py
+++ b/test_haystack/test_managers.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 from django.test import TestCase
 from haystack import connections

--- a/test_haystack/test_models.py
+++ b/test_haystack/test_models.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import logging as std_logging
 import pickle
 import django
@@ -142,10 +143,6 @@ class SearchResultTestCase(TestCase):
         self.assertEqual(awol2.verbose_name_plural, u'')
         self.assertEqual(awol2.stored, None)
         self.assertEqual(len(CaptureHandler.logs_seen), 12)
-
-    if django.get_version() == '1.7':
-        # FIXME: https://github.com/toastdriven/django-haystack/issues/1069
-        test_missing_object = unittest.expectedFailure(test_missing_object)
 
     def test_read_queryset(self):
         # The model is flagged deleted so not returned by the default manager.

--- a/test_haystack/test_utils.py
+++ b/test_haystack/test_utils.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.test import TestCase
 from django.test.utils import override_settings
 from haystack.utils import log
@@ -76,36 +77,36 @@ class HighlighterTestCase(TestCase):
         self.assertEqual(highlighter.find_window({'highlight': [203], 'tests': [120]}), (120, 320))
         self.assertEqual(highlighter.find_window({'highlight': [], 'tests': [100]}), (100, 300))
         self.assertEqual(highlighter.find_window({'highlight': [0], 'tests': [80], 'moof': [120]}), (0, 200))
-        
+
         # Simple cases, with an outlier far outside the window.
         self.assertEqual(highlighter.find_window({'highlight': [0], 'tests': [100, 450]}), (0, 200))
         self.assertEqual(highlighter.find_window({'highlight': [100], 'tests': [220, 450]}), (100, 300))
         self.assertEqual(highlighter.find_window({'highlight': [100], 'tests': [350, 450]}), (350, 550))
         self.assertEqual(highlighter.find_window({'highlight': [100], 'tests': [220], 'moof': [450]}), (100, 300))
-        
+
         # Density checks.
         self.assertEqual(highlighter.find_window({'highlight': [0], 'tests': [100, 180, 450]}), (0, 200))
         self.assertEqual(highlighter.find_window({'highlight': [0, 40], 'tests': [100, 200, 220, 450]}), (40, 240))
         self.assertEqual(highlighter.find_window({'highlight': [0, 40], 'tests': [100, 200, 220], 'moof': [450]}), (40, 240))
         self.assertEqual(highlighter.find_window({'highlight': [0, 40], 'tests': [100, 200, 220], 'moof': [294, 299, 450]}), (100, 300))
-    
+
     def test_render_html(self):
         highlighter = Highlighter('this test')
         highlighter.text_block = self.document_1
         self.assertEqual(highlighter.render_html({'this': [0, 53, 79], 'test': [10, 68]}, 0, 200), '<span class="highlighted">This</span> is a <span class="highlighted">test</span> of the highlightable words detection. <span class="highlighted">This</span> is only a <span class="highlighted">test</span>. Were <span class="highlighted">this</span> an actual emergency, your text would have exploded in mid-air.')
-        
+
         highlighter.text_block = self.document_2
         self.assertEqual(highlighter.render_html({'this': [0, 53, 79], 'test': [10, 68]}, 0, 200), 'The content of words in no particular order causes nothing to occur.')
-        
+
         highlighter.text_block = self.document_3
         self.assertEqual(highlighter.render_html({'this': [0, 53, 79], 'test': [10, 68]}, 0, 200), '<span class="highlighted">This</span> is a <span class="highlighted">test</span> of the highlightable words detection. <span class="highlighted">This</span> is only a <span class="highlighted">test</span>. Were <span class="highlighted">this</span> an actual emergency, your text would have exploded in mid-air. The content of words in no particular order causes no...')
-        
+
         highlighter = Highlighter('content detection')
         highlighter.text_block = self.document_3
         self.assertEqual(highlighter.render_html({'content': [151], 'detection': [42]}, 42, 242), '...<span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-air. The <span class="highlighted">content</span> of words in no particular order causes nothing to occur.')
-        
+
         self.assertEqual(highlighter.render_html({'content': [151], 'detection': [42]}, 42, 200), '...<span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-air. The <span class="highlighted">content</span> of words in no particular order causes no...')
-        
+
         # One term found within another term.
         highlighter = Highlighter('this is')
         highlighter.text_block = self.document_1
@@ -124,32 +125,32 @@ class HighlighterTestCase(TestCase):
         highlighter = Highlighter('i??')
         highlighter.text_block = 'Foo is i?? in most cases.'
         self.assertEqual(highlighter.render_html({'i??': [7]}, 0, 200), 'Foo is <span class="highlighted">i??</span> in most cases.')
-        
+
         # Regression for highlighting already highlighted HTML terms.
         highlighter = Highlighter('span')
         highlighter.text_block = 'A span in spam makes html in a can.'
         self.assertEqual(highlighter.render_html({'span': [2]}, 0, 200), 'A <span class="highlighted">span</span> in spam makes html in a can.')
-        
+
         highlighter = Highlighter('highlight')
         highlighter.text_block = 'A span in spam makes highlighted html in a can.'
         self.assertEqual(highlighter.render_html({'highlight': [21]}, 0, 200), 'A span in spam makes <span class="highlighted">highlight</span>ed html in a can.')
-    
+
     def test_highlight(self):
         highlighter = Highlighter('this test')
         self.assertEqual(highlighter.highlight(self.document_1), u'<span class="highlighted">This</span> is a <span class="highlighted">test</span> of the highlightable words detection. <span class="highlighted">This</span> is only a <span class="highlighted">test</span>. Were <span class="highlighted">this</span> an actual emergency, your text would have exploded in mid-air.')
         self.assertEqual(highlighter.highlight(self.document_2), u'The content of words in no particular order causes nothing to occur.')
         self.assertEqual(highlighter.highlight(self.document_3), u'<span class="highlighted">This</span> is a <span class="highlighted">test</span> of the highlightable words detection. <span class="highlighted">This</span> is only a <span class="highlighted">test</span>. Were <span class="highlighted">this</span> an actual emergency, your text would have exploded in mid-air. The content of words in no particular order causes no...')
-        
+
         highlighter = Highlighter('this test', html_tag='div', css_class=None)
         self.assertEqual(highlighter.highlight(self.document_1), u'<div>This</div> is a <div>test</div> of the highlightable words detection. <div>This</div> is only a <div>test</div>. Were <div>this</div> an actual emergency, your text would have exploded in mid-air.')
         self.assertEqual(highlighter.highlight(self.document_2), u'The content of words in no particular order causes nothing to occur.')
         self.assertEqual(highlighter.highlight(self.document_3), u'<div>This</div> is a <div>test</div> of the highlightable words detection. <div>This</div> is only a <div>test</div>. Were <div>this</div> an actual emergency, your text would have exploded in mid-air. The content of words in no particular order causes no...')
-        
+
         highlighter = Highlighter('content detection')
         self.assertEqual(highlighter.highlight(self.document_1), u'...<span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-air.')
         self.assertEqual(highlighter.highlight(self.document_2), u'...<span class="highlighted">content</span> of words in no particular order causes nothing to occur.')
         self.assertEqual(highlighter.highlight(self.document_3), u'...<span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-air. The <span class="highlighted">content</span> of words in no particular order causes nothing to occur.')
-        
+
         highlighter = Highlighter('content detection', max_length=100)
         self.assertEqual(highlighter.highlight(self.document_1), u'...<span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-...')
         self.assertEqual(highlighter.highlight(self.document_2), u'...<span class="highlighted">content</span> of words in no particular order causes nothing to occur.')

--- a/test_haystack/test_views.py
+++ b/test_haystack/test_views.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import print_function
 from __future__ import unicode_literals
 from threading import Thread

--- a/test_haystack/utils.py
+++ b/test_haystack/utils.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.conf import settings
 from django.utils.unittest import SkipTest
 

--- a/test_haystack/whoosh_tests/__init__.py
+++ b/test_haystack/whoosh_tests/__init__.py
@@ -1,2 +1,3 @@
+# encoding: utf-8
 import warnings
 warnings.simplefilter('ignore', Warning)

--- a/test_haystack/whoosh_tests/test_forms.py
+++ b/test_haystack/whoosh_tests/test_forms.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # To ensure spelling suggestions work...
 from django.conf import settings
 from django.http import HttpRequest

--- a/test_haystack/whoosh_tests/test_inputs.py
+++ b/test_haystack/whoosh_tests/test_inputs.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from django.test import TestCase
 
 from haystack import connections, inputs

--- a/test_haystack/whoosh_tests/test_whoosh_backend.py
+++ b/test_haystack/whoosh_tests/test_whoosh_backend.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import os
 from datetime import timedelta
 from decimal import Decimal

--- a/test_haystack/whoosh_tests/test_whoosh_query.py
+++ b/test_haystack/whoosh_tests/test_whoosh_query.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 
 from haystack import connections


### PR DESCRIPTION
Backported the following fixes from 2.4.x:
- Added source encoding declaration header. (#be67c37)
- Adding fix for previously test for django 1.7. (#99fb662)

Fixed Solr version and download path for travis build tests.
Fixed requirement for elasticsearch-py<2.0.0 in setup.py.
Fixed tests failing with latest 1.x version of elasticsearch-py.
Updated README to show the proper build image and link.