### PR TITLE
Better default configs

### DIFF
--- a/haystack/templates/search_configuration/schema.xml
+++ b/haystack/templates/search_configuration/schema.xml
@@ -55,13 +55,13 @@
         <analyzer type="index">
             <tokenizer class="solr.WhitespaceTokenizerFactory" />
             <filter class="solr.LowerCaseFilterFactory" />
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
             <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="15" />
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.WhitespaceTokenizerFactory" />
             <filter class="solr.LowerCaseFilterFactory" />
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
         </analyzer>
     </fieldType>
 
@@ -84,15 +84,6 @@
     <field name="{{ field.field_name }}" type="{{ field.type }}" indexed="{{ field.indexed }}" stored="{{ field.stored }}" multiValued="{{ field.multi_valued }}" />
     {% endfor %}
     <uniqueKey>{{ ID }}</uniqueKey>
-
-    <!--
-    Not required if the default search field (<str name="df">text</str>) is defined for
-    /select request handler in sorlconfig.xml
-    -->
-    <defaultSearchField>{{ content_field_name }}</defaultSearchField>
-
-    <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
-    <solrQueryParser defaultOperator="{{ default_operator }}"/>
 
     <!--
     ######################## django-haystack specifics end ########################
@@ -410,7 +401,9 @@
         <analyzer type="query">
             <tokenizer class="solr.StandardTokenizerFactory"/>
             <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="true"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
     </fieldType>
@@ -443,7 +436,9 @@
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.StandardTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="true"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.StopFilterFactory"
                     ignoreCase="true"
                     words="lang/stopwords_en.txt"
@@ -480,19 +475,21 @@
                     ignoreCase="true"
                     words="lang/stopwords_en.txt"
             />
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
             <filter class="solr.LowerCaseFilterFactory"/>
             <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
             <filter class="solr.PorterStemFilterFactory"/>
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="true"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.StopFilterFactory"
                     ignoreCase="true"
                     words="lang/stopwords_en.txt"
             />
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
             <filter class="solr.LowerCaseFilterFactory"/>
             <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
             <filter class="solr.PorterStemFilterFactory"/>
@@ -505,9 +502,11 @@
     <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
         <analyzer>
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="false"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
             <filter class="solr.LowerCaseFilterFactory"/>
             <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
             <filter class="solr.EnglishMinimalStemFilterFactory"/>
@@ -531,7 +530,9 @@
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.StandardTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="true"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>

--- a/haystack/templates/search_configuration/solrconfig.xml
+++ b/haystack/templates/search_configuration/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>6.4.0</luceneMatchVersion>
+  <luceneMatchVersion>6.5.0</luceneMatchVersion>
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
@@ -1435,4 +1435,12 @@
       EditorialMarkerFactory will do exactly that:
      <transformer name="qecBooster" class="org.apache.solr.response.transform.EditorialMarkerFactory" />
     -->
+
+    <!-- Extras noted by users of DJangoHaystack -->
+    <requestHandler name="/analysis/field"
+                  startup="lazy"
+                  class="solr.FieldAnalysisRequestHandler" />
+    <requestHandler name="/analysis/document"
+                  class="solr.DocumentAnalysisRequestHandler"
+                  startup="lazy" />
 </config>

--- a/test_haystack/solr_tests/server/confdir/schema.xml
+++ b/test_haystack/solr_tests/server/confdir/schema.xml
@@ -55,13 +55,13 @@
         <analyzer type="index">
             <tokenizer class="solr.WhitespaceTokenizerFactory" />
             <filter class="solr.LowerCaseFilterFactory" />
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
             <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="15" />
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.WhitespaceTokenizerFactory" />
             <filter class="solr.LowerCaseFilterFactory" />
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
         </analyzer>
     </fieldType>
 
@@ -82,15 +82,6 @@
     <field name="django_id" type="string" indexed="true" stored="true" multiValued="false"/>
 
     <uniqueKey>id</uniqueKey>
-
-    <!--
-    Not required if the default search field (<str name="df">text</str>) is defined for
-    /select request handler in sorlconfig.xml
-    -->
-    <defaultSearchField>text</defaultSearchField>
-
-    <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
-    <solrQueryParser defaultOperator="AND"/>
 
     <field name="author" type="string" indexed="true" stored="true" multiValued="false" omitNorms="false"/>
     <field name="average_rating" type="floats" indexed="true" stored="true" multiValued="false"/>
@@ -429,7 +420,9 @@
         <analyzer type="query">
             <tokenizer class="solr.StandardTokenizerFactory"/>
             <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="true"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
     </fieldType>
@@ -462,7 +455,9 @@
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.StandardTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="true"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.StopFilterFactory"
                     ignoreCase="true"
                     words="lang/stopwords_en.txt"
@@ -499,19 +494,21 @@
                     ignoreCase="true"
                     words="lang/stopwords_en.txt"
             />
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
             <filter class="solr.LowerCaseFilterFactory"/>
             <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
             <filter class="solr.PorterStemFilterFactory"/>
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="true"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.StopFilterFactory"
                     ignoreCase="true"
                     words="lang/stopwords_en.txt"
             />
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
             <filter class="solr.LowerCaseFilterFactory"/>
             <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
             <filter class="solr.PorterStemFilterFactory"/>
@@ -524,9 +521,11 @@
     <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
         <analyzer>
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="false"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-            <filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
             <filter class="solr.LowerCaseFilterFactory"/>
             <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
             <filter class="solr.EnglishMinimalStemFilterFactory"/>
@@ -550,7 +549,9 @@
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.StandardTokenizerFactory"/>
-            <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt"
+             format="solr" ignoreCase="false" expand="true"
+             tokenizerFactory="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>

--- a/test_haystack/solr_tests/server/confdir/solrconfig.xml
+++ b/test_haystack/solr_tests/server/confdir/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>6.4.0</luceneMatchVersion>
+  <luceneMatchVersion>6.5.0</luceneMatchVersion>
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
@@ -1435,4 +1435,12 @@
       EditorialMarkerFactory will do exactly that:
      <transformer name="qecBooster" class="org.apache.solr.response.transform.EditorialMarkerFactory" />
     -->
+
+    <!-- Extras noted by users of DJangoHaystack -->
+    <requestHandler name="/analysis/field"
+                  startup="lazy"
+                  class="solr.FieldAnalysisRequestHandler" />
+    <requestHandler name="/analysis/document"
+                  class="solr.DocumentAnalysisRequestHandler"
+                  startup="lazy" />
 </config>

--- a/test_haystack/solr_tests/server/confdir/solrconfig.xml
+++ b/test_haystack/solr_tests/server/confdir/solrconfig.xml
@@ -1436,7 +1436,7 @@
      <transformer name="qecBooster" class="org.apache.solr.response.transform.EditorialMarkerFactory" />
     -->
 
-    <!-- Extras noted by users of DJangoHaystack -->
+    <!-- Extras noted by users of django-haystack -->
     <requestHandler name="/analysis/field"
                   startup="lazy"
                   class="solr.FieldAnalysisRequestHandler" />


### PR DESCRIPTION
Partial answer to #1520 and original symptoms reported in #1504.  This upgrades to:
Remove deprecated settings (as reported by solr itself).  Remove default operator and default text field.  Also removed two analysis modules that are deprecated and replaced with intended modules for upgrade path.
Added new request handlers as suggested (no new tests as of now -- but doesn't break existing)
Can you squash the commit history?...it's messy.



