### PR TITLE
Updated tutorial URL configuration example

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -293,7 +293,7 @@ Add The ``SearchView`` To Your URLconf
 
 Within your URLconf, add the following line::
 
-    (r'^search/', include('haystack.urls')),
+    url(r'^search/', include('haystack.urls')),
 
 This will pull in the default URLconf for Haystack. It consists of a single
 URLconf that points to a ``SearchView`` instance. You can change this class's


### PR DESCRIPTION
Just fixed documentation (include without url not working on Django 1.11).

Problem: http://stackoverflow.com/questions/38786461/django-error-your-url-pattern-is-invalid-ensure-that-urlpatterns-is-a-list-of
