### PR TITLE
Add support for filtering on empty list with Elasticsearch

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -815,10 +815,13 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             elif filter_type == 'in':
                 in_options = []
 
-                for possible_value in prepared_value:
-                    in_options.append(u'"%s"' % self.backend._from_python(possible_value))
+                if not prepared_value:
+                    query_frag = u'(!*:*)'
+                else:
+                    for possible_value in prepared_value:
+                        in_options.append(u'"%s"' % self.backend._from_python(possible_value))
+                    query_frag = u"(%s)" % " OR ".join(in_options)
 
-                query_frag = u"(%s)" % " OR ".join(in_options)
             elif filter_type == 'range':
                 start = self.backend._from_python(prepared_value[0])
                 end = self.backend._from_python(prepared_value[1])

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -839,6 +839,17 @@ class LiveElasticsearchSearchQuerySetTestCase(TestCase):
         self.assertEqual(sqs.query.build_query(), u'("pants\\:rule")')
         self.assertEqual(len(sqs), 0)
 
+    def test_query__in(self):
+        self.assertGreater(len(self.sqs), 0)
+        sqs = self.sqs.filter(django_ct='core.mockmodel', django_id__in=[1, 2])
+        self.assertEqual(len(sqs), 2)
+
+    def test_query__in_empty_list(self):
+        """Confirm that an empty list avoids a Elasticsearch exception"""
+        self.assertGreater(len(self.sqs), 0)
+        sqs = self.sqs.filter(id__in=[])
+        self.assertEqual(len(sqs), 0)
+
     # Regressions
 
     def test_regression_proper_start_offsets(self):

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -160,6 +160,15 @@ class ElasticsearchSearchQueryTestCase(TestCase):
         self.assertEqual(len(sqs.query.narrow_queries), 1)
         self.assertEqual(sqs.query.narrow_queries.pop(), 'foo:(moof)')
 
+    def test_query__in(self):
+        sqs = SearchQuerySet(using='elasticsearch').filter(id__in=[1, 2, 3])
+        self.assertEqual(sqs.query.build_query(), u'id:("1" OR "2" OR "3")')
+
+    def test_query__in_empty_list(self):
+        """Confirm that an empty list avoids a Elasticsearch exception"""
+        sqs = SearchQuerySet(using='elasticsearch').filter(id__in=[])
+        self.assertEqual(sqs.query.build_query(), u'id:(!*:*)')
+
 
 class ElasticsearchSearchQuerySpatialBeforeReleaseTestCase(TestCase):
     def setUp(self):


### PR DESCRIPTION
When filtering on an empty list, Elasticsearch will error.
For example, SearchQuerySet().filter(id__in=[])


