### PR TITLE
Add untokenized SearchField

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -116,3 +116,4 @@ Thanks to
     * Antony Raj (@antonyr) for adding endswith input type and fixing contains input type
     * Morgan Aubert (@ellmetha) for Django 1.10 support
     * João Junior (@joaojunior) and Bruno Marques (@ElSaico) for Elasticsearch 2.x support
+    * Alexander Hoyle (@ahoho) for adding raw string fields.

--- a/docs/searchfield_api.rst
+++ b/docs/searchfield_api.rst
@@ -26,6 +26,7 @@ Included with Haystack are the following field types:
 
 * ``BooleanField``
 * ``CharField``
+* ``StringField``
 * ``DateField``
 * ``DateTimeField``
 * ``DecimalField``
@@ -34,18 +35,21 @@ Included with Haystack are the following field types:
 * ``IntegerField``
 * ``LocationField``
 * ``MultiValueField``
+* ``MultiValueStringField``
 * ``NgramField``
 
 And equivalent faceted versions:
 
 * ``FacetBooleanField``
 * ``FacetCharField``
+* ``FacetStringField``
 * ``FacetDateField``
 * ``FacetDateTimeField``
 * ``FacetDecimalField``
 * ``FacetFloatField``
 * ``FacetIntegerField``
 * ``FacetMultiValueField``
+* ``FacetMultiValueStringField``
 
 .. note::
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -757,6 +757,7 @@ FIELD_MAPPINGS = {
     'ngram':      {'type': 'string', 'analyzer': 'ngram_analyzer'},
     'date':       {'type': 'date'},
     'datetime':   {'type': 'date'},
+    'raw_string': {'type': 'string'},
 
     'location':   {'type': 'geo_point'},
     'boolean':    {'type': 'boolean'},

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -483,6 +483,8 @@ class SolrSearchBackend(BaseSearchBackend):
                 field_data['type'] = 'edge_ngram'
             elif field_class.field_type == 'location':
                 field_data['type'] = 'location'
+            elif field_class.field_type == 'raw_string':
+                field_data['type'] = 'string'
 
             if field_class.is_multivalued:
                 field_data['multi_valued'] = 'true'

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -37,7 +37,7 @@ if not hasattr(whoosh, '__version__') or whoosh.__version__ < (2, 5, 0):
 from whoosh import index
 from whoosh.analysis import StemmingAnalyzer
 from whoosh.fields import ID as WHOOSH_ID
-from whoosh.fields import BOOLEAN, DATETIME, IDLIST, KEYWORD, NGRAM, NGRAMWORDS, NUMERIC, Schema, TEXT
+from whoosh.fields import BOOLEAN, DATETIME, IDLIST, KEYWORD, NGRAM, NGRAMWORDS, NUMERIC, Schema, TEXT, ID
 from whoosh.filedb.filestore import FileStorage, RamStorage
 from whoosh.highlight import highlight as whoosh_highlight
 from whoosh.highlight import ContextFragmenter, HtmlFormatter
@@ -159,6 +159,8 @@ class WhooshSearchBackend(BaseSearchBackend):
                 schema_fields[field_class.index_fieldname] = NGRAM(minsize=3, maxsize=15, stored=field_class.stored, field_boost=field_class.boost)
             elif field_class.field_type == 'edge_ngram':
                 schema_fields[field_class.index_fieldname] = NGRAMWORDS(minsize=2, maxsize=15, at='start', stored=field_class.stored, field_boost=field_class.boost)
+            elif field_class.field_type == 'raw_string':
+                schema_fields[field_class.index_fieldname] = ID(stored=field_class.stored, field_boost=field_class.boost, sortable=True)
             else:
                 schema_fields[field_class.index_fieldname] = TEXT(stored=True, analyzer=StemmingAnalyzer(), field_boost=field_class.boost, sortable=True)
 

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -210,7 +210,9 @@ class CharField(SearchField):
 
         return six.text_type(value)
 
-
+class StringField(CharField):
+    field_type = 'raw_string'
+        
 class LocationField(SearchField):
     field_type = 'location'
 
@@ -419,7 +421,9 @@ class MultiValueField(SearchField):
             return value
 
         return [value]
-
+        
+class MultiValueStringField(MultiValueField):
+    field_type = 'raw_string'
 
 class FacetField(SearchField):
     """
@@ -467,6 +471,8 @@ class FacetField(SearchField):
 class FacetCharField(FacetField, CharField):
     pass
 
+class FacetStringField(FacetField, StringField):
+    pass
 
 class FacetIntegerField(FacetField, IntegerField):
     pass
@@ -493,4 +499,7 @@ class FacetDateTimeField(FacetField, DateTimeField):
 
 
 class FacetMultiValueField(FacetField, MultiValueField):
+    pass
+    
+class FacetMultiValueStringField(FacetField, MultiValueField):
     pass


### PR DESCRIPTION
I've added a new `StringField` class to handle raw strings. There are also faceted and multivalued versions. Unlike `CharField`, these are fields that do not tokenize/analyze strings, but store them in the index as-is.