### PR TITLE
Refactor generic_views

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,3 +113,4 @@ Thanks to
     * Gilad Beeri (@giladbeeri) for adding retries when updating a backend
     * Arjen Verstoep (@terr) for a patch that allows attribute lookups through Django ManyToManyField relationships
     * Tim Babych (@tymofij) for enabling backend-specific parameters in ``.highlight()``
+    * Steve Byerly (@stevebyerly) for various patches.

--- a/haystack/forms.py
+++ b/haystack/forms.py
@@ -66,11 +66,13 @@ class SearchForm(forms.Form):
 
 
 class HighlightedSearchForm(SearchForm):
+
     def search(self):
         return super(HighlightedSearchForm, self).search().highlight()
 
 
 class FacetedSearchForm(SearchForm):
+
     def __init__(self, *args, **kwargs):
         self.selected_facets = kwargs.pop("selected_facets", [])
         super(FacetedSearchForm, self).__init__(*args, **kwargs)
@@ -93,6 +95,7 @@ class FacetedSearchForm(SearchForm):
 
 
 class ModelSearchForm(SearchForm):
+
     def __init__(self, *args, **kwargs):
         super(ModelSearchForm, self).__init__(*args, **kwargs)
         self.fields['models'] = forms.MultipleChoiceField(choices=model_choices(), required=False, label=_('Search In'), widget=forms.CheckboxSelectMultiple)
@@ -113,6 +116,7 @@ class ModelSearchForm(SearchForm):
 
 
 class HighlightedModelSearchForm(ModelSearchForm):
+
     def search(self):
         return super(HighlightedModelSearchForm, self).search().highlight()
 


### PR DESCRIPTION
In using the new generic_views, I noticed that the `SearchView` would be inheriting from `FormMixin` (from the `SearchMixin`) and also `FormView`.

The changes are pretty minor, but I think it helps abstract the views a bit nicer and distinguishes the `mixins` from the `views`. I also removed several properties that shadowed the same defaults as the inherited mixins.