### PR TITLE
Upgrade setuptools in Travis so urllib3-1.18 installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
     - mkdir -p $HOME/download-cache
 
 install:
+    - pip install --upgrade setuptools
     - pip install requests "Django${DJANGO_VERSION}"
     - python setup.py clean build install
 


### PR DESCRIPTION
The version of setuptools in Travis is too old to handle <= as an
environment marker.

This fixes https://github.com/django-haystack/django-haystack/issues/1442

Signed-off-by: Jeremy Cline <jeremy@jcline.org>