### PR TITLE
Added logic to implement Interval Faceting (Solr only).

### DIFF
--- a/docs/searchbackend_api.rst
+++ b/docs/searchbackend_api.rst
@@ -56,7 +56,7 @@ specific to each one.
 ``search``
 ----------
 
-.. method:: SearchBackend.search(self, query_string, sort_by=None, start_offset=0, end_offset=None, fields='', highlight=False, facets=None, date_facets=None, query_facets=None, narrow_queries=None, spelling_query=None, limit_to_registered_models=None, result_class=None, **kwargs)
+.. method:: SearchBackend.search(self, query_string, sort_by=None, start_offset=0, end_offset=None, fields='', highlight=False, facets=None, date_facets=None, interval_facets=None, query_facets=None, narrow_queries=None, spelling_query=None, limit_to_registered_models=None, result_class=None, **kwargs)
 
 Takes a query to search on and returns a dictionary.
 

--- a/docs/searchquery_api.rst
+++ b/docs/searchquery_api.rst
@@ -299,6 +299,13 @@ Adds a regular facet on a field.
 
 Adds a date-based facet on a field.
 
+``add_interval_facet``
+~~~~~~~~~~~~~~~~~~
+
+.. method:: SearchQuery.add_interval_facet(self, field, intervals)
+
+Adds an interval facet on a field.
+
 ``add_query_facet``
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/searchqueryset_api.rst
+++ b/docs/searchqueryset_api.rst
@@ -315,6 +315,23 @@ Example::
     # Count document hits for each author within the index.
     SearchQuerySet().filter(content='foo').facet('author')
 
+``interval_facet``
+~~~~~~~~~~~~~~
+
+.. method:: SearchQuerySet.interval_facet(self, field, interval)
+
+Adds interval faceting to a query for the provided field. You provide the field
+(from one of the ``SearchIndex`` classes) you like to facet on and an array of
+``intervals``. This is currently supported only when using Solr (ver 4.10+)
+
+In the search results you get back, facet counts will be populated in the
+``SearchResult`` object. You can access them via the ``facet_counts`` method.
+
+Example::
+
+    # Count document hits that have a price included in the following ranges: between 0 and 100, and greater than 100
+    SearchQuerySet().filter(content='foo').interval_facet('price', intervals=['[0,100]', '(100,*]'])
+
 ``date_facet``
 ~~~~~~~~~~~~~~
 

--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -127,7 +127,7 @@ class BaseSearchBackend(object):
 
     def build_search_kwargs(self, query_string, sort_by=None, start_offset=0, end_offset=None,
                             fields='', highlight=False, facets=None,
-                            date_facets=None, query_facets=None,
+                            date_facets=None, interval_facet=None, query_facets=None,
                             narrow_queries=None, spelling_query=None,
                             within=None, dwithin=None, distance_point=None,
                             models=None, limit_to_registered_models=None,
@@ -443,6 +443,7 @@ class BaseSearchQuery(object):
         self.highlight = False
         self.facets = {}
         self.date_facets = {}
+        self.interval_facets = {}
         self.query_facets = []
         self.narrow_queries = set()
         #: If defined, fields should be a list of field names - no other values
@@ -510,6 +511,9 @@ class BaseSearchQuery(object):
 
         if self.date_facets:
             kwargs['date_facets'] = self.date_facets
+
+        if self.interval_facets:
+            kwargs['interval_facets'] = self.interval_facets
 
         if self.query_facets:
             kwargs['query_facets'] = self.query_facets
@@ -906,6 +910,15 @@ class BaseSearchQuery(object):
         }
         self.date_facets[connections[self._using].get_unified_index().get_facet_fieldname(field)] = details
 
+    def add_interval_facet(self, field, intervals):
+        """Adds an interval facet on a field."""
+        from haystack import connections
+
+        details = {
+            'intervals': intervals,
+        }
+        self.interval_facets[connections[self._using].get_unified_index().get_facet_fieldname(field)] = details
+
     def add_query_facet(self, field, query):
         """Adds a query facet on a field."""
         from haystack import connections
@@ -989,6 +1002,7 @@ class BaseSearchQuery(object):
         clone.stats = self.stats.copy()
         clone.facets = self.facets.copy()
         clone.date_facets = self.date_facets.copy()
+        clone.interval_facets = self.interval_facets.copy()
         clone.query_facets = self.query_facets[:]
         clone.narrow_queries = self.narrow_queries.copy()
         clone.start_offset = self.start_offset

--- a/haystack/manager.py
+++ b/haystack/manager.py
@@ -61,6 +61,9 @@ class SearchIndexManager(object):
     def date_facet(self, field, start_date, end_date, gap_by, gap_amount=1):
         return self.get_search_queryset().date_facet(field, start_date, end_date, gap_by, gap_amount=1)
 
+    def interval_facet(self, field, intervals):
+        return self.get_search_queryset().interval_facet(field, intervals)
+
     def query_facet(self, field, query):
         return self.get_search_queryset().query_facet(field, query)
 

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -434,6 +434,12 @@ class SearchQuerySet(object):
         clone.query.add_date_facet(field, start_date, end_date, gap_by, gap_amount=gap_amount)
         return clone
 
+    def interval_facet(self, field, intervals):
+        """Adds interval faceting to a query for the provided field."""
+        clone = self._clone()
+        clone.query.add_interval_facet(field, intervals)
+        return clone
+
     def query_facet(self, field, query):
         """Adds faceting to a query for the provided field with a custom query."""
         clone = self._clone()

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -16,6 +16,7 @@ class MockModel(models.Model):
     author = models.CharField(max_length=255)
     foo = models.CharField(max_length=255, blank=True)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
+    price = models.DecimalField(default=0)
     tag = models.ForeignKey(MockTag)
 
     def __unicode__(self):

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -16,7 +16,6 @@ class MockModel(models.Model):
     author = models.CharField(max_length=255)
     foo = models.CharField(max_length=255, blank=True)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
-    price = models.DecimalField(default=0)
     tag = models.ForeignKey(MockTag)
 
     def __unicode__(self):

--- a/test_haystack/solr_tests/server/schema.xml
+++ b/test_haystack/solr_tests/server/schema.xml
@@ -141,7 +141,7 @@
         <field name="name_auto" type="edge_ngram" indexed="true" stored="true" multiValued="false"/>
         <field name="name_exact" type="string" indexed="true" stored="true" multiValued="false"/>
         <field name="post_count" type="sint" indexed="true" stored="true" multiValued="false"/>
-        <field name="price" type="string" indexed="true" stored="true" multiValued="false"/>
+        <field name="price" type="float" indexed="true" stored="true" multiValued="false" docValues="true" />
         <field name="pub_date" type="date" indexed="true" stored="true" multiValued="false"/>
         <field name="sites" type="sint" indexed="true" stored="true" multiValued="true"/>
         <field name="tags" type="text_en" indexed="true" stored="true" multiValued="true"/>

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -46,7 +46,6 @@ class SolrMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     name = indexes.CharField(model_attr='author', faceted=True)
     pub_date = indexes.DateTimeField(model_attr='pub_date')
-    price = indexes.DecimalField(model_attr='price')
     def get_model(self):
         return MockModel
 
@@ -224,7 +223,6 @@ class SolrSearchBackendTestCase(TestCase):
             mock.id = i
             mock.author = 'daniel%s' % i
             mock.pub_date = datetime.date(2009, 2, 25) - datetime.timedelta(days=i)
-            mock.price = i * 10
             self.sample_objs.append(mock)
 
     def tearDown(self):
@@ -274,7 +272,6 @@ class SolrSearchBackendTestCase(TestCase):
                 'name_exact': 'daniel1',
                 'text': 'Indexed!\n1',
                 'pub_date': '2009-02-24T00:00:00Z',
-                'price': 10,
                 'id': 'core.mockmodel.1'
             },
             {
@@ -284,7 +281,6 @@ class SolrSearchBackendTestCase(TestCase):
                 'name_exact': 'daniel2',
                 'text': 'Indexed!\n2',
                 'pub_date': '2009-02-23T00:00:00Z',
-                'price': 20,
                 'id': 'core.mockmodel.2'
             },
             {
@@ -294,7 +290,6 @@ class SolrSearchBackendTestCase(TestCase):
                 'name_exact': 'daniel3',
                 'text': 'Indexed!\n3',
                 'pub_date': '2009-02-22T00:00:00Z',
-                'price': 30,
                 'id': 'core.mockmodel.3'
             }
         ])
@@ -328,7 +323,6 @@ class SolrSearchBackendTestCase(TestCase):
                 'name_exact': 'daniel2',
                 'text': 'Indexed!\n2',
                 'pub_date': '2009-02-23T00:00:00Z',
-                'price': 20,
                 'id': 'core.mockmodel.2'
             },
             {
@@ -338,7 +332,6 @@ class SolrSearchBackendTestCase(TestCase):
                 'name_exact': 'daniel3',
                 'text': 'Indexed!\n3',
                 'pub_date': '2009-02-22T00:00:00Z',
-                'price': 30,
                 'id': 'core.mockmodel.3'
             }
         ])
@@ -540,7 +533,7 @@ class SolrSearchBackendTestCase(TestCase):
 
         (content_field_name, fields) = self.sb.build_schema(old_ui.all_searchfields())
         self.assertEqual(content_field_name, 'text')
-        self.assertEqual(len(fields), 5)
+        self.assertEqual(len(fields), 4)
         self.assertEqual(sorted(fields, key=lambda x: x['field_name']), [
             {
                 'indexed': 'true',
@@ -554,13 +547,6 @@ class SolrSearchBackendTestCase(TestCase):
                 'field_name': 'name_exact',
                 'stored': 'true',
                 'type': 'string',
-                'multi_valued': 'false'
-            },
-            {
-                'indexed': 'true',
-                'type': 'text_en',
-                'stored': 'true',
-                'field_name': 'price',
                 'multi_valued': 'false'
             },
             {

--- a/test_haystack/test_managers.py
+++ b/test_haystack/test_managers.py
@@ -145,6 +145,12 @@ class ManagerTestCase(TestCase):
         self.assertTrue(isinstance(sqs, SearchQuerySet))
         self.assertEqual(len(sqs.query.date_facets), 1)
 
+    def test_interval_facets(self):
+        sqs = self.search_index.objects.interval_facet('price',
+                                                   intervals='[0, 100]')
+        self.assertTrue(isinstance(sqs, SearchQuerySet))
+        self.assertEqual(len(sqs.query.interval_facets), 1)
+
     def test_query_facets(self):
         sqs = self.search_index.objects.query_facet('foo', '[bar TO *]')
         self.assertTrue(isinstance(sqs, SearchQuerySet))


### PR DESCRIPTION
This currently only works with Solr backend (>4.10).

More details about interval faceting can be found at: [Solr - Interval Faceting](https://cwiki.apache.org/confluence/display/solr/Faceting#Faceting-IntervalFaceting)

Example:
`intervals = ['[0,100]', '(100, *]']`
`sqs = SearchQuerySet()`
`sqs.interval_facet('price', intervals=intervals)`

Key replacement is supported as well:
` sqs.interval_facet('price', intervals=['{!key=cheap}[0, 100]', '{!key=expensive}[100, *)']).facet_counts()`

Output:
`{u'dates': {},
 u'fields': {},
 u'intervals': {'price': {u'cheap': 4, u'expensive': 47}},
 u'queries': {}}`

Syntax is explained at the URL posted above.
There is no need to specify the "facet=true"  when defining the search index for the fields you want to use for interval faceting.

Only requirement is that fields used for Interval Faceting must have “docValues” enabled (not required for Solr 5.20 and above)

