### PR TITLE
Add load_all to the generic views form kwargs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -116,3 +116,4 @@ Thanks to
     * Antony Raj (@antonyr) for adding endswith input type and fixing contains input type
     * Morgan Aubert (@ellmetha) for Django 1.10 support
     * João Junior (@joaojunior) and Bruno Marques (@ElSaico) for Elasticsearch 2.x support
+    * Alex Tomkins (@tomkins) for various patches

--- a/haystack/generic_views.py
+++ b/haystack/generic_views.py
@@ -62,7 +62,10 @@ class SearchMixin(MultipleObjectMixin, FormMixin):
             kwargs.update({
                 'data': self.request.GET,
             })
-        kwargs.update({'searchqueryset': self.get_queryset()})
+        kwargs.update({
+            'searchqueryset': self.get_queryset(),
+            'load_all': self.load_all,
+        })
         return kwargs
 
     def form_invalid(self, form):

--- a/test_haystack/test_generic_views.py
+++ b/test_haystack/test_generic_views.py
@@ -28,6 +28,7 @@ class GenericSearchViewsTestCase(TestCase):
         self.assertEqual(form_kwargs.get('data').get('q'), self.query)
         self.assertEqual(form_kwargs.get('initial'), {})
         self.assertTrue('searchqueryset' in form_kwargs)
+        self.assertTrue('load_all' in form_kwargs)
 
     def test_search_view_response(self):
         """Test the generic SearchView response."""


### PR DESCRIPTION
Currently the old views in [views.py](https://github.com/django-haystack/django-haystack/blob/201d27fe62c7adcc92a47c325a31cfb0577ae9fa/haystack/views.py) pass `load_all` to the  search forms being used.

This seems to be missing from the generic views, there's an [attribute on SearchMixin](https://github.com/django-haystack/django-haystack/blob/3a2b1992b2c2b22c599d92c3c5347b7cd9c0bf65/haystack/generic_views.py#L44) which suggests that it was probably intended - however it isn't used at all in `get_form_kwargs`.

This patch updates `SearchMixin` to pass `self.load_all` to the search form.