### PR TITLE
Corrected non-ascii characters in comments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ env
 env3
 *.egg
 .coverage
+.idea
 
 test_haystack/solr_tests/server/solr-4.6.0.tgz
 test_haystack/solr_tests/server/solr4/

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -23,10 +23,10 @@ from haystack.utils.app_loading import haystack_get_model
 try:
     import elasticsearch
     try:
-        # let's try this, for elasticsearch > 1.7.0
+        # let's try this, for elasticsearch > 1.7.0
         from elasticsearch.helpers import bulk
     except ImportError:
-        # let's try this, for elasticsearch <= 1.7.0
+        # let's try this, for elasticsearch <= 1.7.0
         from elasticsearch.helpers import bulk_index as bulk
     from elasticsearch.exceptions import NotFoundError
 except ImportError:


### PR DESCRIPTION
Very minor fix for some non-ascii characters in a comment. This issue was highlighted when upgrading to version 2.3.2 & a hexdump showed a 'c2' character in the space between "# let's".

To illustrate, here are my hexdumps.

Here you can see the version in master
<img width="546" alt="screen shot 2016-06-29 at 10 15 15" src="https://cloud.githubusercontent.com/assets/1461191/16447095/bdf5fa4e-3de2-11e6-92f0-ababa4964c1b.png">

And this is my branch;
<img width="561" alt="screen shot 2016-06-29 at 10 17 17" src="https://cloud.githubusercontent.com/assets/1461191/16447112/d288b41a-3de2-11e6-931a-c491ffa9369a.png">
