### PR TITLE
Added get_context method

### DIFF
--- a/haystack/views.py
+++ b/haystack/views.py
@@ -126,10 +126,7 @@ class SearchView(object):
         """
         return {}
 
-    def create_response(self):
-        """
-        Generates the actual HttpResponse to send back to the user.
-        """
+    def get_context(self):
         (paginator, page) = self.build_page()
 
         context = {
@@ -144,6 +141,13 @@ class SearchView(object):
             context['suggestion'] = self.form.get_suggestion()
 
         context.update(self.extra_context())
+        return context
+
+    def create_response(self):
+        """
+        Generates the actual HttpResponse to send back to the user.
+        """
+        context = self.get_context()
         return render_to_response(self.template, context, context_instance=self.context_class(self.request))
 
 


### PR DESCRIPTION
Adding this `get_context` method makes the `create_response` method exclusively responsible for rendering the template and creating a response. 

This is useful in cases where you want to create a View that will produce a JSON response for example. In that case you will have to override the `create_response` method to build whatever you need using the context.
