### PR TITLE
refactor highlighting. add new option to prevent text from being trimmed

### DIFF
--- a/docs/highlighting.rst
+++ b/docs/highlighting.rst
@@ -38,8 +38,8 @@ your code. For example::
     >>> highlight.highlight(my_text)
     u'...<span class="highlighted">block</span> that would be more <span class="highlighted">meaningful</span> in real life.'
 
-The default implementation takes three optional kwargs: ``html_tag``,
-``css_class`` and ``max_length``. These allow for basic customizations to the
+The default implementation takes four optional kwargs: ``html_tag``, ``css_class``, 
+``max_length``, and ``trim_text``. These allow for basic customizations to the
 output, like so::
 
     >>> from haystack.utils import Highlighter
@@ -50,6 +50,10 @@ output, like so::
     >>> highlight = Highlighter(my_query, html_tag='div', css_class='found', max_length=35)
     >>> highlight.highlight(my_text)
     u'...<div class="found">block</div> that would be more <div class="found">meaningful</div>...'
+
+    >>> highlight = Highlighter(my_query, css_class='found', trim_text=False)
+    >>> highlight.highlight(my_text)
+    u'This is a sample <span class="found">block</span> that would be more <span class="found">meaningful</span> in real life.'
 
 Further, if this implementation doesn't suit your needs, you can define your own
 custom highlighter class. As long as it implements the API you've just seen, it

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -21,19 +21,30 @@ and 200 characters for the excerpt.
 
 Syntax::
 
-    {% highlight <text_block> with <query> [css_class "class_name"] [html_tag "span"] [max_length 200] %}
+    {% highlight <text_block> with <query> [css_class="highlighted"] [html_tag="span"] [max_length=200] [trim_text=True] %}
 
 Example::
 
+    # In these examples, the template_context will have the following values:
+    # result.summary -> 'This is a sample block that would be more meaningful in real life.'
+    # query -> 'block'
+
     # Highlight summary with default behavior.
     {% highlight result.summary with query %}
+    -> '...<span class="highlighted">block</span> that would be more meaningful in real life.'
     
     # Highlight summary but wrap highlighted words with a div and the
     # following CSS class.
-    {% highlight result.summary with query html_tag "div" css_class "highlight_me_please" %}
+    {% highlight result.summary with query html_tag="div" css_class="highlight_me_please" %}
+    -> '...<div class="highlight_me_please">block</div> that would be more meaningful in real life.'
     
     # Highlight summary but only show 40 words.
-    {% highlight result.summary with query max_length 40 %}
+    {% highlight result.summary with query max_length=40 %}
+    -> '...<div class="highlight_me_please">block</div> that would be more meaningful in r...'
+
+    # Highlight summary and don't trim any text
+    {% highlight result.summary with query trim_text=False %}
+    -> 'This is a sample  <div class="highlight_me_please">block</div> that would be more meaningful in real life.'
 
 The highlighter used by this tag can be overridden as needed. See the
 :doc:`highlighting` documentation for more information.

--- a/test_haystack/test_templatetags.py
+++ b/test_haystack/test_templatetags.py
@@ -10,6 +10,7 @@ from haystack.utils import Highlighter
 
 
 class BorkHighlighter(Highlighter):
+
     def render_html(self, highlight_locations=None, start_offset=None, end_offset=None):
         highlighted_chunk = self.text_block[start_offset:end_offset]
 
@@ -20,6 +21,7 @@ class BorkHighlighter(Highlighter):
 
 
 class TemplateTagTestCase(TestCase):
+
     def render(self, template, context):
         # Why on Earth does Django not have a TemplateTestCase yet?
         t = Template(template)
@@ -60,23 +62,39 @@ the attribute of the object to populate that field with.
         }
         self.assertEqual(self.render(template, context), u'...<span class="highlighted">index</span>ing behavior for your model you can specify your own Search<span class="highlighted">Index</span> class.\nThis is useful for ensuring that future-dated or non-live content is not <span class="highlighted">index</span>ed\nand searchable.\n\nEvery custom Search<span class="highlighted">Index</span> ...')
 
-        template = """{% load highlight %}{% highlight entry with query html_tag "div" css_class "foo" max_length 100 %}"""
+        template = """{% load highlight %}{% highlight entry with query html_tag="div" css_class="foo" max_length=100 %}"""
         context = {
             'entry': self.sample_entry,
             'query': 'field',
         }
         self.assertEqual(self.render(template, context), u'...<div class="foo">field</div> with\ndocument=True. This is the primary <div class="foo">field</div> that will get passed to the backend\nfor indexing...')
 
-        template = """{% load highlight %}{% highlight entry with query html_tag "div" css_class "foo" max_length 100 %}"""
+        template = """{% load highlight %}{% highlight entry with query html_tag="div" css_class="foo" max_length=100 %}"""
         context = {
             'entry': self.sample_entry,
             'query': 'Haystack',
         }
         self.assertEqual(self.render(template, context), u'...<div class="foo">Haystack</div> is very similar to registering models and\nModelAdmin classes in the Django admin site. If y...')
 
-        template = """{% load highlight %}{% highlight "xxxxxxxxxxxxx foo bbxxxxx foo" with "foo" max_length 5 html_tag "span" %}"""
+        template = """{% load highlight %}{% highlight "xxxxxxxxxxxxx foo bbxxxxx foo" with "foo" max_length=5 html_tag="span" %}"""
         context = {}
         self.assertEqual(self.render(template, context), u'...<span class="highlighted">foo</span> b...')
+
+        template = """{% load highlight %}{% highlight "test trim shows leading ellipsis" with "trim" %}"""
+        context = {}
+        self.assertEqual(self.render(template, context), u'...<span class="highlighted">trim</span> shows leading ellipsis')
+
+        template = """{% load highlight %}{% highlight "test trim shows leading ellipsis" with "trim" trim_text=False %}"""
+        context = {}
+        self.assertEqual(self.render(template, context), u'test <span class="highlighted">trim</span> shows leading ellipsis')
+
+        template = """{% load highlight %}{% highlight "test trim shows trailing ellipsis" with "trim" max_length=19 %}"""
+        context = {}
+        self.assertEqual(self.render(template, context), u'...<span class="highlighted">trim</span> shows trailing...')
+
+        template = """{% load highlight %}{% highlight "test trim shows trailing ellipsis" with "trim" max_length=19 trim_text=False %}"""
+        context = {}
+        self.assertEqual(self.render(template, context), u'test <span class="highlighted">trim</span> shows trailing ellipsis')
 
     def test_custom(self):
         # Stow.

--- a/test_haystack/test_utils.py
+++ b/test_haystack/test_utils.py
@@ -161,6 +161,13 @@ class HighlighterTestCase(TestCase):
         self.assertEqual(highlighter.highlight(self.document_2), u'...<span class="highlighted">content</span> of words in no particular order causes nothing to occur.')
         self.assertEqual(highlighter.highlight(self.document_3), u'This is a test of the highlightable words <span class="highlighted">detection</span>. This is only a test. Were this an actual emerge...')
 
+        self.maxDiff = 4000
+
+        highlighter = Highlighter('content detection', trim_text=False)
+        self.assertEqual(highlighter.highlight(self.document_1), u'This is a test of the highlightable words <span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-air.')
+        self.assertEqual(highlighter.highlight(self.document_2), u'The <span class="highlighted">content</span> of words in no particular order causes nothing to occur.')
+        self.assertEqual(highlighter.highlight(self.document_3), u'This is a test of the highlightable words <span class="highlighted">detection</span>. This is only a test. Were this an actual emergency, your text would have exploded in mid-air. The <span class="highlighted">content</span> of words in no particular order causes nothing to occur.')
+
 
 class LoggingFacadeTestCase(TestCase):
     def test_everything_noops_if_settings_are_off(self):


### PR DESCRIPTION
I started this update because I wanted a way to prevent the highlighter from always trimming the text the way it does:
`...<span class="highlighted">this</span> wasn't  ideal`

Since I was adding a fourth option, the current initialization didn't seem ideal (checking the kwargs in various places), so I turned to looping over the passed-in values and setting them in an options dict that gets passed to the Highlighter as its kwargs. Updating how the tag is called helped ease this process, and I also think using `key=value` is a bit more readable.

let me know what you think and if you have any changes you'd like to see.