### PR TITLE
Do not raise when model cannot be searched

### DIFF
--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -76,7 +76,7 @@ class SimpleSearchBackend(BaseSearchBackend):
 
                             queries.append(Q(**{'%s__icontains' % field.name: term}))
 
-                        qs = model.objects.filter(six.moves.reduce(lambda x, y: x | y, queries))
+                        qs = model.objects.filter(six.moves.reduce(lambda x, y: x | y, queries)) if queries else []
 
                 hits += len(qs)
 

--- a/test_haystack/simple_tests/test_simple_backend.py
+++ b/test_haystack/simple_tests/test_simple_backend.py
@@ -11,7 +11,7 @@ from haystack import connection_router, connections, indexes
 from haystack.query import SearchQuerySet
 from haystack.utils.loading import UnifiedIndex
 
-from ..core.models import MockModel, ScoreMockModel
+from ..core.models import MockModel, ScoreMockModel, OneToManyRightSideModel
 from ..mocks import MockSearchResult
 from .search_indexes import SimpleMockScoreIndex, SimpleMockSearchIndex
 
@@ -78,6 +78,10 @@ class SimpleSearchBackendTestCase(TestCase):
 
         # Ensure that swapping the ``result_class`` works.
         self.assertTrue(isinstance(self.backend.search(u'index document', result_class=MockSearchResult)['results'][0], MockSearchResult))
+
+        # Ensure empty queries does not raise.
+        self.assertEqual(self.backend.search(u'foo', models=[OneToManyRightSideModel]), {'hits': 0, 'results': []})
+
 
     def test_filter_models(self):
         self.backend.update(self.index, self.sample_objs)


### PR DESCRIPTION
* Return empty list.
* Test.
As per #657 reduce can be called on empty list 'queries' 
This however will only  happen when a model unsuitable for the simple_backend is specified.

``` syntax:python
    for field in model._meta._fields():
        if hasattr(field, 'related'):
            continue
        if not field.get_internal_type() in ('TextField', 'CharField', 'SlugField'):
            continue
```

``` syntax:python

Traceback:
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  115.                         response = callback(request, *callback_args, **callback_kwargs)
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/haystack/views.py" in __call__
  50.         return self.create_response()
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/haystack/views.py" in create_response
  130.         (paginator, page) = self.build_page()
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/haystack/views.py" in build_page
  107.         self.results[start_offset:start_offset + self.results_per_page]
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/haystack/query.py" in __getitem__
  268.                 self._fill_cache(start, bound)
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/haystack/query.py" in _fill_cache
  166.         results = self.query.get_results(**kwargs)
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/haystack/backends/__init__.py" in get_results
  644.                 self.run(**kwargs)
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/haystack/backends/__init__.py" in run
  562.         results = self.backend.search(final_query, **search_kwargs)
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/haystack/backends/__init__.py" in wrapper
  34.             return func(obj, query_string, *args, **kwargs)
File "/home/ben/.virtualenvs/cc/local/lib/python2.7/site-packages/haystack/backends/simple_backend.py" in search
  76.                         qs = model.objects.filter(six.moves.reduce(lambda x, y: x|y, queries))

Exception Type: TypeError at /search/
Exception Value: reduce() of empty sequence with no initial value
```
