### PR TITLE
SearchQuerySet._clone() to also clone using value

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -603,7 +603,7 @@ class SearchQuerySet(object):
             klass = self.__class__
 
         query = self.query._clone()
-        clone = klass(query=query)
+        clone = klass(using=self._using, query=query)
         clone._load_all = self._load_all
         return clone
 


### PR DESCRIPTION
# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](http://django-haystack.readthedocs.org/en/latest/contributing.html) and confirm that [the tests pass](http://django-haystack.readthedocs.org/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.
I came across an issue when using a different index.  Even though I had created my SearchQuerySet with using='something', the _clone method was creating a clone with using='default' -- which was causing a problem since I did not have a 'default' index.

I've updated the code to maintain the self._using when cloning.  I have fixed this in my own project by sub-classing SearchQuerySet and overriding the _clone method to be the same as this changeset.