### PR TITLE
reStructuredText link format fixes.

### DIFF
--- a/docs/backend_support.rst
+++ b/docs/backend_support.rst
@@ -50,7 +50,7 @@ Elasticsearch
 * Stored (non-indexed) fields
 * Highlighting
 * Spatial search
-* Requires: elasticsearch-py > 1.0 & Elasticsearch 1.0+ (Neither Elasticsearch 2.X `#1247 <https://github.com/django-haystack/django-haystack/issues/1247>` nor Elasticsearch 5.X `#1383 <https://github.com/django-haystack/django-haystack/issues/1383>` are supported yet._)
+* Requires: elasticsearch-py > 1.0 & Elasticsearch 1.0+ (Neither Elasticsearch 2.X `#1247 <https://github.com/django-haystack/django-haystack/issues/1247>`_ nor Elasticsearch 5.X `#1383 <https://github.com/django-haystack/django-haystack/issues/1383>`_ are supported yet.)
 
 Whoosh
 ------


### PR DESCRIPTION
Doh! My first attempt at a `reStructuredText` doc. Didn't understand inline links formatting, at all. Now I sorta do.