### PR TITLE
Update how facet forms / views operate

### DIFF
--- a/docs/faceting.rst
+++ b/docs/faceting.rst
@@ -254,7 +254,7 @@ might look like this::
                     <dt>Author</dt>
                     {# Provide only the top 5 authors #}
                     {% for author in facets.fields.author|slice:":5" %}
-                        <dd><a href="{{ request.get_full_path }}&amp;selected_facets=author_exact:{{ author.0|urlencode }}">{{ author.0 }}</a> ({{ author.1 }})</dd>
+                        <dd><a href="{{ request.get_full_path }}&amp;facets=author_exact:{{ author.0|urlencode }}">{{ author.0 }}</a> ({{ author.1 }})</dd>
                     {% endfor %}
                 {% else %}
                     <p>No author facets.</p>
@@ -283,7 +283,7 @@ and the ``author.1`` is the facet count.
 -----------------------
 
 We've also set ourselves up for the last bit, the drill-down aspect. By
-appending on the ``selected_facets`` to the URLs, we're informing the
+appending on the ``facets`` to the URLs, we're informing the
 ``FacetedSearchForm`` that we want to narrow our results to only those
 containing the author we provided.
 
@@ -305,16 +305,16 @@ For a concrete example, if the facets on author come back as::
 You should present a list similar to::
 
     <ul>
-        <li><a href="/search/?q=Haystack&selected_facets=author_exact:john">john</a> (4)</li>
-        <li><a href="/search/?q=Haystack&selected_facets=author_exact:daniel">daniel</a> (2)</li>
-        <li><a href="/search/?q=Haystack&selected_facets=author_exact:sally">sally</a> (1)</li>
-        <li><a href="/search/?q=Haystack&selected_facets=author_exact:terry">terry</a> (1)</li>
+        <li><a href="/search/?q=Haystack&facets=author_exact:john">john</a> (4)</li>
+        <li><a href="/search/?q=Haystack&facets=author_exact:daniel">daniel</a> (2)</li>
+        <li><a href="/search/?q=Haystack&facets=author_exact:sally">sally</a> (1)</li>
+        <li><a href="/search/?q=Haystack&facets=author_exact:terry">terry</a> (1)</li>
     </ul>
 
 .. warning::
 
     Haystack can automatically handle most details around faceting. However,
-    since ``selected_facets`` is passed directly to narrow, it must use the
+    since ``facets`` is passed directly to narrow, it must use the
     duplicated field name. Improvements to this are planned but incomplete.
 
 This is simply the default behavior but it is possible to override or provide

--- a/docs/views_and_forms.rst
+++ b/docs/views_and_forms.rst
@@ -80,9 +80,21 @@ the selected models.
 ``FacetedSearchForm``
 ---------------------
 
-Identical to the ``SearchForm`` except that it adds a hidden ``selected_facets``
-field onto the form, allowing the form to narrow the results based on the facets
-chosen by the user.
+Identical to the ``SearchForm`` except that it adds a hidden ``facets``
+``MultipleChoiceField`` onto the form, allowing the form to narrow the results 
+based on the facets chosen by the user.
+
+The form has a ``get_choices`` method that allows you to customize the choices
+that you can facet on, and a ``_facet_separator`` property that allows you to
+customize how the querystring will be sent back to the view.
+
+.. note::
+
+    The ``facets`` field was originally named ``selected_facets`` and was not an
+    actual field on the form, but was passed-in as a kwarg to the constructor by
+    the view.
+
+    The data would have been saved in a ``selected_facets`` property of the form.
 
 Creating Your Own Form
 ----------------------

--- a/haystack/generic_views.py
+++ b/haystack/generic_views.py
@@ -90,13 +90,6 @@ class FacetedSearchMixin(SearchMixin):
     form_class = FacetedSearchForm
     facet_fields = None
 
-    def get_form_kwargs(self):
-        kwargs = super(FacetedSearchMixin, self).get_form_kwargs()
-        kwargs.update({
-            'selected_facets': self.request.GET.getlist("selected_facets")
-        })
-        return kwargs
-
     def get_context_data(self, **kwargs):
         context = super(FacetedSearchMixin, self).get_context_data(**kwargs)
         context.update({'facets': self.queryset.facet_counts()})

--- a/haystack/views.py
+++ b/haystack/views.py
@@ -166,16 +166,6 @@ class FacetedSearchView(SearchView):
 
         super(FacetedSearchView, self).__init__(*args, **kwargs)
 
-    def build_form(self, form_kwargs=None):
-        if form_kwargs is None:
-            form_kwargs = {}
-
-        # This way the form can always receive a list containing zero or more
-        # facet expressions:
-        form_kwargs['selected_facets'] = self.request.GET.getlist("selected_facets")
-
-        return super(FacetedSearchView, self).build_form(form_kwargs)
-
     def extra_context(self):
         extra = super(FacetedSearchView, self).extra_context()
         extra['request'] = self.request

--- a/test_haystack/core/forms.py
+++ b/test_haystack/core/forms.py
@@ -1,0 +1,11 @@
+
+from haystack.forms import FacetedSearchForm
+
+
+class CustomChoiceFacetedSearchForm(FacetedSearchForm):
+
+    def get_facet_choices(self):
+        return [
+            ['author:daniel', 'author:daniel'],
+            ['author:chris', 'author:chris']
+        ]


### PR DESCRIPTION
I was working on updating the generic_views and noticed that the faceting views/forms operated in a way I did not expect. Specifically, it required the view to pass in data from the GET Querydict as a kwarg to the form, then the form saved it as a property.

This update aims to make the code follow a more standardized process, letting the form handle the processing and cleaning of the data, and also making it a bit easier to customize.