### PR TITLE
Fix for python 3.5.1 (OrderedDict may be unmutable)

### DIFF
--- a/haystack/utils/app_loading.py
+++ b/haystack/utils/app_loading.py
@@ -21,7 +21,7 @@ def haystack_load_apps():
 def haystack_get_models(label):
     try:
         app_mod = apps.get_app_config(label)
-        return app_mod.get_models()
+        return list(app_mod.get_models())
     except LookupError:
         if '.' not in label:
             raise ImproperlyConfigured('Unknown application label {}'.format(label))


### PR DESCRIPTION
After updating to latest ubuntu LTS (which ships with python 3.5.1) i get the following stacktrace:

```
Traceback (most recent call last):
  File "./manage.py", line 9, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.5/dist-packages/haystack/management/commands/update_index.py", line 210, in handle
    self.update_backend(label, using)
  File "/usr/local/lib/python3.5/dist-packages/haystack/management/commands/update_index.py", line 219, in update_backend
    for model in haystack_get_models(label):
  File "/usr/local/lib/python3.5/dist-packages/django/apps/config.py", line 180, in get_models
    for model in self.models.values():
RuntimeError: OrderedDict mutated during iteration
```

Djangos `config.py` does return a generator pointing to an OrderedDict which may not be mutated. Changing this to a list solves it.

There maz be a better approach that I'm not aware of, though, as I don't know the haystack internals.