### PR TITLE
Fix "more like this" w/ filter

### DIFF
--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -1007,6 +1007,8 @@ class BaseSearchQuery(object):
         clone._raw_query = self._raw_query
         clone._raw_query_params = self._raw_query_params
         clone.spelling_query = self.spelling_query
+        clone._more_like_this = self._more_like_this
+        clone._mlt_instance = self._mlt_instance
 
         return clone
 

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -1225,6 +1225,13 @@ class LiveSolrMoreLikeThisTestCase(TestCase):
         for i in (16, 17, 19, 22, 23):
             self.assertIn(i, top_filtered_results)
 
+        mlt_filtered = self.sqs.more_like_this(MockModel.objects.get(pk=3)).filter(name='daniel3')
+        self.assertLess(mlt_filtered.count(), all_mlt.count())
+        top_mlt_filtered_pks = [int(result.pk) for result in mlt_filtered[:5]]
+
+        for i in (17, 16, 19, 23, 22):
+            self.assertIn(i, top_mlt_filtered_pks)
+
         filtered_mlt_with_models = self.sqs.models(MockModel).more_like_this(MockModel.objects.get(pk=1))
         self.assertLessEqual(filtered_mlt_with_models.count(), all_mlt.count())
         top_filtered_with_models = [int(result.pk) for result in filtered_mlt_with_models[:5]]


### PR DESCRIPTION
This is a follow-up from #629 by @JoshData. I pulled out the more_like_this change and added a test to cover it. Previously, if you took `more_like_this()` results and called `filter()` on it, the result would "forget" about the more_like_this part of the query, and you would get all documents that match the filter. (in primary key order) The new test does just this, and then checks the results. The fix is straigthforward, updating `_clone()` to copy both `_more_like_this` and `_mlt_instance`.