### PR TITLE
Refactored build_search_kwargs on Elasticsearch backends

### DIFF
--- a/haystack/backends/elasticsearch2_backend.py
+++ b/haystack/backends/elasticsearch2_backend.py
@@ -10,7 +10,6 @@ from haystack.backends.elasticsearch_backend import ElasticsearchSearchBackend, 
 from haystack.constants import DJANGO_CT
 from haystack.exceptions import MissingDependency
 from haystack.utils import get_identifier, get_model_ct
-from haystack.utils import log as logging
 
 try:
     import elasticsearch
@@ -70,37 +69,10 @@ class Elasticsearch2SearchBackend(ElasticsearchSearchBackend):
             else:
                 self.log.error("Failed to clear Elasticsearch index: %s", e, exc_info=True)
 
-    def build_search_kwargs(self, query_string, sort_by=None, start_offset=0, end_offset=None,
-                            fields='', highlight=False, facets=None,
-                            date_facets=None, query_facets=None,
-                            narrow_queries=None, spelling_query=None,
-                            within=None, dwithin=None, distance_point=None,
-                            models=None, limit_to_registered_models=None,
-                            result_class=None):
-        kwargs = super(Elasticsearch2SearchBackend, self).build_search_kwargs(query_string, sort_by,
-                                                                              start_offset, end_offset,
-                                                                              fields, highlight,
-                                                                              spelling_query=spelling_query,
-                                                                              within=within, dwithin=dwithin,
-                                                                              distance_point=distance_point,
-                                                                              models=models,
-                                                                              limit_to_registered_models=
-                                                                              limit_to_registered_models,
-                                                                              result_class=result_class)
-
-        filters = []
-        if start_offset is not None:
-            kwargs['from'] = start_offset
-
-        if end_offset is not None:
-            kwargs['size'] = end_offset - start_offset
-
-        if narrow_queries is None:
-            narrow_queries = set()
+    def _build_search_kwargs_facets(self, facets, date_facets, query_facets):
+        result = {}
 
         if facets is not None:
-            kwargs.setdefault('aggs', {})
-
             for facet_fieldname, extra_options in facets.items():
                 facet_options = {
                     'meta': {
@@ -119,11 +91,9 @@ class Elasticsearch2SearchBackend(ElasticsearchSearchBackend):
                 if 'facet_filter' in extra_options:
                     facet_options['facet_filter'] = extra_options.pop('facet_filter')
                 facet_options['terms'].update(extra_options)
-                kwargs['aggs'][facet_fieldname] = facet_options
+                result[facet_fieldname] = facet_options
 
         if date_facets is not None:
-            kwargs.setdefault('aggs', {})
-
             for facet_fieldname, value in date_facets.items():
                 # Need to detect on gap_by & only add amount if it's more than one.
                 interval = value.get('gap_by').lower()
@@ -133,7 +103,7 @@ class Elasticsearch2SearchBackend(ElasticsearchSearchBackend):
                     # Just the first character is valid for use.
                     interval = "%s%s" % (value['gap_amount'], interval[:1])
 
-                kwargs['aggs'][facet_fieldname] = {
+                result[facet_fieldname] = {
                     'meta': {
                         '_type': 'date_histogram',
                     },
@@ -157,10 +127,8 @@ class Elasticsearch2SearchBackend(ElasticsearchSearchBackend):
                 }
 
         if query_facets is not None:
-            kwargs.setdefault('aggs', {})
-
             for facet_fieldname, value in query_facets:
-                kwargs['aggs'][facet_fieldname] = {
+                result[facet_fieldname] = {
                     'meta': {
                         '_type': 'query',
                     },
@@ -171,31 +139,14 @@ class Elasticsearch2SearchBackend(ElasticsearchSearchBackend):
                     },
                 }
 
-        for q in narrow_queries:
-            filters.append({
-                'query_string': {
-                    'query': q
-                }
-            })
+        return 'aggs', result
 
-        # if we want to filter, change the query type to filteres
-        if filters:
-            kwargs["query"] = {"filtered": {"query": kwargs.pop("query")}}
-            filtered = kwargs["query"]["filtered"]
-            if 'filter' in filtered:
-                if "bool" in filtered["filter"].keys():
-                    another_filters = kwargs['query']['filtered']['filter']['bool']['must']
-                else:
-                    another_filters = [kwargs['query']['filtered']['filter']]
-            else:
-                another_filters = filters
-
-            if len(another_filters) == 1:
-                kwargs['query']['filtered']["filter"] = another_filters[0]
-            else:
-                kwargs['query']['filtered']["filter"] = {"bool": {"must": another_filters}}
-
-        return kwargs
+    def _build_search_filters_narrow_query(self, q):
+        return {
+            'query_string': {
+                'query': q
+            }
+        }
 
     def more_like_this(self, model_instance, additional_query_string=None,
                        start_offset=0, end_offset=None, models=None,

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -251,9 +251,9 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             else:
                 self.log.error("Failed to clear Elasticsearch index: %s", e, exc_info=True)
 
-    def build_search_kwargs(self, query_string, sort_by=None, start_offset=0, end_offset=None,
-                            fields='', highlight=False, facets=None,
-                            date_facets=None, query_facets=None,
+    def build_search_kwargs(self, query_string, sort_by=None, start_offset=0,
+                            end_offset=None, fields='', highlight=False,
+                            facets=None, date_facets=None, query_facets=None,
                             narrow_queries=None, spelling_query=None,
                             within=None, dwithin=None, distance_point=None,
                             models=None, limit_to_registered_models=None,
@@ -261,14 +261,86 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         index = haystack.connections[self.connection_alias].get_unified_index()
         content_field = index.document_field
 
+        kwargs = self._build_search_kwargs_default(content_field, query_string)
+
+        # so far, no filters
+        filters = []
+
+        if fields:
+            field, result = self._build_search_kwargs_fields(fields)
+            kwargs[field] = result
+
+        if sort_by is not None:
+            kwargs['sort'] = self._build_search_kwargs_sort(distance_point,
+                                                            sort_by)
+
+        # From/size offsets don't seem to work right in Elasticsearch's DSL. :/
+        # if start_offset is not None:
+        #     kwargs['from'] = start_offset
+
+        # if end_offset is not None:
+        #     kwargs['size'] = end_offset - start_offset
+
+        if highlight:
+            # `highlight` can either be True or a dictionary containing custom parameters
+            # which will be passed to the backend and may override our default settings:
+
+            kwargs['highlight'] = self._build_search_kwargs_highlight(
+                content_field, highlight)
+
+        if self.include_spelling:
+            kwargs['suggest'] = self._build_search_kwargs_suggest(
+                query_string, spelling_query)
+
+        field, result = self._build_search_kwargs_facets(facets, date_facets,
+                                                         query_facets)
+        kwargs[field] = result
+
+        if limit_to_registered_models is None:
+            limit_to_registered_models = getattr(
+                settings, 'HAYSTACK_LIMIT_TO_REGISTERED_MODELS', True)
+        if models and len(models):
+            model_choices = sorted(get_model_ct(model) for model in models)
+        elif limit_to_registered_models:
+            # Using narrow queries, limit the results to only models handled
+            # with the current routers.
+            model_choices = self.build_models_list()
+        else:
+            model_choices = []
+        if len(model_choices) > 0:
+            filters.append(self._build_search_filters_model_choices(
+                model_choices))
+
+        if narrow_queries is None:
+            narrow_queries = set()
+        for q in narrow_queries:
+            filters.append(self._build_search_filters_narrow_query(q))
+
+        if within is not None:
+            filters.append(self._build_search_filters_within(within))
+
+        if dwithin is not None:
+            filters.append(self._build_search_filters_dwithin(dwithin))
+
+        # if we want to filter, change the query type to filteres
+        if filters:
+            kwargs['query'] = self._build_search_kwargs_query(
+                filters, kwargs.pop('query'))
+
+        if extra_kwargs:
+            kwargs.update(extra_kwargs)
+
+        return kwargs
+
+    def _build_search_kwargs_default(self, content_field, query_string):
         if query_string == '*:*':
-            kwargs = {
+            return {
                 'query': {
                     "match_all": {}
                 },
             }
         else:
-            kwargs = {
+            return {
                 'query': {
                     'query_string': {
                         'default_field': content_field,
@@ -282,76 +354,61 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 },
             }
 
-        # so far, no filters
-        filters = []
+    def _build_search_kwargs_fields(self, fields):
+        if isinstance(fields, (list, set)):
+            fields = " ".join(fields)
+        return 'fields', fields
 
-        if fields:
-            if isinstance(fields, (list, set)):
-                fields = " ".join(fields)
-
-            kwargs['fields'] = fields
-
-        if sort_by is not None:
-            order_list = []
-            for field, direction in sort_by:
-                if field == 'distance' and distance_point:
-                    # Do the geo-enabled sort.
-                    lng, lat = distance_point['point'].get_coords()
-                    sort_kwargs = {
-                        "_geo_distance": {
-                            distance_point['field']: [lng, lat],
-                            "order": direction,
-                            "unit": "km"
-                        }
+    def _build_search_kwargs_sort(self, distance_point, sort_by):
+        order_list = []
+        for field, direction in sort_by:
+            if field == 'distance' and distance_point:
+                # Do the geo-enabled sort.
+                lng, lat = distance_point['point'].get_coords()
+                sort_kwargs = {
+                    "_geo_distance": {
+                        distance_point['field']: [lng, lat],
+                        "order": direction,
+                        "unit": "km"
                     }
-                else:
-                    if field == 'distance':
-                        warnings.warn("In order to sort by distance, you must call the '.distance(...)' method.")
-
-                    # Regular sorting.
-                    sort_kwargs = {field: {'order': direction}}
-
-                order_list.append(sort_kwargs)
-
-            kwargs['sort'] = order_list
-
-        # From/size offsets don't seem to work right in Elasticsearch's DSL. :/
-        # if start_offset is not None:
-        #     kwargs['from'] = start_offset
-
-        # if end_offset is not None:
-        #     kwargs['size'] = end_offset - start_offset
-
-        if highlight:
-            # `highlight` can either be True or a dictionary containing custom parameters
-            # which will be passed to the backend and may override our default settings:
-
-            kwargs['highlight'] = {
-                'fields': {
-                    content_field: {'store': 'yes'},
                 }
+            else:
+                if field == 'distance':
+                    warnings.warn(
+                        "In order to sort by distance, you must call the '.distance(...)' method.")
+
+                # Regular sorting.
+                sort_kwargs = {field: {'order': direction}}
+
+            order_list.append(sort_kwargs)
+        return order_list
+
+    def _build_search_kwargs_highlight(self, content_field, highlight):
+        result = {
+            'fields': {
+                content_field: {'store': 'yes'},
             }
+        }
+        if isinstance(highlight, dict):
+            result.update(highlight)
+        return result
 
-            if isinstance(highlight, dict):
-                kwargs['highlight'].update(highlight)
-
-        if self.include_spelling:
-            kwargs['suggest'] = {
-                'suggest': {
-                    'text': spelling_query or query_string,
-                    'term': {
-                        # Using content_field here will result in suggestions of stemmed words.
-                        'field': '_all',
-                    },
+    def _build_search_kwargs_suggest(self, query_string, spelling_query):
+        return {
+            'suggest': {
+                'text': spelling_query or query_string,
+                'term': {
+                    # Using content_field here will result in suggestions of
+                    # stemmed words.
+                    'field': '_all',
                 },
-            }
+            },
+        }
 
-        if narrow_queries is None:
-            narrow_queries = set()
+    def _build_search_kwargs_facets(self, facets, date_facets, query_facets):
+        result = {}
 
         if facets is not None:
-            kwargs.setdefault('facets', {})
-
             for facet_fieldname, extra_options in facets.items():
                 facet_options = {
                     'terms': {
@@ -366,11 +423,9 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 if 'facet_filter' in extra_options:
                     facet_options['facet_filter'] = extra_options.pop('facet_filter')
                 facet_options['terms'].update(extra_options)
-                kwargs['facets'][facet_fieldname] = facet_options
+                result[facet_fieldname] = facet_options
 
         if date_facets is not None:
-            kwargs.setdefault('facets', {})
-
             for facet_fieldname, value in date_facets.items():
                 # Need to detect on gap_by & only add amount if it's more than one.
                 interval = value.get('gap_by').lower()
@@ -380,7 +435,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     # Just the first character is valid for use.
                     interval = "%s%s" % (value['gap_amount'], interval[:1])
 
-                kwargs['facets'][facet_fieldname] = {
+                result[facet_fieldname] = {
                     'date_histogram': {
                         'field': facet_fieldname,
                         'interval': interval,
@@ -396,10 +451,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 }
 
         if query_facets is not None:
-            kwargs.setdefault('facets', {})
-
             for facet_fieldname, value in query_facets:
-                kwargs['facets'][facet_fieldname] = {
+                result[facet_fieldname] = {
                     'query': {
                         'query_string': {
                             'query': value,
@@ -407,89 +460,72 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     },
                 }
 
-        if limit_to_registered_models is None:
-            limit_to_registered_models = getattr(settings, 'HAYSTACK_LIMIT_TO_REGISTERED_MODELS', True)
+        return 'facets', result
 
-        if models and len(models):
-            model_choices = sorted(get_model_ct(model) for model in models)
-        elif limit_to_registered_models:
-            # Using narrow queries, limit the results to only models handled
-            # with the current routers.
-            model_choices = self.build_models_list()
-        else:
-            model_choices = []
+    def _build_search_filters_model_choices(self, model_choices):
+        return {"terms": {DJANGO_CT: model_choices}}
 
-        if len(model_choices) > 0:
-            filters.append({"terms": {DJANGO_CT: model_choices}})
-
-        for q in narrow_queries:
-            filters.append({
-                'fquery': {
-                    'query': {
-                        'query_string': {
-                            'query': q
-                        },
+    def _build_search_filters_narrow_query(self, q):
+        return {
+            'fquery': {
+                'query': {
+                    'query_string': {
+                        'query': q
                     },
-                    '_cache': True,
-                }
-            })
-
-        if within is not None:
-            from haystack.utils.geo import generate_bounding_box
-
-            ((south, west), (north, east)) = generate_bounding_box(within['point_1'], within['point_2'])
-            within_filter = {
-                "geo_bounding_box": {
-                    within['field']: {
-                        "top_left": {
-                            "lat": north,
-                            "lon": west
-                        },
-                        "bottom_right": {
-                            "lat": south,
-                            "lon": east
-                        }
-                    }
                 },
+                '_cache': True,
             }
-            filters.append(within_filter)
+        }
 
-        if dwithin is not None:
-            lng, lat = dwithin['point'].get_coords()
-
-            # NB: the 1.0.0 release of elasticsearch introduce an
-            #     incompatible change on the distance filter formating
-            if elasticsearch.VERSION >= (1, 0, 0):
-                distance = "%(dist).6f%(unit)s" % {
-                        'dist': dwithin['distance'].km,
-                        'unit': "km"
-                    }
-            else:
-                distance = dwithin['distance'].km
-
-            dwithin_filter = {
-                "geo_distance": {
-                    "distance": distance,
-                    dwithin['field']: {
-                        "lat": lat,
-                        "lon": lng
+    def _build_search_filters_within(self, within):
+        from haystack.utils.geo import generate_bounding_box
+        ((south, west), (north, east)) = generate_bounding_box(
+            within['point_1'], within['point_2'])
+        within_filter = {
+            "geo_bounding_box": {
+                within['field']: {
+                    "top_left": {
+                        "lat": north,
+                        "lon": west
+                    },
+                    "bottom_right": {
+                        "lat": south,
+                        "lon": east
                     }
                 }
+            },
+        }
+        return within_filter
+
+    def _build_search_filters_dwithin(self, dwithin):
+        lng, lat = dwithin['point'].get_coords()
+        # NB: the 1.0.0 release of elasticsearch introduce an
+        #     incompatible change on the distance filter formating
+        if elasticsearch.VERSION >= (1, 0, 0):
+            distance = "%(dist).6f%(unit)s" % {
+                'dist': dwithin['distance'].km,
+                'unit': "km"
             }
-            filters.append(dwithin_filter)
+        else:
+            distance = dwithin['distance'].km
+        dwithin_filter = {
+            "geo_distance": {
+                "distance": distance,
+                dwithin['field']: {
+                    "lat": lat,
+                    "lon": lng
+                }
+            }
+        }
+        return dwithin_filter
 
-        # if we want to filter, change the query type to filteres
-        if filters:
-            kwargs["query"] = {"filtered": {"query": kwargs.pop("query")}}
-            if len(filters) == 1:
-                kwargs['query']['filtered']["filter"] = filters[0]
-            else:
-                kwargs['query']['filtered']["filter"] = {"bool": {"must": filters}}
-
-        if extra_kwargs:
-            kwargs.update(extra_kwargs)
-
-        return kwargs
+    def _build_search_kwargs_query(self, filters, query):
+        result = {"filtered": {"query": query}}
+        if len(filters) == 1:
+            result['filtered']["filter"] = filters[0]
+        else:
+            result['filtered']["filter"] = {"bool": {"must": filters}}
+        return result
 
     @log_query
     def search(self, query_string, **kwargs):


### PR DESCRIPTION
This compartmentalizes better its operations, simplifies the Elasticsearch 2.x backend and lays groundwork towards a simpler 5.x implementation.