### PR TITLE
fixes improper call to logger in mgmt command

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -102,10 +102,10 @@ def do_update(backend, index, qs, start, end, total, verbosity=1, commit=True,
                 error_msg += ' (pid %(pid)s): %(exc)s'
 
             if retries >= max_retries:
-                LOG.error(error_msg, exc_info=True, **error_context)
+                LOG.error(error_msg, error_context, exc_info=True)
                 raise
             elif verbosity >= 2:
-                LOG.warning(error_msg, exc_info=True, **error_context)
+                LOG.warning(error_msg, error_context, exc_info=True)
 
             # If going to try again, sleep a bit before
             time.sleep(2 ** retries)


### PR DESCRIPTION
update_index management command is not correctly interpreting the fairly ambiguous Python docs on the logging facility:

> The msg is the message format string, and the args are the arguments which are merged into msg using the string formatting operator. (Note that this means that you can use keywords in the format string, together with a single dictionary argument.)

The current revision on master results in an unexpected keyword argument due to attempting kwargs expansion.