### PR TITLE
Fix django pinning in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ except ImportError:
     from setuptools import setup
 
 install_requires = [
-    'Django>=1.8',
-    'Django<1.12',
+    'Django>=1.8,<1.12',
 ]
 
 tests_require = [


### PR DESCRIPTION
Current pip version does not properly process the way Django is pinned in setup.py. The minimal and maximal required version should on the same line.

To demonstrate with a checkout of v2.6.1:
```shell
$ pip --version
pip 9.0.1 from /home/tom/code/django-haystack/env/local/lib/python2.7/site-packages (python 2.7)
$ pip install django
Collecting django
  Using cached Django-1.11.5-py2.py3-none-any.whl
Collecting pytz (from django)
  Using cached pytz-2017.2-py2.py3-none-any.whl
Installing collected packages: pytz, django
Successfully installed django-1.11.5 pytz-2017.2
$ pip install .
Processing /home/tom/code/django-haystack
Requirement already satisfied: Django>=1.8 in ./env/lib/python2.7/site-packages (from django-haystack==2.6.1)
Requirement already satisfied: pytz in ./env/lib/python2.7/site-packages (from Django>=1.8->django-haystack==2.6.1)
Building wheels for collected packages: django-haystack
  Running setup.py bdist_wheel for django-haystack ... done
  Stored in directory: /home/tom/.cache/pip/wheels/73/58/74/05f39030f6e7307470e939f0624e471a3c971781f0692c7133
Successfully built django-haystack
Installing collected packages: django-haystack
Successfully installed django-haystack-2.6.1
```

In v2.6.1, support for django 1.11 is blocked in `setup.py` by:
```python
install_requires = [
    'Django>=1.8',
    'Django<1.11',
]
```
Which means that the install of haystack 2.6.1 should have downgraded Django to a 1.10 version. But it didn't, and the log shows (`Requirement already satisfied: Django>=1.8 in ...`) that pip never saw the django<1.11 requirement.

Some further investigation showed that pip handles the requirement differently when the definition is in the installed package (`pip install django-haystack`), or on a dependency (`pip install django-oscar` -> depends on haystack). But that just complicates the detection of this issue.

The correct way of pinning is by putting everything regarding a single package on a single line: https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires
