### PR TITLE
Fix elasticsearch installation in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,13 @@ before_install:
       if [[ $VERSION_ES == '>=2.0.0,<3.0.0' ]];
       then
         echo "deb http://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list
+        sudo apt-get update
+        sudo apt-get -y --allow-downgrades install elasticsearch=2.4.5
       else
         echo "deb http://packages.elastic.co/elasticsearch/1.7/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elasticsearch-1.7.list
+        sudo apt-get update
+        sudo apt-get -y --allow-downgrades install elasticsearch=1.7.6
       fi
-    - sudo apt-get update
-    - sudo apt-get -y install elasticsearch
     - sudo service elasticsearch restart
 
 install:

--- a/AUTHORS
+++ b/AUTHORS
@@ -116,3 +116,4 @@ Thanks to
     * Antony Raj (@antonyr) for adding endswith input type and fixing contains input type
     * Morgan Aubert (@ellmetha) for Django 1.10 support
     * João Junior (@joaojunior) and Bruno Marques (@ElSaico) for Elasticsearch 2.x support
+    * Alex Tomkins (@tomkins) for various patches


### PR DESCRIPTION
Recent travis updates installed a later version of elasticsearch by default, so we need to force a downgrade to test the right versions.

apt-get doesn't allow version ranges, so the elasticsearch versions are hardcoded. I doubt we'll see updates of 1.x and 2.x versions anyway.