### PR TITLE
Converting an empty list to int might fail

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -276,7 +276,7 @@ class IntegerField(SearchField):
         return self.convert(super(IntegerField, self).prepare(obj))
 
     def convert(self, value):
-        if value is None:
+        if not value: 
             return None
 
         return int(value)


### PR DESCRIPTION
In this context just checking the truthiness is enough than checking the object to None. Here is an example case where it throws TypeError and not handled properly.

https://www.dropbox.com/s/ff3ma22x8413l61/Screenshot%202016-09-26%2014.15.06.png?dl=0