### PR TITLE
Checking for __iter__ not valid way to check is iterable

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -153,7 +153,9 @@ class SearchField(object):
                 return current_objects.all()
             return []
 
-        elif not hasattr(current_objects, '__iter__'):
+        try:
+            current_objects = [obj for obj in current_objects]
+        except:
             current_objects = [current_objects]
 
         return current_objects


### PR DESCRIPTION
Some objects have an `__iter__` method even though they are not iterable - `SimpleLazyObject` for ex.

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.