### PR TITLE
Removed deprecated use of Template.render()

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -176,7 +176,7 @@ class SearchField(object):
             template_names = ['search/indexes/%s/%s_%s.txt' % (app_label, model_name, self.instance_name)]
 
         t = loader.select_template(template_names)
-        return t.render(Context({'object': obj}).flatten())
+        return t.render({'object': obj})
 
     def convert(self, value):
         """


### PR DESCRIPTION
It will be removed in Django 1.10

https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/#django-template-loader