### PR TITLE
Support ManyToManyFields in model_attr lookups

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -111,3 +111,4 @@ Thanks to
     * Claude Paroz (@claudep) for Django 1.9 support
     * Chris Brooke (@chrisbrooke) for patching around a backwards-incompatible change in ElasticSearch 2
     * Gilad Beeri (@giladbeeri) for adding retries when updating a backend
+    * Arjen Verstoep (@terr) for a patch that allows attribute lookups through Django ManyToManyField relationships

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -79,3 +79,22 @@ class ScoreMockModel(models.Model):
 
     def __unicode__(self):
         return self.score
+
+
+class ManyToManyLeftSideModel(models.Model):
+    related_models = models.ManyToManyField('ManyToManyRightSideModel')
+
+
+class ManyToManyRightSideModel(models.Model):
+    name = models.CharField(max_length=32, default='Default name')
+
+    def __unicode__(self):
+        return self.name
+
+
+class OneToManyLeftSideModel(models.Model):
+    pass
+
+
+class OneToManyRightSideModel(models.Model):
+    left_side = models.ForeignKey(OneToManyLeftSideModel, related_name='right_side')

--- a/test_haystack/test_indexes.py
+++ b/test_haystack/test_indexes.py
@@ -8,7 +8,8 @@ from threading import Thread
 
 from django.test import TestCase
 from django.utils.six.moves import queue
-from test_haystack.core.models import AFifthMockModel, AThirdMockModel, MockModel
+from test_haystack.core.models import (AFifthMockModel, AThirdMockModel, MockModel, ManyToManyLeftSideModel,
+                                       ManyToManyRightSideModel)
 
 from haystack import connection_router, connections, indexes
 from haystack.exceptions import SearchFieldError
@@ -132,6 +133,14 @@ class MROFieldsSearchIndexB(indexes.SearchIndex, indexes.Indexable):
 
 class MROFieldsSearchChild(MROFieldsSearchIndexA, MROFieldsSearchIndexB):
     pass
+
+
+class ModelWithManyToManyFieldAndAttributeLookupSearchIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True)
+    related_models = indexes.MultiValueField(model_attr='related_models__name')
+
+    def get_model(self):
+        return ManyToManyLeftSideModel
 
 
 class SearchIndexTestCase(TestCase):
@@ -650,3 +659,27 @@ class ModelSearchIndexTestCase(TestCase):
         self.assertTrue(isinstance(self.yabmsi.fields['average_delay'], indexes.FloatField))
         self.assertEqual(self.yabmsi.fields['average_delay'].null, False)
         self.assertEqual(self.yabmsi.fields['average_delay'].index_fieldname, 'average_delay')
+
+
+class ModelWithManyToManyFieldAndAttributeLookupSearchIndexTestCase(TestCase):
+    def test_full_prepare(self):
+        index = ModelWithManyToManyFieldAndAttributeLookupSearchIndex()
+
+        left_model = ManyToManyLeftSideModel.objects.create()
+        right_model_1 = ManyToManyRightSideModel.objects.create(name='Right side 1')
+        right_model_2 = ManyToManyRightSideModel.objects.create()
+        left_model.related_models.add(right_model_1)
+        left_model.related_models.add(right_model_2)
+
+        result = index.full_prepare(left_model)
+
+        self.assertDictEqual(
+            result,
+            {
+                'django_ct': 'core.manytomanyleftsidemodel',
+                'django_id': '1',
+                'text': None,
+                'id': 'core.manytomanyleftsidemodel.1',
+                'related_models': ['Right side 1', 'Default name'],
+            }
+        )


### PR DESCRIPTION
Hi,

This pull request adds support for ManyToManyFields in SearchFields' `model_attr` attribute lookups.

Before the change, a `model_attr` with value `related_models__name` (where `related_models` is a `ManyToManyField`) would result in the following exception:

    haystack.exceptions.SearchFieldError: The model '<ManyToManyLeftSideModel: ManyToManyLeftSideModel object>' combined with model_attr 'related_models__name' returned None, but doesn't allow a default or null value.

`SearchField.prepare` will now return multiple values when it encounters `ManyToManyFields` somewhere in the lookup chain.