### PR TITLE
Fix object not iterable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ env3
 # Build artifacts from test setup
 *.tgz
 test_haystack/solr_tests/server/solr4/
+
+haystack_tests.db

--- a/AUTHORS
+++ b/AUTHORS
@@ -114,3 +114,4 @@ Thanks to
     * Arjen Verstoep (@terr) for a patch that allows attribute lookups through Django ManyToManyField relationships
     * Tim Babych (@tymofij) for enabling backend-specific parameters in ``.highlight()``
     * Antony Raj (@antonyr) for adding endswith input type and fixing contains input type
+    * Henrique Chehad (@henriquechehad) for some patches

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -153,8 +153,8 @@ class SearchField(object):
                 return current_objects.all()
             return []
 
-        elif not hasattr(current_objects, '__iter__'):
-            current_objects = [current_objects]
+        if not isinstance(current_objects, list):
+            return [current_objects]
 
         return current_objects
 


### PR DESCRIPTION
Fix of "'Model' object is not iterable", occurs when save a object and update the index.

![captura de tela 2016-09-28 as 12 36 39](https://cloud.githubusercontent.com/assets/1929407/18922393/d540dfc8-857e-11e6-9844-e1adf437976e.jpg)

![captura de tela 2016-09-28 as 12 36 22](https://cloud.githubusercontent.com/assets/1929407/18922400/da55654c-857e-11e6-98db-c900061aae3d.jpg)
