### PR TITLE
Uuid pk fix

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -172,11 +172,14 @@ class SearchQuerySet(object):
 
         for result in results:
             if self._load_all:
-                # We have to deal with integer keys being cast from strings
+                
                 model_objects = loaded_objects.get(result.model, {})
+                # Try to coerce a primary key object that matches the models pk
+                # We have to deal with semi-arbitrary keys being cast from strings (UUID, int, etc)
                 if result.pk not in model_objects:
                     try:
-                        result.pk = int(result.pk)
+                        result_klass = type(next(iter(model_objects)))
+                        result.pk = result_klass(result.pk)
                     except ValueError:
                         pass
                 try:

--- a/test_haystack/core/fixtures/base_data.json
+++ b/test_haystack/core/fixtures/base_data.json
@@ -71,4 +71,18 @@
       "deleted": true
     }
   }
+  {
+    "pk": "53554c58-7051-4350-bcc9-dad75eb248a9",
+    "model": "core.uuidmockmodel",
+    "fields": {
+      "characteristics": "some text that was indexed",
+    }
+  }
+  {
+    "pk": "77554c58-7051-4350-bcc9-dad75eb24888",
+    "model": "core.uuidmockmodel",
+    "fields": {
+      "characteristics": "more text that was indexed",
+    }
+  }
 ]

--- a/test_haystack/core/fixtures/base_data.json
+++ b/test_haystack/core/fixtures/base_data.json
@@ -70,19 +70,19 @@
       "author": "sam2",
       "deleted": true
     }
-  }
+  },
   {
     "pk": "53554c58-7051-4350-bcc9-dad75eb248a9",
     "model": "core.uuidmockmodel",
     "fields": {
-      "characteristics": "some text that was indexed",
+      "characteristics": "some text that was indexed"
     }
-  }
+  },
   {
     "pk": "77554c58-7051-4350-bcc9-dad75eb24888",
     "model": "core.uuidmockmodel",
     "fields": {
-      "characteristics": "more text that was indexed",
+      "characteristics": "more text that was indexed"
     }
   }
 ]

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -25,7 +25,7 @@ class MockModel(models.Model):
     def hello(self):
         return 'World!'
 
-class MockUUIDModel(models.Model):
+class UUIDMockModel(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     characteristics = models.TextField()
 

--- a/test_haystack/mocks.py
+++ b/test_haystack/mocks.py
@@ -108,6 +108,11 @@ class CharPKMockSearchBackend(MockSearchBackend):
     mock_search_results = [MockSearchResult('core', 'CharPKMockModel', 'sometext', 0.5),
                            MockSearchResult('core', 'CharPKMockModel', '1234', 0.3)]
 
+class UUIDMockSearchBackend(MockSearchBackend):
+    model_name = 'uuidmockmodel'
+    mock_search_results = [MockSearchResult('core', 'UUIDMockModel', '53554c58-7051-4350-bcc9-dad75eb248a9', 0.5),
+                           MockSearchResult('core', 'UUIDMockModel', '77554c58-7051-4350-bcc9-dad75eb24888', 0.5)]
+
 
 class ReadQuerySetMockSearchBackend(MockSearchBackend):
     model_name = 'afifthmockmodel'

--- a/test_haystack/test_query.py
+++ b/test_haystack/test_query.py
@@ -6,7 +6,7 @@ import unittest
 
 from django.test import TestCase
 from django.test.utils import override_settings
-from test_haystack.core.models import AnotherMockModel, CharPKMockModel, MockModel
+from test_haystack.core.models import AnotherMockModel, CharPKMockModel, MockModel, UUIDMockModel
 
 from haystack import connections, indexes, reset_search_queries
 from haystack.backends import SQ, BaseSearchQuery
@@ -16,7 +16,7 @@ from haystack.query import EmptySearchQuerySet, SearchQuerySet, ValuesListSearch
 from haystack.utils.loading import UnifiedIndex
 
 from .mocks import (MOCK_SEARCH_RESULTS, CharPKMockSearchBackend, MockSearchBackend, MockSearchQuery,
-                    ReadQuerySetMockSearchBackend)
+                    ReadQuerySetMockSearchBackend, UUIDMockSearchBackend)
 from .test_indexes import GhettoAFifthMockModelSearchIndex, TextReadQuerySetTestSearchIndex
 from .test_views import BasicAnotherMockModelSearchIndex, BasicMockModelSearchIndex
 
@@ -323,6 +323,11 @@ class CharPKMockModelSearchIndex(indexes.SearchIndex, indexes.Indexable):
     def get_model(self):
         return CharPKMockModel
 
+class SimpleMockUUIDModelIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, model_attr="characteristics")
+
+    def get_model(self):
+        return UUIDMockModel
 
 @override_settings(DEBUG=True)
 class SearchQuerySetTestCase(TestCase):
@@ -423,7 +428,6 @@ class SearchQuerySetTestCase(TestCase):
         results = self.msqs.all()
         loaded = [result.pk for result in results._manual_iter()]
         self.assertEqual(loaded, [u'53554c58-7051-4350-bcc9-dad75eb248a9', u'77554c58-7051-4350-bcc9-dad75eb24888'])
-        self.assertEqual(len(connections['default'].queries), 1)
 
         connections['default']._index = old_ui
 


### PR DESCRIPTION
This is to fix #1543.  The primary purpose of the PR is to fix django-haystack to properly work with UUID primary key models for regular searching.

As fallout of the PR I have also implemented tests that actually use the UUIDMockModel (that was contributed previously but not actively used) and run it through a reasonable number of tests I think.


