### PR TITLE
Allow Routers to return multiple indexes

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -56,10 +56,6 @@ class SearchQuerySet(object):
 
         backend_alias = connection_router.for_read(**hints)
 
-        if isinstance(backend_alias, (list, tuple)) and len(backend_alias):
-            # We can only effectively read from one engine.
-            backend_alias = backend_alias[0]
-
         # The ``SearchQuery`` might swap itself out for a different variant
         # here.
         if self.query:

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -8,6 +8,7 @@ import threading
 import warnings
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
 from django.utils.module_loading import module_has_submodule
 
 from haystack.exceptions import NotHandled, SearchFieldError
@@ -147,7 +148,7 @@ class ConnectionRouter(object):
                 self._routers.append(router_class())
         return self._routers
 
-    def for_action(self, action, **hints):
+    def _for_action(self, action, many, **hints):
         conns = []
 
         for router in self.routers:
@@ -156,15 +157,20 @@ class ConnectionRouter(object):
                 connection_to_use = action_callable(**hints)
 
                 if connection_to_use is not None:
-                    conns.append(connection_to_use)
+                    if isinstance(connection_to_use, six.string_types):
+                        conns.append(connection_to_use)
+                    else:
+                        conns.extend(connection_to_use)
+                    if not many:
+                        break
 
         return conns
 
     def for_write(self, **hints):
-        return self.for_action('for_write', **hints)
+        return self._for_action('for_write', True, **hints)
 
     def for_read(self, **hints):
-        return self.for_action('for_read', **hints)
+        return self._for_action('for_read', False, **hints)[0]
 
 
 class UnifiedIndex(object):

--- a/test_haystack/mocks.py
+++ b/test_haystack/mocks.py
@@ -32,6 +32,11 @@ class MockPassthroughRouter(BaseRouter):
         return None
 
 
+class MockMultiRouter(BaseRouter):
+    def for_write(self, **hints):
+        return ['multi1', 'multi2']
+
+
 class MockSearchResult(SearchResult):
     def __init__(self, app_label, model_name, pk, score, **kwargs):
         super(MockSearchResult, self).__init__(app_label, model_name, pk, score, **kwargs)

--- a/test_haystack/test_loading.py
+++ b/test_haystack/test_loading.py
@@ -112,24 +112,31 @@ class ConnectionRouterTestCase(TestCase):
     def test_actions1(self):
         del settings.HAYSTACK_ROUTERS
         cr = loading.ConnectionRouter()
-        self.assertEqual(cr.for_read(), ['default'])
+        self.assertEqual(cr.for_read(), 'default')
         self.assertEqual(cr.for_write(), ['default'])
 
     @override_settings(HAYSTACK_ROUTERS=['test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
     def test_actions2(self):
         cr = loading.ConnectionRouter()
-        self.assertEqual(cr.for_read(), ['slave', 'default'])
+        self.assertEqual(cr.for_read(), 'slave')
         self.assertEqual(cr.for_write(), ['master', 'default'])
 
     @override_settings(HAYSTACK_ROUTERS=['test_haystack.mocks.MockPassthroughRouter', 'test_haystack.mocks.MockMasterSlaveRouter', 'haystack.routers.DefaultRouter'])
     def test_actions3(self):
         cr = loading.ConnectionRouter()
         # Demonstrate pass-through
-        self.assertEqual(cr.for_read(), ['slave', 'default'])
+        self.assertEqual(cr.for_read(), 'slave')
         self.assertEqual(cr.for_write(), ['master', 'default'])
         # Demonstrate that hinting can change routing.
-        self.assertEqual(cr.for_read(pass_through=False), ['pass', 'slave', 'default'])
+        self.assertEqual(cr.for_read(pass_through=False), 'pass')
         self.assertEqual(cr.for_write(pass_through=False), ['pass', 'master', 'default'])
+
+    @override_settings(HAYSTACK_ROUTERS=['test_haystack.mocks.MockMultiRouter', 'haystack.routers.DefaultRouter'])
+    def test_actions4(self):
+        cr = loading.ConnectionRouter()
+        # Demonstrate that a router can return multiple backends in the "for_write" method
+        self.assertEqual(cr.for_read(), 'default')
+        self.assertEqual(cr.for_write(), ['multi1', 'multi2', 'default'])
 
 
 class MockNotAModel(object):


### PR DESCRIPTION
## Main course

This allows Routers to return multiple indexes to write to with their `for_write` method.

## Side-dishes

The contract of `ConnectionRouter.for_read` is changed so that it only returns a single index. It updates the documentation accordingly and improves it. It also fixes issue #934: `ConnectionRouter.for_read` goes through configured Routers' `for_read` methods until it gets an index, and stops.

## Motivation

Some quite common use-cases are simplified by being able to return multiple indexes in a single Router.

Let's have an example, i18n. Suppose we have indexes for each of three supported languages: English, French and German. Our default language will be English. We want a behavior like this:

* when querying, use results from the index corresponding to the request's language
* when updating a model, update all the backends

We could use something like this : 
https://anthony-tresontani.github.io/Django/2012/09/20/multilingual-search/

This essentially creates a "default" engine whose backend knows that it must update all other backends when it is told to update. And a custom Query that retrieves the language and sets the right `using`. This looks a bit complicated to me.

Let's instead use Routers, they should be made for this sort of use-cases, right? Without this PR, we would need three of them, as many as languages:

    class EnglishRouter(BaseRouter):
        def for_read(self, **hints):
            return "english"
    
        def for_write(self, **hints):
            return "english"
    
    class FrenchRouter(BaseRouter):
        def for_read(self, **hints):
            if translation.get_language == 'fr':
                return "french"
    
        def for_write(self, **hints):
            return "french"
    
    class GermanRouter(BaseRouter):
        def for_read(self, **hints):
            if translation.get_language == 'de':
                return "german"
    
        def for_write(self, **hints):
            return "german"
    
    HAYSTACK_ROUTERS = ['GermanRouter', 'FrenchRouter', 'EnglishRouter']

With this PR, we would need only one, it would be much cleaner:

    class I18nRouter(BaseRouter):
        def for_read(self, **hints):
            lang_map = {'fr': 'french', 'de': 'german'}
            return lang_map.get(translation.get_language(), 'english')

        def for_write(self, **hints):
            return ('german', 'french', 'english')

    HAYSTACK_ROUTERS = ['I18nRouter']

## Drawbacks

I don't see any, this would be 100% backward compatible with Routers as they are now, limited to only a single index return. Maybe the only breaking change would be the short-circuit evaluation (to comply with the existing documentation!) of `for_read`. If people relied on side-effects of evaluation all of the Routers' `for_read` instead of up to the first matching one, this would break behavior. But I sure hope no-one does that.