### PR TITLE
enable .highlight(backend_specific_options)

### DIFF
--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -858,9 +858,9 @@ class BaseSearchQuery(object):
         """Adds stats and stats_facets queries for the Solr backend."""
         self.stats[stats_field] = stats_facets
 
-    def add_highlight(self):
+    def add_highlight(self, options=True):
         """Adds highlighting to the search results."""
-        self.highlight = True
+        self.highlight = options
 
     def add_within(self, field, point_1, point_2):
         """Adds bounding box parameters to search query."""

--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -858,9 +858,9 @@ class BaseSearchQuery(object):
         """Adds stats and stats_facets queries for the Solr backend."""
         self.stats[stats_field] = stats_facets
 
-    def add_highlight(self, options=True):
+    def add_highlight(self, **kwargs):
         """Adds highlighting to the search results."""
-        self.highlight = options
+        self.highlight = kwargs or True
 
     def add_within(self, field, point_1, point_2):
         """Adds bounding box parameters to search query."""

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -322,12 +322,14 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         # if end_offset is not None:
         #     kwargs['size'] = end_offset - start_offset
 
-        if highlight is True:
+        if highlight:
             kwargs['highlight'] = {
                 'fields': {
                     content_field: {'store': 'yes'},
                 }
             }
+            if isinstance(highlight, dict):
+                kwargs['highlight'].update(highlight)
 
         if self.include_spelling:
             kwargs['suggest'] = {

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -319,10 +319,10 @@ class SearchQuerySet(object):
 
         return clone
 
-    def highlight(self, options=True):
+    def highlight(self, **kwargs):
         """Adds highlighting to the results."""
         clone = self._clone()
-        clone.query.add_highlight(options)
+        clone.query.add_highlight(**kwargs or True)
         return clone
 
     def models(self, *models):

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -319,10 +319,10 @@ class SearchQuerySet(object):
 
         return clone
 
-    def highlight(self):
+    def highlight(self, options=True):
         """Adds highlighting to the results."""
         clone = self._clone()
-        clone.query.add_highlight()
+        clone.query.add_highlight(options)
         return clone
 
     def models(self, *models):

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -774,7 +774,7 @@ class LiveElasticsearchSearchQuerySetTestCase(TestCase):
     def test_highlight_options(self):
         reset_search_queries()
         results = self.sqs.filter(content='index')
-        results = results.highlight({'pre_tags': ['<i>'],'post_tags': ['</i>']})
+        results = results.highlight(pre_tags=['<i>'], post_tags=['</i>'])
         self.assertEqual(results[0].highlighted, [u'<i>Indexed</i>!\n1'])
 
     def test_manual_iter(self):

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -423,6 +423,9 @@ class ElasticsearchSearchBackendTestCase(TestCase):
         self.assertEqual(self.sb.search('Index', highlight=True)['hits'], 3)
         self.assertEqual(sorted([result.highlighted[0] for result in self.sb.search('Index', highlight=True)['results']]),
                          [u'<em>Indexed</em>!\n1', u'<em>Indexed</em>!\n2', u'<em>Indexed</em>!\n3'])
+        self.assertEqual(sorted([result.highlighted[0] for result in self.sb.search('Index', highlight={'pre_tags': ['<start>'],'post_tags': ['</end>']})['results']]),
+                         [u'<start>Indexed</end>!\n1', u'<start>Indexed</end>!\n2', u'<start>Indexed</end>!\n3'])
+
 
         self.assertEqual(self.sb.search('Indx')['hits'], 0)
         self.assertEqual(self.sb.search('indaxed')['spelling_suggestion'], 'indexed')
@@ -762,6 +765,17 @@ class LiveElasticsearchSearchQuerySetTestCase(TestCase):
         self.assertEqual(sqs.count(), 23)
         # Should only execute one query to count the length of the result set.
         self.assertEqual(len(connections['elasticsearch'].queries), 1)
+
+    def test_highlight(self):
+        reset_search_queries()
+        results = self.sqs.filter(content='index').highlight()
+        self.assertEqual(results[0].highlighted, [u'<em>Indexed</em>!\n1'])
+
+    def test_highlight_options(self):
+        reset_search_queries()
+        results = self.sqs.filter(content='index')
+        results = results.highlight({'pre_tags': ['<i>'],'post_tags': ['</i>']})
+        self.assertEqual(results[0].highlighted, [u'<i>Indexed</i>!\n1'])
 
     def test_manual_iter(self):
         results = self.sqs.all()


### PR DESCRIPTION
ElasticSearch (and may be other backends) lets user customise tags used for highlighting search results. This is important for highlighting HTML texts: they can contain `em` already. Let's expose this functionality as an option that can be passed to SearchQuerySet.highlight()

Example usage:
```
result = query.filter('needle').highlight({'pre_tags': ['<i>'],'post_tags': ['</i>']})
```