### PR TITLE
fix: multiprocessing-unsafe session handling in update_worker

### DIFF
--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -1040,7 +1040,7 @@ class BaseEngine(object):
         return self.query(using=self.using)
 
     def reset_queries(self):
-        self.queries = []
+        del self.queries[:]
 
     def get_unified_index(self):
         if self._index is None:

--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -1032,6 +1032,10 @@ class BaseEngine(object):
             self._backend = self.backend(self.using, **self.options)
         return self._backend
 
+    def reset_sessions(self):
+        """Reset any transient connections, file handles, etc."""
+        self._backend = None
+
     def get_query(self):
         return self.query(using=self.using)
 

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -88,9 +88,10 @@ def do_update(backend, index, qs, start, end, total, verbosity=1, commit=True,
                                                                              retries + 1,
                                                                              max_retries))
             break
-        except (SystemExit, KeyboardInterrupt):
-            raise
         except Exception as exc:
+            # Catch all exceptions which do not normally trigger a system exit, excluding SystemExit and
+            # KeyboardInterrupt. This avoids needing to import the backend-specific exception subclasses
+            # from pysolr, elasticsearch, whoosh, requests, etc.
             retries += 1
 
             error_context = {'start': start + 1,


### PR DESCRIPTION
The `update_index` management command does not handle the `multiprocessing` environment safely. On POSIX systems, `multiprocessing` uses `fork()` which means that when called in a context such as the test suite where the connection has already been used, backends like pysolr or ElasticSearch may have a pre-existing open socket connected to the search server which will be shared *across* workers and HTTP requests are interleaved, producing unexpected errors when the client attempts to decode something like an XML fragment as the HTTP status code.

This commit resets the backend connection inside the workers and in testing has been stable across hundreds of runs, unlike the current situation where a single-digit number of runs would almost certainly have at least one failure.

Other improvements:
* Improved sanity checks for indexed documents in management command test suite. This wasn’t actually the cause of the problem above but since I wrote it while tracking down the real problem there’s no reason not to use it.
* update_index now checks that each block dispatched was processed to catch silent failures.

See #1001 and possibly the most recent comment on #860 