### PR TITLE
Update boost.rst

### DIFF
--- a/docs/boost.rst
+++ b/docs/boost.rst
@@ -57,7 +57,7 @@ See the :doc:`searchqueryset_api` docs for more details on using this method.
 Document Boost
 ==============
 
-Document boosting is done by adding a ``boost`` field to the prepared data
+Document boosting is done by adding a ``_boost`` field to the prepared data
 ``SearchIndex`` creates. The best way to do this is to override
 ``SearchIndex.prepare``::
 
@@ -70,7 +70,7 @@ Document boosting is done by adding a ``boost`` field to the prepared data
 
         def prepare(self, obj):
             data = super(NoteSearchIndex, self).prepare(obj)
-            data['boost'] = 1.1
+            data['_boost'] = 1.1
             return data
 
 


### PR DESCRIPTION
To fix the dict key that needs to be passed for Document boosting ('_boost' and not 'boost')

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.