### PR TITLE
utils.default_get_identifier: Support non-numeric object pk

### DIFF
--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -11,7 +11,7 @@ from django.utils import six
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID
 from haystack.utils.highlighting import Highlighter
 
-IDENTIFIER_REGEX = re.compile('^[\w\d_]+\.[\w\d_]+\.\d+$')
+IDENTIFIER_REGEX = re.compile('^[\w\d_]+\.[\w\d_]+\.[\w\d_\-]+$')
 
 
 def default_get_identifier(obj_or_string):


### PR DESCRIPTION
Issue: when non-numeric pk is used on model (UUIDField for ex) it is impossible to remove object from index:
"AttributeError: Provided string 'products.product.1243-4567-1234-6789' is not a valid identifier."
