### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
-# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](http://django-haystack.readthedocs.org/en/latest/contributing.html) and confirm that [the tests pass](http://django-haystack.readthedocs.org/en/latest/running_tests.html) with at least one search engine.
+# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.
 
 # Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ should take to help get it added/fixed in Haystack:
   https://github.com/blog/1943-how-to-write-the-perfect-pull-request
 
   Instructions for running the tests are at
-  http://django-haystack.readthedocs.org/en/latest/running_tests.html
+  https://django-haystack.readthedocs.io/en/latest/running_tests.html
 
 You might also hop into the IRC channel (`#haystack` on `irc.freenode.net`)
 & raise your question there, as there may be someone who can help you with a

--- a/README.rst
+++ b/README.rst
@@ -33,13 +33,13 @@ Documentation
 =============
 
 * Development version: http://docs.haystacksearch.org/
-* v2.4.X: http://django-haystack.readthedocs.org/en/v2.4.1/
-* v2.3.X: http://django-haystack.readthedocs.org/en/v2.3.0/
-* v2.2.X: http://django-haystack.readthedocs.org/en/v2.2.0/
-* v2.1.X: http://django-haystack.readthedocs.org/en/v2.1.0/
-* v2.0.X: http://django-haystack.readthedocs.org/en/v2.0.0/
-* v1.2.X: http://django-haystack.readthedocs.org/en/v1.2.7/
-* v1.1.X: http://django-haystack.readthedocs.org/en/v1.1/
+* v2.4.X: https://django-haystack.readthedocs.io/en/v2.4.1/
+* v2.3.X: https://django-haystack.readthedocs.io/en/v2.3.0/
+* v2.2.X: https://django-haystack.readthedocs.io/en/v2.2.0/
+* v2.1.X: https://django-haystack.readthedocs.io/en/v2.1.0/
+* v2.0.X: https://django-haystack.readthedocs.io/en/v2.0.0/
+* v1.2.X: https://django-haystack.readthedocs.io/en/v1.2.7/
+* v1.1.X: https://django-haystack.readthedocs.io/en/v1.1/
 
 See the `changelog <docs/changelog.rst>`_
 
@@ -58,5 +58,5 @@ Haystack has a relatively easily-met set of requirements.
 * A supported version of Django: https://www.djangoproject.com/download/#supported-versions
 
 Additionally, each backend has its own requirements. You should refer to
-http://django-haystack.readthedocs.org/en/latest/installing_search_engines.html for more
+https://django-haystack.readthedocs.io/en/latest/installing_search_engines.html for more
 details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,13 +15,13 @@ Elasticsearch_, Whoosh_, Xapian_, etc.) without having to modify your code.
 
     This documentation represents the current version of Haystack. For old versions of the documentation:
 
-    * v2.4.X: http://django-haystack.readthedocs.org/en/v2.4.1/
-    * v2.3.X: http://django-haystack.readthedocs.org/en/v2.3.0/
-    * v2.2.X: http://django-haystack.readthedocs.org/en/v2.2.0/
-    * v2.1.X: http://django-haystack.readthedocs.org/en/v2.1.0/
-    * v2.0.X: http://django-haystack.readthedocs.org/en/v2.0.0/
-    * v1.2.X: http://django-haystack.readthedocs.org/en/v1.2.7/
-    * v1.1.X: http://django-haystack.readthedocs.org/en/v1.1/
+    * v2.4.X: https://django-haystack.readthedocs.io/en/v2.4.1/
+    * v2.3.X: https://django-haystack.readthedocs.io/en/v2.3.0/
+    * v2.2.X: https://django-haystack.readthedocs.io/en/v2.2.0/
+    * v2.1.X: https://django-haystack.readthedocs.io/en/v2.1.0/
+    * v2.0.X: https://django-haystack.readthedocs.io/en/v2.0.0/
+    * v1.2.X: https://django-haystack.readthedocs.io/en/v1.2.7/
+    * v1.1.X: https://django-haystack.readthedocs.io/en/v1.1/
 
 Getting Started
 ---------------

--- a/docs/running_tests.rst
+++ b/docs/running_tests.rst
@@ -39,7 +39,7 @@ list of possible options::
     cd test_haystack
     ./run_tests.py --help
 
-.. _nose: https://nose.readthedocs.org/en/latest/
+.. _nose: https://nose.readthedocs.io/en/latest/
 
 Configuring Solr
 ================

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -447,7 +447,7 @@ class SolrSearchBackendTestCase(TestCase):
                                              sort_by='distance asc')
 
         # Points in Solr are lat, lon pairs but Django GIS Point() uses lon, lat so we'll check for the flip
-        # See http://django-haystack.readthedocs.org/en/latest/spatial.html#points
+        # See https://django-haystack.readthedocs.io/en/latest/spatial.html#points
         self.assertEqual(kwargs.get('pt'), '4.56,1.23')
         self.assertEqual(kwargs.get('sfield'), 'location')
         self.assertEqual(kwargs.get('sort'), 'geodist() asc')


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.