### PR TITLE
Update haystack.generic_views.SearchView to handle empty GET requests

### DIFF
--- a/haystack/generic_views.py
+++ b/haystack/generic_views.py
@@ -58,7 +58,7 @@ class SearchMixin(MultipleObjectMixin, FormMixin):
         Returns the keyword arguments for instantiating the form.
         """
         kwargs = {'initial': self.get_initial()}
-        if self.request.method == 'GET' and self.request.GET:
+        if self.request.method == 'GET':
             kwargs.update({
                 'data': self.request.GET,
             })


### PR DESCRIPTION
Previously behaviour was inconsistent when a GET request hit the generic `SearchView` with no query string parameters at all.

Thanks to @jbzdak for the patch.

Closes #1466