### PR TITLE
Fix Context object usage in template rendering. Fixes build_solr_schema. Django 1.11

### DIFF
--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -42,14 +42,14 @@ class Command(BaseCommand):
         content_field_name, fields = backend.build_schema(
             connections[using].get_unified_index().all_searchfields()
         )
-        return Context({
+        return {
             'content_field_name': content_field_name,
             'fields': fields,
             'default_operator': constants.DEFAULT_OPERATOR,
             'ID': constants.ID,
             'DJANGO_CT': constants.DJANGO_CT,
             'DJANGO_ID': constants.DJANGO_ID,
-        })
+        }
 
     def build_template(self, using):
         t = loader.get_template('search_configuration/solr.xml')

--- a/test_haystack/test_altered_internal_names.py
+++ b/test_haystack/test_altered_internal_names.py
@@ -55,7 +55,7 @@ class AlteredInternalNamesTestCase(TestCase):
 
     def test_solr_schema(self):
         command = Command()
-        context_data = command.build_context(using='solr').dicts[-1]
+        context_data = command.build_context(using='solr')
         self.assertEqual(len(context_data), 6)
         self.assertEqual(context_data['DJANGO_ID'], 'my_django_id')
         self.assertEqual(context_data['content_field_name'], 'text')


### PR DESCRIPTION
Fix a break of build_solr_schema with django 1.11 where they drop support for the Context object.  Also updated test.