### PR TITLE
Clarifies need for HAYSTACK_DOCUMENT_FIELD

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -263,6 +263,11 @@ which field is the primary field for searching within.
     There is nothing special about the ``text`` field name used in all of the
     examples. It could be anything; you could call it ``pink_polka_dot`` and
     it won't matter. It's simply a convention to call it ``text``.
+    
+    To use a document field with a name other than ``text``, be sure to configure
+    the ``HAYSTACK_DOCUMENT_FIELD`` setting. For example,::
+    
+        HAYSTACK_DOCUMENT_FIELD = 'pink_polka_dot'
 
 Additionally, we're providing ``use_template=True`` on the ``text`` field. This
 allows us to use a data template (rather than error-prone concatenation) to


### PR DESCRIPTION
This setting is needed when using a document field name other than `text`, which is not clear as-written.