### PR TITLE
Fix MultiValueField issues with single value

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -411,7 +411,10 @@ class MultiValueField(SearchField):
         if value is None:
             return None
 
-        return list(value)
+        if hasattr(value, '__iter__') and not isinstance(value, six.text_type):
+            return value
+
+        return [value]
 
 
 class FacetField(SearchField):

--- a/test_haystack/test_fields.py
+++ b/test_haystack/test_fields.py
@@ -472,6 +472,26 @@ class MultiValueFieldTestCase(TestCase):
 
         self.assertEqual(multy_none.prepare(mock), None)
 
+    def test_convert_with_single_string(self):
+        field = MultiValueField()
+
+        self.assertEqual(['String'], field.convert('String'))
+
+    def test_convert_with_single_int(self):
+        field = MultiValueField()
+
+        self.assertEqual([1], field.convert(1))
+
+    def test_convert_with_list_of_strings(self):
+        field = MultiValueField()
+
+        self.assertEqual(['String 1', 'String 2'], field.convert(['String 1', 'String 2']))
+
+    def test_convert_with_list_of_ints(self):
+        field = MultiValueField()
+
+        self.assertEqual([1, 2, 3], field.convert([1, 2, 3]))
+
 
 class CharFieldWithTemplateTestCase(TestCase):
     def test_init(self):


### PR DESCRIPTION
From my [previous PR](https://github.com/django-haystack/django-haystack/pull/1363):

> Hi again,
> 
> When working with the changes from my earlier patch, I noticed that MultiValueFields that prepared a single string value ended up as ['S', 't', 'r', 'i', 'n', 'g'] in the search backend. Also, single int values (and probably others) resulted in an error. So it seems that I introduced a regression. Apologies.
> 
> I fixed it by battling the symptom of how MultiValueField.convert handles the incoming value. I don't think any other fields were affected because they all expect a single value.

The tests should now also pass in Python 3