### PR TITLE
make empty lists return null or default

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -87,7 +87,7 @@ class SearchField(object):
 
             if len(values) == 1:
                 return values[0]
-            else:
+            elif len(values) > 1:
                 return values
 
         if self.has_default():

--- a/test_haystack/test_fields.py
+++ b/test_haystack/test_fields.py
@@ -85,6 +85,14 @@ class SearchFieldTestCase(TestCase):
 
         self.assertEqual([1, 1], field.resolve_attributes_lookup([obj], ['related', 'related', 'value']))
 
+    def test_prepare_with_null_django_onetomany_rel(self):
+        left_model = OneToManyLeftSideModel.objects.create()
+
+        field = SearchField(model_attr='right_side__pk', null=True)
+        result = field.prepare(left_model)
+
+        self.assertEqual(None, result)
+
 
 class CharFieldTestCase(TestCase):
     def test_init(self):


### PR DESCRIPTION
This fix resolves the issue with integerFields trying to convert empty list in case a Nnull value is returned from the datasource

Tests are passing
