### PR TITLE
Add support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,10 @@ env:
     matrix:
         - DJANGO_VERSION=">=1.8,<1.9"
         - DJANGO_VERSION=">=1.9,<1.10"
-        - DJANGO_VERSION="==1.10a1"
+        - DJANGO_VERSION=">=1.10,<1.11"
 
 matrix:
     allow_failures:
-        - env: DJANGO_VERSION="==1.10a1"
         - python: 'pypy'
 
 services:

--- a/AUTHORS
+++ b/AUTHORS
@@ -114,3 +114,4 @@ Thanks to
     * Arjen Verstoep (@terr) for a patch that allows attribute lookups through Django ManyToManyField relationships
     * Tim Babych (@tymofij) for enabling backend-specific parameters in ``.highlight()``
     * Antony Raj (@antonyr) for adding endswith input type and fixing contains input type
+    * Morgan Aubert (@ellmetha) for Django 1.10 support

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -64,7 +64,10 @@ get_identifier = _lookup_identifier_method()
 
 
 def get_model_ct_tuple(model):
-    return (model._meta.app_label, model._meta.model_name)
+    # Deferred models should be identified as if they were the underlying model.
+    model_name = model._meta.concrete_model._meta.model_name \
+        if hasattr(model, '_deferred') and model._deferred else model._meta.model_name
+    return (model._meta.app_label, model_name)
 
 def get_model_ct(model):
     return "%s.%s" % get_model_ct_tuple(model)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 install_requires = [
     'Django>=1.8',
-    'Django<1.10',
+    'Django<1.11',
 ]
 
 tests_require = [

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -1126,11 +1126,10 @@ class LiveElasticsearchMoreLikeThisTestCase(TestCase):
         if hasattr(MockModel.objects, 'defer'):
             # Make sure MLT works with deferred bits.
             mi = MockModel.objects.defer('foo').get(pk=1)
-            self.assertEqual(mi._deferred, True)
             deferred = self.sqs.models(MockModel).more_like_this(mi)
-            self.assertEqual(deferred.count(), 0)
-            self.assertEqual([result.pk for result in deferred], [])
-            self.assertEqual(len([result.pk for result in deferred]), 0)
+            self.assertEqual(deferred.count(), 4)
+            self.assertEqual(set([result.pk for result in deferred]), set([u'2', u'6', u'16', u'23']))
+            self.assertEqual(len([result.pk for result in deferred]), 4)
 
         # Ensure that swapping the ``result_class`` works.
         self.assertTrue(isinstance(self.sqs.result_class(MockSearchResult).more_like_this(MockModel.objects.get(pk=1))[0], MockSearchResult))

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -394,12 +394,12 @@ class SolrSearchBackendTestCase(TestCase):
         highlight_dict = {'simple.pre':'<i>', 'simple.post': '</i>'}
         self.assertEqual(self.sb.search('', highlight=highlight_dict), {'hits': 0, 'results': []})
         self.assertEqual(self.sb.search('Index', highlight=highlight_dict)['hits'], 3)
-        self.assertEqual([result.highlighted['text'][0] for result in self.sb.search('Index', highlight=highlight_dict)['results']], 
+        self.assertEqual([result.highlighted['text'][0] for result in self.sb.search('Index', highlight=highlight_dict)['results']],
             ['<i>Indexed</i>!\n1', '<i>Indexed</i>!\n2', '<i>Indexed</i>!\n3'])
 
         # full-form highlighting options
         highlight_dict = {'hl.simple.pre':'<i>', 'hl.simple.post': '</i>'}
-        self.assertEqual([result.highlighted['text'][0] for result in self.sb.search('Index', highlight=highlight_dict)['results']], 
+        self.assertEqual([result.highlighted['text'][0] for result in self.sb.search('Index', highlight=highlight_dict)['results']],
             ['<i>Indexed</i>!\n1', '<i>Indexed</i>!\n2', '<i>Indexed</i>!\n3'])
 
         self.assertEqual(self.sb.search('Indx')['hits'], 0)
@@ -1233,12 +1233,10 @@ class LiveSolrMoreLikeThisTestCase(TestCase):
 
     def test_more_like_this_defer(self):
         mi = MockModel.objects.defer('foo').get(pk=1)
-        # FIXME: this currently is known to fail because haystack.utils.loading doesn't see the
-        #        MockModel_Deferred_foo class as registered:
         deferred = self.sqs.models(MockModel).more_like_this(mi)
-        self.assertEqual(deferred.count(), 0)
-        self.assertEqual([result.pk for result in deferred], [])
-        self.assertEqual(len([result.pk for result in deferred]), 0)
+        top_results = [int(result.pk) for result in deferred[:5]]
+        for i in (14, 6, 4, 22, 10):
+            self.assertIn(i, top_results)
 
     def test_more_like_this_custom_result_class(self):
         """Ensure that swapping the ``result_class`` works"""

--- a/test_haystack/test_views.py
+++ b/test_haystack/test_views.py
@@ -8,6 +8,7 @@ from django import forms
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpRequest, QueryDict
+from django.test import override_settings
 from django.test import TestCase
 from django.utils.six.moves import queue
 from test_haystack.core.models import AnotherMockModel, MockModel
@@ -152,9 +153,9 @@ class SearchViewTestCase(TestCase):
             del settings.HAYSTACK_CONNECTIONS['default']['INCLUDE_SPELLING']
 
 
+@override_settings(ROOT_URLCONF='test_haystack.results_per_page_urls')
 class ResultsPerPageTestCase(TestCase):
     fixtures = ['base_data']
-    urls = 'test_haystack.results_per_page_urls'
 
     def setUp(self):
         super(ResultsPerPageTestCase, self).setUp()

--- a/test_haystack/whoosh_tests/test_whoosh_backend.py
+++ b/test_haystack/whoosh_tests/test_whoosh_backend.py
@@ -901,12 +901,11 @@ class LiveWhooshMoreLikeThisTestCase(WhooshTestCase):
 
         if hasattr(MockModel.objects, 'defer'):
             # Make sure MLT works with deferred bits.
-            mi = MockModel.objects.defer('foo').get(pk=21)
-            self.assertEqual(mi._deferred, True)
+            mi = MockModel.objects.defer('foo').get(pk=22)
             deferred = self.sqs.models(MockModel).more_like_this(mi)
-            self.assertEqual(deferred.count(), 0)
-            self.assertEqual([result.pk for result in deferred], [])
-            self.assertEqual(len([result.pk for result in deferred]), 0)
+            self.assertEqual(deferred.count(), 22)
+            self.assertEqual(sorted([result.pk for result in deferred]), sorted([u'9', u'8', u'7', u'6', u'5', u'4', u'3', u'2', u'1', u'21', u'20', u'19', u'18', u'17', u'16', u'15', u'14', u'13', u'12', u'11', u'10', u'23']))
+            self.assertEqual(len([result.pk for result in deferred]), 22)
 
         # Ensure that swapping the ``result_class`` works.
         self.assertTrue(isinstance(self.sqs.result_class(MockSearchResult).more_like_this(MockModel.objects.get(pk=21))[0], MockSearchResult))

--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,23 @@
 envlist = docs,
         py27-django1.8,
         py27-django1.9,
+        py27-django1.10,
         py34-django1.8,
         py34-django1.9,
+        py34-django1.10,
         py35-django1.8,
         py35-django1.9,
+        py35-django1.10,
         pypy-django1.8,
         pypy-django1.9,
+        pypy-django1.10,
 
 [base]
 deps = requests
+
+[django1.10]
+deps =
+    Django>=1.10,<1.11
 
 [django1.9]
 deps =
@@ -35,6 +43,11 @@ deps =
     {[django1.9]deps}
     {[base]deps}
 
+[testenv:pypy-django1.10]
+deps =
+    {[django1.10]deps}
+    {[base]deps}
+
 [testenv:py27-django1.8]
 basepython = python2.7
 deps =
@@ -45,6 +58,12 @@ deps =
 basepython = python2.7
 deps =
     {[django1.9]deps}
+    {[base]deps}
+
+[testenv:py27-django1.10]
+basepython = python2.7
+deps =
+    {[django1.10]deps}
     {[base]deps}
 
 [testenv:py34-django1.8]
@@ -59,6 +78,12 @@ deps =
     {[django1.9]deps}
     {[base]deps}
 
+[testenv:py34-django1.10]
+basepython = python3.4
+deps =
+    {[django1.10]deps}
+    {[base]deps}
+
 [testenv:py35-django1.8]
 basepython = python3.5
 deps =
@@ -69,6 +94,12 @@ deps =
 basepython = python3.5
 deps =
     {[django1.9]deps}
+    {[base]deps}
+
+[testenv:py35-django1.10]
+basepython = python3.5
+deps =
+    {[django1.10]deps}
     {[base]deps}
 
 [testenv:docs]


### PR DESCRIPTION
*Support for Django 1.10*
Refs: #1437, #1434

I had to fix the ``haystack.utils.default_get_identifier`` function so that it returns a correct identifier when used with instances whose fields have been deferred. Django 1.10 removed the dynamic model classes that were generated when using ``QuerySet.defer()`` and ``only()``: some tests were failing because of that (the ones related to the use of deferred objects with MLT queries).
