### PR TITLE
test to test doc boost and field weight

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -190,9 +190,9 @@ class WhooshSearchBackend(BaseSearchBackend):
                 # other way.
                 for key in doc:
                     doc[key] = self._from_python(doc[key])
-
-                # Document boosts aren't supported in Whoosh 2.5.0+.
+                # Document boosts are supported in Whoosh 2.0+ via `_boost` kwarg
                 if 'boost' in doc:
+                    doc['_boost'] = doc['boost']
                     del doc['boost']
 
                 try:

--- a/test_haystack/run_tests.py
+++ b/test_haystack/run_tests.py
@@ -19,6 +19,8 @@ def run_all(argv=None):
             '--cover-erase', '--verbose',
         ]
 
+    argv.extend([str('--nocapture')])
+
     nose.run_exit(
         argv=argv,
         defaultTest=abspath(dirname(__file__))


### PR DESCRIPTION
I made a test to test Whoosh's _boost using @DylannCordel's PR https://github.com/django-haystack/django-haystack/pull/1425. Can you take a look? If this is sufficient, it'd be nice to get this into 2.5.2 or whatever the next version is so that boost will be "reprecated". :)