### PR TITLE
autoprefix 'hl.' for Solr options

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -188,7 +188,10 @@ class SolrSearchBackend(BaseSearchBackend):
             kwargs['hl.fragsize'] = '200'
 
             if isinstance(highlight, dict):
-                kwargs.update(highlight)
+                # autoprefix highlighter options with 'hl.', all of them start with it anyway
+                # this makes option dicts shorter: {'maxAnalyzedChars': 42}
+                # and lets some of options be used as keyword arguments: `.highlight(preserveMulti=False)`
+                kwargs.update({'hl.' + key: highlight[key] for key in highlight.keys()})
 
         if self.include_spelling is True:
             kwargs['spellcheck'] = 'true'

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -191,7 +191,10 @@ class SolrSearchBackend(BaseSearchBackend):
                 # autoprefix highlighter options with 'hl.', all of them start with it anyway
                 # this makes option dicts shorter: {'maxAnalyzedChars': 42}
                 # and lets some of options be used as keyword arguments: `.highlight(preserveMulti=False)`
-                kwargs.update({'hl.' + key: highlight[key] for key in highlight.keys()})
+                kwargs.update({
+                    key if key.startswith("hl.") else ('hl.' + key): highlight[key] 
+                    for key in highlight.keys()
+                })
 
         if self.include_spelling is True:
             kwargs['spellcheck'] = 'true'

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -390,9 +390,15 @@ class SolrSearchBackendTestCase(TestCase):
         self.assertEqual(self.sb.search('Index', highlight=True)['hits'], 3)
         self.assertEqual([result.highlighted['text'][0] for result in self.sb.search('Index', highlight=True)['results']], ['<em>Indexed</em>!\n1', '<em>Indexed</em>!\n2', '<em>Indexed</em>!\n3'])
 
+        # shortened highlighting options
         highlight_dict = {'simple.pre':'<i>', 'simple.post': '</i>'}
         self.assertEqual(self.sb.search('', highlight=highlight_dict), {'hits': 0, 'results': []})
         self.assertEqual(self.sb.search('Index', highlight=highlight_dict)['hits'], 3)
+        self.assertEqual([result.highlighted['text'][0] for result in self.sb.search('Index', highlight=highlight_dict)['results']], 
+            ['<i>Indexed</i>!\n1', '<i>Indexed</i>!\n2', '<i>Indexed</i>!\n3'])
+
+        # full-form highlighting options
+        highlight_dict = {'hl.simple.pre':'<i>', 'hl.simple.post': '</i>'}
         self.assertEqual([result.highlighted['text'][0] for result in self.sb.search('Index', highlight=highlight_dict)['results']], 
             ['<i>Indexed</i>!\n1', '<i>Indexed</i>!\n2', '<i>Indexed</i>!\n3'])
 

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -390,6 +390,12 @@ class SolrSearchBackendTestCase(TestCase):
         self.assertEqual(self.sb.search('Index', highlight=True)['hits'], 3)
         self.assertEqual([result.highlighted['text'][0] for result in self.sb.search('Index', highlight=True)['results']], ['<em>Indexed</em>!\n1', '<em>Indexed</em>!\n2', '<em>Indexed</em>!\n3'])
 
+        highlight_dict = {'simple.pre':'<i>', 'simple.post': '</i>'}
+        self.assertEqual(self.sb.search('', highlight=highlight_dict), {'hits': 0, 'results': []})
+        self.assertEqual(self.sb.search('Index', highlight=highlight_dict)['hits'], 3)
+        self.assertEqual([result.highlighted['text'][0] for result in self.sb.search('Index', highlight=highlight_dict)['results']], 
+            ['<i>Indexed</i>!\n1', '<i>Indexed</i>!\n2', '<i>Indexed</i>!\n3'])
+
         self.assertEqual(self.sb.search('Indx')['hits'], 0)
         self.assertEqual(self.sb.search('indax')['spelling_suggestion'], 'index')
         self.assertEqual(self.sb.search('Indx', spelling_query='indexy')['spelling_suggestion'], 'index')


### PR DESCRIPTION
All Solr highlighting options start with "hl.", so let's add this prefix automatically.
https://wiki.apache.org/solr/HighlightingParameters

This will make option dicts shorter: `{'maxAnalyzedChars': 42}` instead of `{'hl.maxAnalyzedChars': 42'}`
And let some of the options be used as simple keyword arguments in QuerySet: `.highlight(preserveMulti=False)`

@acdha 