### PR TITLE
Changed GeoDjango Link in Documentation

### DIFF
--- a/docs/spatial.rst
+++ b/docs/spatial.rst
@@ -14,7 +14,7 @@ close to GeoDjango_ as possible. There are some differences, which we'll
 highlight throughout this guide. Additionally, while the support isn't as
 comprehensive as PostGIS (for example), it is still quite useful.
 
-.. _GeoDjango: http://geodjango.org/
+.. _GeoDjango: https://docs.djangoproject.com/en/1.11/ref/contrib/gis/
 
 
 Additional Requirements


### PR DESCRIPTION
Changed GeoDjango link from geodjango.org to https://docs.djangoproject.com/en/1.11/ref/contrib/gis/
