### PR TITLE
Django2.0a1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ env:
         - DJANGO_VERSION=">=1.9,<1.10" VERSION_ES=">=2.0.0,<3.0.0"
         - DJANGO_VERSION=">=1.10,<1.11" VERSION_ES=">=2.0.0,<3.0.0"
         - DJANGO_VERSION=">=1.11,<1.12" VERSION_ES=">=2.0.0,<3.0.0"
+        - DJANGO_VERSION=">=2.0a1,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
 
 matrix:
     allow_failures:

--- a/AUTHORS
+++ b/AUTHORS
@@ -117,3 +117,4 @@ Thanks to
     * Morgan Aubert (@ellmetha) for Django 1.10 support
     * João Junior (@joaojunior) and Bruno Marques (@ElSaico) for Elasticsearch 2.x support
     * Alex Tomkins (@tomkins) for various patches
+    * Christopher Schäpers (@Kondou-ger) for Django 2.0a1 compatibility

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -10,6 +10,7 @@ from haystack import connections
 
 class Command(BaseCommand):
     help = "Clears out the search index completely."
+    stealth_options = ('batchsize', 'workers')
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -134,6 +134,7 @@ def do_update(backend, index, qs, start, end, total, verbosity=1, commit=True,
 
 class Command(BaseCommand):
     help = "Freshens the index for the given app(s)."
+    stealth_options = ('interactive', )
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/test_haystack/solr_tests/test_admin.py
+++ b/test_haystack/solr_tests/test_admin.py
@@ -2,11 +2,15 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import django
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.core.urlresolvers import reverse
+if django.VERSION < (1, 10):
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 
 from haystack import connections, reset_search_queries
 from haystack.utils.loading import UnifiedIndex

--- a/test_haystack/test_app_loading.py
+++ b/test_haystack/test_app_loading.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from types import GeneratorType, ModuleType
 
-from django.core.urlresolvers import reverse
+import django
+if django.VERSION < (1, 10):
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 from django.test import TestCase
 
 from haystack.utils import app_loading

--- a/test_haystack/test_views.py
+++ b/test_haystack/test_views.py
@@ -5,8 +5,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import time
 from threading import Thread
 
+import django
 from django import forms
-from django.core.urlresolvers import reverse
+if django.VERSION < (1, 10):
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 from django.http import HttpRequest, QueryDict
 from django.test import TestCase, override_settings
 from django.utils.six.moves import queue

--- a/tox.ini
+++ b/tox.ini
@@ -6,27 +6,37 @@ envlist = docs,
         py34-django1.8-es1.x,
         py34-django1.9-es1.x,
         py34-django1.10-es1.x,
+        py34-django2.0-es1.x,
         py35-django1.8-es1.x,
         py35-django1.9-es1.x,
         py35-django1.10-es1.x,
+        py35-django2.0-es1.x,
         pypy-django1.8-es1.x,
         pypy-django1.9-es1.x,
         pypy-django1.10-es1.x,
+        pypy-django2.0-es1.x,
         py27-django1.8-es2.x,
         py27-django1.9-es2.x,
         py27-django1.10-es2.x,
         py34-django1.8-es2.x,
         py34-django1.9-es2.x,
         py34-django1.10-es2.x,
+        py34-django2.0-es2.x,
         py35-django1.8-es2.x,
         py35-django1.9-es2.x,
         py35-django1.10-es2.x,
+        py35-django2.0-es2.x,
         pypy-django1.8-es2.x,
         pypy-django1.9-es2.x,
         pypy-django1.10-es2.x,
+        pypy-django2.0-es2.x,
 
 [base]
 deps = requests
+
+[django2.0]
+deps =
+    Django>=2.0a1,<2.1
 
 [django1.10]
 deps =
@@ -72,6 +82,13 @@ setenv = VERSION_ES=>=1.0.0,<2.0.0
 deps =
     {[es1.x]deps}
     {[django1.10]deps}
+    {[base]deps}
+
+[testenv:pypy-django2.0-es1.x]
+setenv = VERSION_ES=>=1.0.0,<2.0.0
+deps =
+    {[es1.x]deps}
+    {[django2.0]deps}
     {[base]deps}
 
 [testenv:py27-django1.8-es1.x]
@@ -121,6 +138,13 @@ deps =
     {[django1.10]deps}
     {[base]deps}
 
+[testenv:py34-django2.0-es1.x]
+basepython = python3.4
+setenv = VERSION_ES=>=1.0.0,<2.0.0
+deps =
+    {[django2.0]deps}
+    {[base]deps}
+
 [testenv:py35-django1.8-es1.x]
 basepython = python3.5
 setenv = VERSION_ES=>=1.0.0,<2.0.0
@@ -145,6 +169,14 @@ deps =
     {[django1.10]deps}
     {[base]deps}
 
+[testenv:py35-django2.0-es1.x]
+basepython = python3.5
+setenv = VERSION_ES=>=1.0.0,<2.0.0
+deps =
+    {[es1.x]deps}
+    {[django2.0]deps}
+    {[base]deps}
+
 [testenv:pypy-django1.8-es2.x]
 setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
@@ -164,6 +196,13 @@ setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
     {[es2.x]deps}
     {[django1.10]deps}
+    {[base]deps}
+
+[testenv:pypy-django2.0-es2.x]
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.0]deps}
     {[base]deps}
 
 [testenv:py27-django1.8-es2.x]
@@ -214,6 +253,14 @@ deps =
     {[django1.10]deps}
     {[base]deps}
 
+[testenv:py34-django2.0-es2.x]
+basepython = python3.4
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.0]deps}
+    {[base]deps}
+
 [testenv:py35-django1.8-es2.x]
 basepython = python3.5
 setenv = VERSION_ES=>=2.0.0,<3.0.0
@@ -236,6 +283,14 @@ setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
     {[es2.x]deps}
     {[django1.10]deps}
+    {[base]deps}
+
+[testenv:py35-django2.0-es2.x]
+basepython = python3.5
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.0]deps}
     {[base]deps}
 
 [testenv:docs]


### PR DESCRIPTION
1. Every option passed to a command needs to be pre-defined via `add_arguments`, otherwise it errors out. This will happen when calling rebuild_index.

```python-traceback
/tests/util.py:13: in rebuild_index
    management.call_command("rebuild_index", interactive=False, verbosity=0)
/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py:141: in call_command
    return command.execute(*args, **defaults)
/usr/local/lib/python3.6/site-packages/django/core/management/base.py:335: in execute
    output = self.handle(*args, **options)
/usr/local/lib/python3.6/site-packages/haystack/management/commands/rebuild_index.py:36: in handle
    call_command('clear_index', **options)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

command_name = 'clear_index', args = (), options = {'batchsize': None, 'commit': True, 'interactive': False, 'no_color': False, ...}
command = <haystack.management.commands.clear_index.Command object at 0x7f3d8845aac8>, app_name = 'haystack'
parser = CommandParser(prog=' clear_index', usage=None, description='Clears out the search index completely.', formatter_class=<class 'argparse.HelpFormatter'>, conflict_handler='error', add_help=True)
arg_options = {'batchsize': None, 'commit': True, 'interactive': False, 'no_color': False, ...}
defaults = {'batchsize': None, 'commit': True, 'interactive': False, 'no_color': False, ...}
stealth_options = {'skip_checks', 'stderr', 'stdout'}
dest_parameters = {'commit', 'help', 'interactive', 'no_color', 'pythonpath', 'settings', ...}
valid_options = {'commit', 'help', 'interactive', 'no_color', 'nocommit', 'noinput', ...}, unknown_options = {'batchsize', 'workers'}

    def call_command(command_name, *args, **options):
        # --- snip ---
        if unknown_options:
            raise TypeError(
                "Unknown option(s) for %s command: %s. "
                "Valid options are: %s." % (
                    command_name,
                    ', '.join(sorted(unknown_options)),
>                   ', '.join(sorted(valid_options)),
                )
            )
E           TypeError: Unknown option(s) for clear_index command: batchsize, workers. Valid options are: commit, help, interactive, no_color, nocommit, noinput, pythonpath, settings, skip_checks, stderr, stdout, traceback, using, verbosity, version.

/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py:133: TypeError
```

2. `from django.core.urlresolvers` has been removed. I added a version dependent import.

----

Especially regarding the tests im not certain, if I added 2.0a1 correctly, or if you're even supporting/testing against django1.11? What's the take on 2.0?
Even if you don't care, the command fix will not change anything in older versions, while in 2.0 it's required. So if you don't want the `django.urls` part, at least accept the `stealth_options` part.