### PR TITLE
Add Socialhome to who uses

### DIFF
--- a/docs/who_uses.rst
+++ b/docs/who_uses.rst
@@ -365,3 +365,13 @@ provide search across users and lessons.
 Using: Solr
 
 * http://www.educreations.com/browse/
+
+
+Socialhome
+----------
+
+Decentralized and federated profile builder with social networking features. Haystack is used for searching other users and content.
+
+Using: Whoosh
+
+* https://socialhome.network/


### PR DESCRIPTION
Socialhome is a decentralized and federated profile builder with social networking features. Haystack is used for searching other users and content. We use Whoosh. The code is at https://github.com/jaywink/socialhome