### PR TITLE
Explicit setting of search indexes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,3 +115,4 @@ Thanks to
     * Tim Babych (@tymofij) for enabling backend-specific parameters in ``.highlight()``
     * Antony Raj (@antonyr) for adding endswith input type and fixing contains input type
     * Morgan Aubert (@ellmetha) for Django 1.10 support
+    * Karl Fleischmann (@fleischie) for enabling the setting of custom search index modules.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -309,3 +309,19 @@ This setting allows you to change the number of terms fuzzy queries will
 expand to when using ``fuzzy`` filter.
 
 Default is ``50``
+
+
+``HAYSTACK_SEARCH_INDEX_MODULES``
+=================================
+
+**Optional**
+
+This setting allows you to directly specify modules, that contain search
+indexes. It is a list of python modules (of the form
+``'package.module.submodule'``), that should be scanned for search index
+models. Invalid or non-existing python modules will be silently ignored. These
+modules will be used in addition to the default modules, that get automatically
+collected by filtering the ``INSTALLED_APPS`` of your project for files named
+``search_indexes.py``.
+
+Default is ``[]``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -316,12 +316,13 @@ Default is ``50``
 
 **Optional**
 
-This setting allows you to directly specify modules, that contain search
-indexes. It is a list of python modules (of the form
-``'package.module.submodule'``), that should be scanned for search index
-models. Invalid or non-existing python modules will be silently ignored. These
-modules will be used in addition to the default modules, that get automatically
-collected by filtering the ``INSTALLED_APPS`` of your project for files named
-``search_indexes.py``.
+This setting allows you to directly specify modules that contain search
+indexes instead of/in addition to relying on ``search_index.py`` files
+residing in your installed apps. It is a list of dotted paths to python
+modules (of the form ``'package.module.submodule'``) that should be scanned
+for search index classes. Invalid or non-existing python modules will be
+silently ignored. These modules will be used in addition to the default
+modules that are automatically collected by searching the ``INSTALLED_APPS``
+of your project.
 
 Default is ``[]``

--- a/haystack/utils/app_loading.py
+++ b/haystack/utils/app_loading.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.apps import apps
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 __all__ = ['haystack_get_models', 'haystack_load_apps']
@@ -13,6 +14,13 @@ MODEL = 'model'
 def haystack_get_app_modules():
     """Return the Python module for each installed app"""
     return [i.module for i in apps.get_app_configs()]
+
+def haystack_get_search_indexes():
+    """Return all modules to collect search indexes in"""
+    app_modules = ['%s.search_indexes' % app_mod.__name__ for app_mod in haystack_get_app_modules()]
+    app_modules.extend(getattr(settings, 'HAYSTACK_SEARCH_INDEX_MODULES', []))
+
+    return app_modules
 
 def haystack_load_apps():
     """Return a list of app labels for all installed applications which have models"""

--- a/haystack/utils/app_loading.py
+++ b/haystack/utils/app_loading.py
@@ -17,8 +17,9 @@ def haystack_get_app_modules():
 
 def haystack_get_search_indexes():
     """Return all modules to collect search indexes in"""
-    app_modules = ['%s.search_indexes' % app_mod.__name__ for app_mod in haystack_get_app_modules()]
-    app_modules.extend(getattr(settings, 'HAYSTACK_SEARCH_INDEX_MODULES', []))
+    app_modules = [(app_mod, '%s.search_indexes' % app_mod.__name__) for app_mod in haystack_get_app_modules()]
+    custom_search_indexes = getattr(settings, 'HAYSTACK_SEARCH_INDEX_MODULES', [])
+    app_modules.extend([(None, search_index) for search_index in custom_search_indexes])
 
     return app_modules
 

--- a/haystack/utils/app_loading.py
+++ b/haystack/utils/app_loading.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.apps import apps
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 __all__ = ['haystack_get_models', 'haystack_load_apps']
@@ -14,14 +13,6 @@ MODEL = 'model'
 def haystack_get_app_modules():
     """Return the Python module for each installed app"""
     return [i.module for i in apps.get_app_configs()]
-
-def haystack_get_search_indexes():
-    """Return all modules to collect search indexes in"""
-    app_modules = [(app_mod, '%s.search_indexes' % app_mod.__name__) for app_mod in haystack_get_app_modules()]
-    custom_search_indexes = getattr(settings, 'HAYSTACK_SEARCH_INDEX_MODULES', [])
-    app_modules.extend([(None, search_index) for search_index in custom_search_indexes])
-
-    return app_modules
 
 def haystack_load_apps():
     """Return a list of app labels for all installed applications which have models"""

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -186,12 +186,13 @@ class UnifiedIndex(object):
     def collect_indexes(self):
         indexes = []
 
-        for app_mod in haystack_get_search_indexes():
+        for module, search_index in haystack_get_search_indexes():
             try:
-                search_index_module = importlib.import_module(app_mod)
+                search_index_module = importlib.import_module(search_index)
             except ImportError:
-                module_splits = app_mod.split('.')
-                if module_has_submodule('.'.join(module_splits[:-1]), module_splits[-1]):
+                module_splits = search_index.split('.')
+                if (module is not None and
+                        module_has_submodule(module, module_splits[-1]):
                     raise
 
                 continue
@@ -199,7 +200,7 @@ class UnifiedIndex(object):
             for item_name, item in inspect.getmembers(search_index_module, inspect.isclass):
                 if getattr(item, 'haystack_use_for_indexing', False) and getattr(item, 'get_model', None):
                     # We've got an index. Check if we should be ignoring it.
-                    class_path = "%s.%s" % (app_mod, item_name)
+                    class_path = "%s.%s" % (search_index, item_name)
 
                     if class_path in self.excluded_indexes or self.excluded_indexes_ids.get(item_name) == id(item):
                         self.excluded_indexes_ids[str(item_name)] = id(item)

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -192,7 +192,7 @@ class UnifiedIndex(object):
             except ImportError:
                 module_splits = search_index.split('.')
                 if (module is not None and
-                        module_has_submodule(module, module_splits[-1]):
+                        module_has_submodule(module, module_splits[-1])):
                     raise
 
                 continue

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -15,7 +15,16 @@ from django.utils.module_loading import module_has_submodule
 
 from haystack.exceptions import NotHandled, SearchFieldError
 from haystack.utils import importlib
-from haystack.utils.app_loading import haystack_get_search_indexes
+from haystack.utils.app_loading import haystack_get_app_modules
+
+
+def haystack_get_search_indexes():
+    """Return all modules to collect search indexes in"""
+    app_modules = [(app_mod, '%s.search_indexes' % app_mod.__name__) for app_mod in haystack_get_app_modules()]
+    custom_search_indexes = getattr(settings, 'HAYSTACK_SEARCH_INDEX_MODULES', [])
+    app_modules.extend([(None, search_index) for search_index in custom_search_indexes])
+
+    return app_modules
 
 
 def import_class(path):

--- a/test_haystack/custom_search_indexes/custom_indexes.py
+++ b/test_haystack/custom_search_indexes/custom_indexes.py
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from test_haystack.discovery.models import Foo
+
+from haystack import indexes
+
+
+class FooIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, model_attr='body')
+
+    def get_model(self):
+        return Foo

--- a/test_haystack/custom_search_indexes/custom_search_indexes.py
+++ b/test_haystack/custom_search_indexes/custom_search_indexes.py
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from test_haystack.discovery.models import Bar
+
+from haystack import indexes
+
+
+class BarIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True)
+
+    def get_model(self):
+        return Bar

--- a/test_haystack/custom_search_indexes/models.py
+++ b/test_haystack/custom_search_indexes/models.py
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.db import models
+
+
+class Foo(models.Model):
+    title = models.CharField(max_length=255)
+    body = models.TextField()
+
+    def __unicode__(self):
+        return self.title
+
+
+class Bar(models.Model):
+    author = models.CharField(max_length=255)
+    content = models.TextField()
+
+    def __unicode__(self):
+        return self.author

--- a/test_haystack/custom_search_indexes/templates/search/indexes/bar_text.txt
+++ b/test_haystack/custom_search_indexes/templates/search/indexes/bar_text.txt
@@ -1,0 +1,2 @@
+{{ object.title }}
+{{ object.body }}

--- a/test_haystack/test_app_loading.py
+++ b/test_haystack/test_app_loading.py
@@ -28,20 +28,20 @@ class AppLoadingTests(TestCase):
 
     def test_get_search_indexes_with_unset_custom_search_indexes(self):
         search_indexes = app_loading.haystack_get_search_indexes()
-        app_modules = [i.__name__ for i in app_loading.haystack_get_app_modules()]
+        app_modules = app_loading.haystack_get_app_modules()
 
         self.assertEqual(len(search_indexes), len(app_modules))
         for i in app_modules:
-            self.assertIn('%s.search_indexes' % i, search_indexes)
+            self.assertIn((i, '%s.search_indexes' % i.__name__), search_indexes)
 
     def test_get_search_indexes_with_empty_custom_search_indexes(self):
         with self.settings(HAYSTACK_SEARCH_INDEX_MODULES=[]):
             search_indexes = app_loading.haystack_get_search_indexes()
-        app_modules = [i.__name__ for i in app_loading.haystack_get_app_modules()]
+        app_modules = app_loading.haystack_get_app_modules()
 
         self.assertEqual(len(search_indexes), len(app_modules))
         for i in app_modules:
-            self.assertIn('%s.search_indexes' % i, search_indexes)
+            self.assertIn((i, '%s.search_indexes' % i.__name__), search_indexes)
 
     def test_get_search_indexes_with_custom_search_indexes(self):
         SEARCH_INDEX_MODULES = [
@@ -53,7 +53,7 @@ class AppLoadingTests(TestCase):
             search_indexes = app_loading.haystack_get_search_indexes()
 
         for i in SEARCH_INDEX_MODULES:
-            self.assertIn(i, search_indexes)
+            self.assertIn((None, i), search_indexes)
 
     def test_get_search_indexes_custom_search_indexes_extend_app_modules(self):
         SEARCH_INDEX_MODULES = [
@@ -63,11 +63,11 @@ class AppLoadingTests(TestCase):
 
         with self.settings(HAYSTACK_SEARCH_INDEX_MODULES=SEARCH_INDEX_MODULES):
             search_indexes = app_loading.haystack_get_search_indexes()
-            app_modules = [i.__name__ for i in app_loading.haystack_get_app_modules()]
+            app_modules = app_loading.haystack_get_app_modules()
 
         self.assertGreater(len(search_indexes), len(app_modules))
         for i in SEARCH_INDEX_MODULES:
-            self.assertIn(i, search_indexes)
+            self.assertIn((None, i), search_indexes)
         self.assertEqual(len(search_indexes),
                          len(app_modules) + len(SEARCH_INDEX_MODULES))
 

--- a/test_haystack/test_app_loading.py
+++ b/test_haystack/test_app_loading.py
@@ -26,6 +26,51 @@ class AppLoadingTests(TestCase):
         for i in app_modules:
             self.assertIsInstance(i, ModuleType)
 
+    def test_get_search_indexes_with_unset_custom_search_indexes(self):
+        search_indexes = app_loading.haystack_get_search_indexes()
+        app_modules = [i.__name__ for i in app_loading.haystack_get_app_modules()]
+
+        self.assertEqual(len(search_indexes), len(app_modules))
+        for i in app_modules:
+            self.assertIn('%s.search_indexes' % i, search_indexes)
+
+    def test_get_search_indexes_with_empty_custom_search_indexes(self):
+        with self.settings(HAYSTACK_SEARCH_INDEX_MODULES=[]):
+            search_indexes = app_loading.haystack_get_search_indexes()
+        app_modules = [i.__name__ for i in app_loading.haystack_get_app_modules()]
+
+        self.assertEqual(len(search_indexes), len(app_modules))
+        for i in app_modules:
+            self.assertIn('%s.search_indexes' % i, search_indexes)
+
+    def test_get_search_indexes_with_custom_search_indexes(self):
+        SEARCH_INDEX_MODULES = [
+            'test_haystack.custom_search_indexes.custom_search_indexes',
+            'test_haystack.custom_search_indexes.custom_indexes',
+        ]
+
+        with self.settings(HAYSTACK_SEARCH_INDEX_MODULES=SEARCH_INDEX_MODULES):
+            search_indexes = app_loading.haystack_get_search_indexes()
+
+        for i in SEARCH_INDEX_MODULES:
+            self.assertIn(i, search_indexes)
+
+    def test_get_search_indexes_custom_search_indexes_extend_app_modules(self):
+        SEARCH_INDEX_MODULES = [
+            'test_haystack.custom_search_indexes.custom_search_indexes',
+            'test_haystack.custom_search_indexes.custom_indexes',
+        ]
+
+        with self.settings(HAYSTACK_SEARCH_INDEX_MODULES=SEARCH_INDEX_MODULES):
+            search_indexes = app_loading.haystack_get_search_indexes()
+            app_modules = [i.__name__ for i in app_loading.haystack_get_app_modules()]
+
+        self.assertGreater(len(search_indexes), len(app_modules))
+        for i in SEARCH_INDEX_MODULES:
+            self.assertIn(i, search_indexes)
+        self.assertEqual(len(search_indexes),
+                         len(app_modules) + len(SEARCH_INDEX_MODULES))
+
     def test_get_models_all(self):
         models = app_loading.haystack_get_models('core')
         self.assertIsInstance(models, (list, GeneratorType))

--- a/test_haystack/test_app_loading.py
+++ b/test_haystack/test_app_loading.py
@@ -26,51 +26,6 @@ class AppLoadingTests(TestCase):
         for i in app_modules:
             self.assertIsInstance(i, ModuleType)
 
-    def test_get_search_indexes_with_unset_custom_search_indexes(self):
-        search_indexes = app_loading.haystack_get_search_indexes()
-        app_modules = app_loading.haystack_get_app_modules()
-
-        self.assertEqual(len(search_indexes), len(app_modules))
-        for i in app_modules:
-            self.assertIn((i, '%s.search_indexes' % i.__name__), search_indexes)
-
-    def test_get_search_indexes_with_empty_custom_search_indexes(self):
-        with self.settings(HAYSTACK_SEARCH_INDEX_MODULES=[]):
-            search_indexes = app_loading.haystack_get_search_indexes()
-        app_modules = app_loading.haystack_get_app_modules()
-
-        self.assertEqual(len(search_indexes), len(app_modules))
-        for i in app_modules:
-            self.assertIn((i, '%s.search_indexes' % i.__name__), search_indexes)
-
-    def test_get_search_indexes_with_custom_search_indexes(self):
-        SEARCH_INDEX_MODULES = [
-            'test_haystack.custom_search_indexes.custom_search_indexes',
-            'test_haystack.custom_search_indexes.custom_indexes',
-        ]
-
-        with self.settings(HAYSTACK_SEARCH_INDEX_MODULES=SEARCH_INDEX_MODULES):
-            search_indexes = app_loading.haystack_get_search_indexes()
-
-        for i in SEARCH_INDEX_MODULES:
-            self.assertIn((None, i), search_indexes)
-
-    def test_get_search_indexes_custom_search_indexes_extend_app_modules(self):
-        SEARCH_INDEX_MODULES = [
-            'test_haystack.custom_search_indexes.custom_search_indexes',
-            'test_haystack.custom_search_indexes.custom_indexes',
-        ]
-
-        with self.settings(HAYSTACK_SEARCH_INDEX_MODULES=SEARCH_INDEX_MODULES):
-            search_indexes = app_loading.haystack_get_search_indexes()
-            app_modules = app_loading.haystack_get_app_modules()
-
-        self.assertGreater(len(search_indexes), len(app_modules))
-        for i in SEARCH_INDEX_MODULES:
-            self.assertIn((None, i), search_indexes)
-        self.assertEqual(len(search_indexes),
-                         len(app_modules) + len(SEARCH_INDEX_MODULES))
-
     def test_get_models_all(self):
         models = app_loading.haystack_get_models('core')
         self.assertIsInstance(models, (list, GeneratorType))


### PR DESCRIPTION
Allow users to set specific search index modules via the `HAYSTACK_SEARCH_INDEX_MODULES` setting attribute.

I took care to add test cases for the use cases I modified. Although I must admit, that I didn't took the time to test out several Python/Django versions and combinations.
