### PR TITLE
Django 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ env:
 matrix:
     allow_failures:
         - python: 'pypy'
+        - python: 2.7
+          env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
 
 notifications:
     irc: "irc.freenode.org#haystack"

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ matrix:
         - python: 'pypy'
         - python: 2.7
           env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
+        - python: 2.7
+          env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=1.0.0,<2.0.0"
 
 notifications:
     irc: "irc.freenode.org#haystack"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ env:
         - DJANGO_VERSION=">=1.9,<1.10" VERSION_ES=">=2.0.0,<3.0.0"
         - DJANGO_VERSION=">=1.10,<1.11" VERSION_ES=">=2.0.0,<3.0.0"
         - DJANGO_VERSION=">=1.11,<1.12" VERSION_ES=">=2.0.0,<3.0.0"
+        - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
 
 matrix:
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,15 @@ script:
 
 env:
     matrix:
-        - DJANGO_VERSION=">=1.11,<1.12" VERSION_ES=">=1.0.0,<2.0.0"
+        - DJANGO_VERSION=">=1.11,<2.0" VERSION_ES=">=1.0.0,<2.0.0"
         - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=1.0.0,<2.0.0"
-        - DJANGO_VERSION=">=1.11,<1.12" VERSION_ES=">=2.0.0,<3.0.0"
+        - DJANGO_VERSION=">=1.11,<2.0" VERSION_ES=">=2.0.0,<3.0.0"
         - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
 
 matrix:
     allow_failures:
         - python: 'pypy'
+    exclude:
         - python: 2.7
           env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 2.7
     - 3.4
     - 3.5
+    - 3.6
     - pypy
 
 cache:
@@ -58,12 +59,8 @@ script:
 
 env:
     matrix:
-        - DJANGO_VERSION=">=1.8,<1.9" VERSION_ES=">=1.0.0,<2.0.0"
-        - DJANGO_VERSION=">=1.9,<1.10" VERSION_ES=">=1.0.0,<2.0.0"
-        - DJANGO_VERSION=">=1.10,<1.11" VERSION_ES=">=1.0.0,<2.0.0"
-        - DJANGO_VERSION=">=1.8,<1.9" VERSION_ES=">=2.0.0,<3.0.0"
-        - DJANGO_VERSION=">=1.9,<1.10" VERSION_ES=">=2.0.0,<3.0.0"
-        - DJANGO_VERSION=">=1.10,<1.11" VERSION_ES=">=2.0.0,<3.0.0"
+        - DJANGO_VERSION=">=1.11,<1.12" VERSION_ES=">=1.0.0,<2.0.0"
+        - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=1.0.0,<2.0.0"
         - DJANGO_VERSION=">=1.11,<1.12" VERSION_ES=">=2.0.0,<3.0.0"
         - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -117,3 +117,4 @@ Thanks to
     * Morgan Aubert (@ellmetha) for Django 1.10 support
     * João Junior (@joaojunior) and Bruno Marques (@ElSaico) for Elasticsearch 2.x support
     * Alex Tomkins (@tomkins) for various patches
+    * Martin Pauly (@mpauly) for Django 2.0 support

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -296,7 +296,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             for field, direction in sort_by:
                 if field == 'distance' and distance_point:
                     # Do the geo-enabled sort.
-                    lng, lat = distance_point['point'].get_coords()
+                    lng, lat = distance_point['point'].coords
                     sort_kwargs = {
                         "_geo_distance": {
                             distance_point['field']: [lng, lat],
@@ -455,7 +455,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             filters.append(within_filter)
 
         if dwithin is not None:
-            lng, lat = dwithin['point'].get_coords()
+            lng, lat = dwithin['point'].coords
 
             # NB: the 1.0.0 release of elasticsearch introduce an
             #     incompatible change on the distance filter formating

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -173,7 +173,7 @@ class SolrSearchBackend(BaseSearchBackend):
         if sort_by is not None:
             if sort_by in ['distance asc', 'distance desc'] and distance_point:
                 # Do the geo-enabled sort.
-                lng, lat = distance_point['point'].get_coords()
+                lng, lat = distance_point['point'].coords
                 kwargs['sfield'] = distance_point['field']
                 kwargs['pt'] = '%s,%s' % (lat, lng)
 
@@ -290,7 +290,7 @@ class SolrSearchBackend(BaseSearchBackend):
 
         if dwithin is not None:
             kwargs.setdefault('fq', [])
-            lng, lat = dwithin['point'].get_coords()
+            lng, lat = dwithin['point'].coords
             geofilt = '{!geofilt pt=%s,%s sfield=%s d=%s}' % (lat, lng, dwithin['field'], dwithin['distance'].km)
             kwargs['fq'].append(geofilt)
 

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -443,7 +443,7 @@ class ModelSearchIndex(SearchIndex):
             return True
 
         # Ignore certain fields (AutoField, related fields).
-        if field.primary_key or (hasattr(field, 'rel') and getattr(field, 'rel')):
+        if field.primary_key or field.is_relation:
             return True
 
         return False

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -443,7 +443,7 @@ class ModelSearchIndex(SearchIndex):
             return True
 
         # Ignore certain fields (AutoField, related fields).
-        if field.primary_key or getattr(field, 'rel'):
+        if field.primary_key or (hasattr(field, 'rel') and getattr(field, 'rel')):
             return True
 
         return False

--- a/haystack/management/commands/rebuild_index.py
+++ b/haystack/management/commands/rebuild_index.py
@@ -1,8 +1,6 @@
 # encoding: utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import copy
-
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
@@ -34,8 +32,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        clear_options = copy.copy(options)
-        update_options = copy.copy(options)
+        clear_options = options.copy()
+        update_options = options.copy()
         for key in ('batchsize', 'workers'):
             del clear_options[key]
         for key in ('interactive', ):

--- a/haystack/management/commands/rebuild_index.py
+++ b/haystack/management/commands/rebuild_index.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
-import copy
-
 from __future__ import absolute_import, division, print_function, unicode_literals
+
+import copy
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand

--- a/haystack/management/commands/rebuild_index.py
+++ b/haystack/management/commands/rebuild_index.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         update_options = copy.copy(options)
         for key in ('batchsize', 'workers'):
             del clear_options[key]
-        for key in ():
+        for key in ('interactive', ):
             del update_options[key]
         call_command('clear_index', **clear_options)
         call_command('update_index', **update_options)

--- a/haystack/management/commands/rebuild_index.py
+++ b/haystack/management/commands/rebuild_index.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+import copy
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
@@ -33,5 +34,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        call_command('clear_index', **options)
-        call_command('update_index', **options)
+        clear_options = copy.copy(options)
+        update_options = copy.copy(options)
+        for key in ('batchsize', 'workers'):
+            del clear_options[key]
+        for key in ():
+            del update_options[key]
+        call_command('clear_index', **clear_options)
+        call_command('update_index', **update_options)

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -133,7 +133,7 @@ class SearchResult(object):
             if location_field is None:
                 return None
 
-            lf_lng, lf_lat = location_field.get_coords()
+            lf_lng, lf_lat = location_field.coords
             self._distance = Distance(km=geopy_distance.distance((po_lat, po_lng), (lf_lat, lf_lng)).km)
 
         # We've either already calculated it or the backend returned it, so

--- a/haystack/utils/geo.py
+++ b/haystack/utils/geo.py
@@ -43,7 +43,7 @@ def ensure_wgs84(point):
 
     if not new_point.srid:
         # It has no spatial reference id. Assume WGS-84.
-        new_point.set_srid(WGS_84_SRID)
+        new_point.srid = WGS_84_SRID
     elif new_point.srid != WGS_84_SRID:
         # Transform it to get to the right system.
         new_point.transform(WGS_84_SRID)
@@ -72,7 +72,7 @@ def generate_bounding_box(bottom_left, top_right):
 
     The two-tuple is in the form ``((min_lat, min_lng), (max_lat, max_lng))``.
     """
-    west, lat_1 = bottom_left.get_coords()
-    east, lat_2 = top_right.get_coords()
+    west, lat_1 = bottom_left.coords
+    east, lat_2 = top_right.coords
     min_lat, max_lat = min(lat_1, lat_2), max(lat_1, lat_2)
     return ((min_lat, west), (max_lat, east))

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     from setuptools import setup
 
 install_requires = [
-    'Django>=1.8,<2.1',
+    'Django>=1.11,<2.1',
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     from setuptools import setup
 
 install_requires = [
-    'Django>=1.11,<2.1',
+    'Django>=1.11',
 ]
 
 tests_require = [
@@ -54,6 +54,8 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     from setuptools import setup
 
 install_requires = [
-    'Django>=1.8,<1.12',
+    'Django>=1.8,<2.1',
 ]
 
 tests_require = [

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -17,7 +17,7 @@ class MockModel(models.Model):
     author = models.CharField(max_length=255)
     foo = models.CharField(max_length=255, blank=True)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
-    tag = models.ForeignKey(MockTag, on_delete=models.CASCADE)
+    tag = models.ForeignKey(MockTag, models.CASCADE)
 
     def __unicode__(self):
         return self.author
@@ -108,4 +108,4 @@ class OneToManyLeftSideModel(models.Model):
 
 
 class OneToManyRightSideModel(models.Model):
-    left_side = models.ForeignKey(OneToManyLeftSideModel, related_name='right_side', on_delete=models.CASCADE)
+    left_side = models.ForeignKey(OneToManyLeftSideModel, models.CASCADE, related_name='right_side')

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -17,7 +17,7 @@ class MockModel(models.Model):
     author = models.CharField(max_length=255)
     foo = models.CharField(max_length=255, blank=True)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
-    tag = models.ForeignKey(MockTag)
+    tag = models.ForeignKey(MockTag, on_delete=models.CASCADE)
 
     def __unicode__(self):
         return self.author
@@ -108,4 +108,4 @@ class OneToManyLeftSideModel(models.Model):
 
 
 class OneToManyRightSideModel(models.Model):
-    left_side = models.ForeignKey(OneToManyLeftSideModel, related_name='right_side')
+    left_side = models.ForeignKey(OneToManyLeftSideModel, related_name='right_side', on_delete=models.CASCADE)

--- a/test_haystack/core/urls.py
+++ b/test_haystack/core/urls.py
@@ -13,7 +13,7 @@ admin.autodiscover()
 
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 
     url(r'^$', SearchView(load_all=False), name='haystack_search'),
     url(r'^faceted/$',
@@ -23,5 +23,5 @@ urlpatterns = [
 ]
 
 urlpatterns += [
-    url(r'', include('test_haystack.test_app_without_models.urls', namespace='app-without-models')),
+    url(r'', include(('test_haystack.test_app_without_models.urls', 'app-without-models'))),
 ]

--- a/test_haystack/settings.py
+++ b/test_haystack/settings.py
@@ -51,12 +51,11 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 ]
 

--- a/test_haystack/solr_tests/test_admin.py
+++ b/test_haystack/solr_tests/test_admin.py
@@ -2,11 +2,15 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import django
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.core.urlresolvers import reverse
+if django.VERSION < (1, 10):
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 
 from haystack import connections, reset_search_queries
 from haystack.utils.loading import UnifiedIndex

--- a/test_haystack/solr_tests/test_admin.py
+++ b/test_haystack/solr_tests/test_admin.py
@@ -7,10 +7,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
-if django.VERSION < (1, 10):
-    from django.core.urlresolvers import reverse
-else:
-    from django.urls import reverse
+from django.urls import reverse
 
 from haystack import connections, reset_search_queries
 from haystack.utils.loading import UnifiedIndex

--- a/test_haystack/solr_tests/test_admin.py
+++ b/test_haystack/solr_tests/test_admin.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import django
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -1457,8 +1457,11 @@ class SolrBoostBackendTestCase(TestCase):
             'core.afourthmockmodel.4'
         ])
 
-
-@unittest.skipIf(tuple(pysolr.__version__.split('.')) < (3, 1, 1), 'content extraction requires pysolr > 3.1.0')
+if isinstance(pysolr.__version__, tuple):
+    pysolr_version = pysolr.__version__
+else:
+    pysolr_version = tuple([int(n) for n in pysolr.__version__.split('.')])
+@unittest.skipIf(pysolr_version < (3, 1, 1), 'content extraction requires pysolr > 3.1.0')
 class LiveSolrContentExtractionTestCase(TestCase):
     def setUp(self):
         super(LiveSolrContentExtractionTestCase, self).setUp()

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -1458,7 +1458,7 @@ class SolrBoostBackendTestCase(TestCase):
         ])
 
 
-@unittest.skipIf(pysolr.__version__ < (3, 1, 1), 'content extraction requires pysolr > 3.1.0')
+@unittest.skipIf(tuple(pysolr.__version__.split('.')) < (3, 1, 1), 'content extraction requires pysolr > 3.1.0')
 class LiveSolrContentExtractionTestCase(TestCase):
     def setUp(self):
         super(LiveSolrContentExtractionTestCase, self).setUp()

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -1457,11 +1457,7 @@ class SolrBoostBackendTestCase(TestCase):
             'core.afourthmockmodel.4'
         ])
 
-if isinstance(pysolr.__version__, tuple):
-    pysolr_version = pysolr.__version__
-else:
-    pysolr_version = tuple([int(n) for n in pysolr.__version__.split('.')])
-@unittest.skipIf(pysolr_version < (3, 1, 1), 'content extraction requires pysolr > 3.1.0')
+
 class LiveSolrContentExtractionTestCase(TestCase):
     def setUp(self):
         super(LiveSolrContentExtractionTestCase, self).setUp()

--- a/test_haystack/solr_tests/test_solr_management_commands.py
+++ b/test_haystack/solr_tests/test_solr_management_commands.py
@@ -194,7 +194,7 @@ class ManagementCommandTestCase(TestCase):
                                                    'PATH': mkdtemp(prefix='dummy-path-'), }
 
         connections['whoosh']._index = self.ui
-        self.assertRaises(ImproperlyConfigured, call_command, 'build_solr_schema', using='whoosh', interactive=False)
+        self.assertRaises(ImproperlyConfigured, call_command, 'build_solr_schema', using='whoosh')
 
     def test_build_schema(self):
 
@@ -276,38 +276,38 @@ class AppModelManagementCommandTestCase(TestCase):
         call_command('clear_index', interactive=False, verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 0)
 
-        call_command('update_index', 'core', interactive=False, verbosity=0)
+        call_command('update_index', 'core', verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 25)
 
         call_command('clear_index', interactive=False, verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 0)
 
         with self.assertRaises(ImproperlyConfigured):
-            call_command('update_index', 'fake_app_thats_not_there', interactive=False)
+            call_command('update_index', 'fake_app_thats_not_there')
 
-        call_command('update_index', 'core', 'discovery', interactive=False, verbosity=0)
+        call_command('update_index', 'core', 'discovery', verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 25)
 
         call_command('clear_index', interactive=False, verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 0)
 
-        call_command('update_index', 'discovery', interactive=False, verbosity=0)
+        call_command('update_index', 'discovery', verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 0)
 
         call_command('clear_index', interactive=False, verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 0)
 
-        call_command('update_index', 'core.MockModel', interactive=False, verbosity=0)
+        call_command('update_index', 'core.MockModel', verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 23)
 
         call_command('clear_index', interactive=False, verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 0)
 
-        call_command('update_index', 'core.MockTag', interactive=False, verbosity=0)
+        call_command('update_index', 'core.MockTag', verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 2)
 
         call_command('clear_index', interactive=False, verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 0)
 
-        call_command('update_index', 'core.MockTag', 'core.MockModel', interactive=False, verbosity=0)
+        call_command('update_index', 'core.MockTag', 'core.MockModel', verbosity=0)
         self.assertEqual(self.solr.search('*:*').hits, 25)

--- a/test_haystack/spatial/test_spatial.py
+++ b/test_haystack/spatial/test_spatial.py
@@ -37,7 +37,7 @@ class SpatialUtilitiesTestCase(TestCase):
         self.assertEqual(std_pnt.y, 38.97127105172941)
 
         orig_pnt = Point(-95.23592948913574, 38.97127105172941)
-        orig_pnt.set_srid(2805)
+        orig_pnt.srid = 2805
         std_pnt = ensure_wgs84(orig_pnt)
         self.assertEqual(orig_pnt.srid, 2805)
         self.assertEqual(std_pnt.srid, 4326)
@@ -96,8 +96,8 @@ class SpatialSolrTestCase(TestCase):
         self.assertEqual(sqs.count(), 1)
         self.assertEqual(sqs[0].username, first.username)
         # Make sure we've got a proper ``Point`` object.
-        self.assertAlmostEqual(sqs[0].location.get_coords()[0], first.longitude)
-        self.assertAlmostEqual(sqs[0].location.get_coords()[1], first.latitude)
+        self.assertAlmostEqual(sqs[0].location.coords[0], first.longitude)
+        self.assertAlmostEqual(sqs[0].location.coords[1], first.latitude)
 
         # Double-check, to make sure there was nothing accidentally copied
         # between instances.
@@ -106,8 +106,8 @@ class SpatialSolrTestCase(TestCase):
         sqs = self.sqs.models(Checkin).filter(django_id=second.pk)
         self.assertEqual(sqs.count(), 1)
         self.assertEqual(sqs[0].username, second.username)
-        self.assertAlmostEqual(sqs[0].location.get_coords()[0], second.longitude)
-        self.assertAlmostEqual(sqs[0].location.get_coords()[1], second.latitude)
+        self.assertAlmostEqual(sqs[0].location.coords[0], second.longitude)
+        self.assertAlmostEqual(sqs[0].location.coords[1], second.latitude)
 
     def test_within(self):
         self.assertEqual(self.sqs.all().count(), 10)

--- a/test_haystack/test_app_loading.py
+++ b/test_haystack/test_app_loading.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from types import GeneratorType, ModuleType
 
-from django.core.urlresolvers import reverse
+import django
+if django.VERSION < (1, 10):
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 from django.test import TestCase
 
 from haystack.utils import app_loading

--- a/test_haystack/test_app_loading.py
+++ b/test_haystack/test_app_loading.py
@@ -4,10 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from types import GeneratorType, ModuleType
 
 import django
-if django.VERSION < (1, 10):
-    from django.core.urlresolvers import reverse
-else:
-    from django.urls import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from haystack.utils import app_loading

--- a/test_haystack/test_app_loading.py
+++ b/test_haystack/test_app_loading.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from types import GeneratorType, ModuleType
 
-import django
 from django.urls import reverse
 from django.test import TestCase
 

--- a/test_haystack/test_indexes.py
+++ b/test_haystack/test_indexes.py
@@ -581,6 +581,11 @@ class TextReadQuerySetTestSearchIndex(indexes.SearchIndex, indexes.Indexable):
         return self.get_model().objects.complete_set()
 
 
+class ModelWithManyToManyFieldModelSearchIndex(indexes.ModelSearchIndex):
+    def get_model(self):
+        return ManyToManyLeftSideModel
+
+
 class ModelSearchIndexTestCase(TestCase):
     def setUp(self):
         super(ModelSearchIndexTestCase, self).setUp()
@@ -590,6 +595,7 @@ class ModelSearchIndexTestCase(TestCase):
         self.emsi = ExcludesModelSearchIndex()
         self.fwomsi = FieldsWithOverrideModelSearchIndex()
         self.yabmsi = YetAnotherBasicModelSearchIndex()
+        self.m2mmsi = ModelWithManyToManyFieldModelSearchIndex()
 
     def test_basic(self):
         self.assertEqual(len(self.bmsi.fields), 4)
@@ -623,6 +629,7 @@ class ModelSearchIndexTestCase(TestCase):
         self.assertTrue(isinstance(self.emsi.fields['pub_date'], indexes.DateTimeField))
         self.assertTrue('text' in self.emsi.fields)
         self.assertTrue(isinstance(self.emsi.fields['text'], indexes.CharField))
+        self.assertFalse('related_models' in self.m2mmsi.fields)
 
     def test_fields_with_override(self):
         self.assertEqual(len(self.fwomsi.fields), 3)

--- a/test_haystack/test_indexes.py
+++ b/test_haystack/test_indexes.py
@@ -629,7 +629,7 @@ class ModelSearchIndexTestCase(TestCase):
         self.assertTrue(isinstance(self.emsi.fields['pub_date'], indexes.DateTimeField))
         self.assertTrue('text' in self.emsi.fields)
         self.assertTrue(isinstance(self.emsi.fields['text'], indexes.CharField))
-        self.assertFalse('related_models' in self.m2mmsi.fields)
+        self.assertNotIn('related_models', self.m2mmsi.fields)
 
     def test_fields_with_override(self):
         self.assertEqual(len(self.fwomsi.fields), 3)

--- a/test_haystack/test_management_commands.py
+++ b/test_haystack/test_management_commands.py
@@ -89,7 +89,7 @@ class CoreManagementCommandsTestCase(TestCase):
 
     @patch('haystack.management.commands.clear_index.Command.handle')
     @patch('haystack.management.commands.update_index.Command.handle')
-    def test_rebuild_index_nocommit(self, *mocks):
+    def test_rebuild_index_nocommit(self, update_mock, clear_mock):
         """
         Confirm that command-line option parsing produces the same results as using call_command() directly,
         mostly as a sanity check for the logic in rebuild_index which combines the option_lists for its
@@ -99,7 +99,7 @@ class CoreManagementCommandsTestCase(TestCase):
 
         Command().run_from_argv(['django-admin.py', 'rebuild_index', '--noinput', '--nocommit'])
 
-        for m in mocks:
+        for m in (clear_mock, update_mock):
             self.assertEqual(m.call_count, 1)
 
             args, kwargs = m.call_args
@@ -107,7 +107,7 @@ class CoreManagementCommandsTestCase(TestCase):
             self.assertIn('commit', kwargs)
             self.assertEqual(False, kwargs['commit'])
 
-        args, kwargs = mocks[0].call_args
+        args, kwargs = clear_mock.call_args
 
         self.assertIn('interactive', kwargs)
         self.assertEqual(False, kwargs['interactive'])

--- a/test_haystack/test_management_commands.py
+++ b/test_haystack/test_management_commands.py
@@ -87,8 +87,8 @@ class CoreManagementCommandsTestCase(TestCase):
             self.assertIn('commit', kwargs)
             self.assertEqual(False, kwargs['commit'])
 
-    @patch('haystack.management.commands.update_index.Command.handle')
     @patch('haystack.management.commands.clear_index.Command.handle')
+    @patch('haystack.management.commands.update_index.Command.handle')
     def test_rebuild_index_nocommit(self, *mocks):
         """
         Confirm that command-line option parsing produces the same results as using call_command() directly,
@@ -107,7 +107,7 @@ class CoreManagementCommandsTestCase(TestCase):
             self.assertIn('commit', kwargs)
             self.assertEqual(False, kwargs['commit'])
 
-        args, kwargs = mocks[1].call_args
+        args, kwargs = mocks[0].call_args
 
         self.assertIn('interactive', kwargs)
         self.assertEqual(False, kwargs['interactive'])

--- a/test_haystack/test_management_commands.py
+++ b/test_haystack/test_management_commands.py
@@ -69,6 +69,9 @@ class CoreManagementCommandsTestCase(TestCase):
     @patch('haystack.management.commands.update_index.Command.handle')
     @patch('haystack.management.commands.clear_index.Command.handle')
     def test_rebuild_index(self, mock_handle_clear, mock_handle_update):
+        mock_handle_clear.return_value = ''
+        mock_handle_update.return_value = ''
+
         call_command('rebuild_index', interactive=False)
 
         self.assertTrue(mock_handle_clear.called)
@@ -96,6 +99,9 @@ class CoreManagementCommandsTestCase(TestCase):
         component commands.
         """
         from haystack.management.commands.rebuild_index import Command
+
+        update_mock.return_value = ''
+        clear_mock.return_value = ''
 
         Command().run_from_argv(['django-admin.py', 'rebuild_index', '--noinput', '--nocommit'])
 

--- a/test_haystack/test_management_commands.py
+++ b/test_haystack/test_management_commands.py
@@ -107,5 +107,7 @@ class CoreManagementCommandsTestCase(TestCase):
             self.assertIn('commit', kwargs)
             self.assertEqual(False, kwargs['commit'])
 
-            self.assertIn('interactive', kwargs)
-            self.assertEqual(False, kwargs['interactive'])
+        args, kwargs = mocks[1].call_args
+
+        self.assertIn('interactive', kwargs)
+        self.assertEqual(False, kwargs['interactive'])

--- a/test_haystack/test_management_commands.py
+++ b/test_haystack/test_management_commands.py
@@ -66,12 +66,9 @@ class CoreManagementCommandsTestCase(TestCase):
         m2.assert_called_with("eng")
         m1.assert_any_call("core", "eng")
 
-    @patch('haystack.management.commands.update_index.Command.handle')
-    @patch('haystack.management.commands.clear_index.Command.handle')
+    @patch('haystack.management.commands.update_index.Command.handle', return_value='')
+    @patch('haystack.management.commands.clear_index.Command.handle', return_value='')
     def test_rebuild_index(self, mock_handle_clear, mock_handle_update):
-        mock_handle_clear.return_value = ''
-        mock_handle_update.return_value = ''
-
         call_command('rebuild_index', interactive=False)
 
         self.assertTrue(mock_handle_clear.called)
@@ -90,8 +87,8 @@ class CoreManagementCommandsTestCase(TestCase):
             self.assertIn('commit', kwargs)
             self.assertEqual(False, kwargs['commit'])
 
-    @patch('haystack.management.commands.clear_index.Command.handle')
-    @patch('haystack.management.commands.update_index.Command.handle')
+    @patch('haystack.management.commands.clear_index.Command.handle', return_value='')
+    @patch('haystack.management.commands.update_index.Command.handle', return_value='')
     def test_rebuild_index_nocommit(self, update_mock, clear_mock):
         """
         Confirm that command-line option parsing produces the same results as using call_command() directly,
@@ -99,9 +96,6 @@ class CoreManagementCommandsTestCase(TestCase):
         component commands.
         """
         from haystack.management.commands.rebuild_index import Command
-
-        update_mock.return_value = ''
-        clear_mock.return_value = ''
 
         Command().run_from_argv(['django-admin.py', 'rebuild_index', '--noinput', '--nocommit'])
 
@@ -116,4 +110,4 @@ class CoreManagementCommandsTestCase(TestCase):
         args, kwargs = clear_mock.call_args
 
         self.assertIn('interactive', kwargs)
-        self.assertEqual(False, kwargs['interactive'])
+        self.assertIs(kwargs['interactive'], False)

--- a/test_haystack/test_views.py
+++ b/test_haystack/test_views.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import time
 from threading import Thread
 
-import django
 from django import forms
 from django.http import HttpRequest, QueryDict
 from django.test import TestCase, override_settings

--- a/test_haystack/test_views.py
+++ b/test_haystack/test_views.py
@@ -10,10 +10,7 @@ from django import forms
 from django.http import HttpRequest, QueryDict
 from django.test import TestCase, override_settings
 from django.utils.six.moves import queue
-if django.VERSION < (1, 10):
-    from django.core.urlresolvers import reverse
-else:
-    from django.urls import reverse
+from django.urls import reverse
 from test_haystack.core.models import AnotherMockModel, MockModel
 
 from haystack import connections, indexes

--- a/test_haystack/test_views.py
+++ b/test_haystack/test_views.py
@@ -5,11 +5,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import time
 from threading import Thread
 
+import django
 from django import forms
-from django.core.urlresolvers import reverse
 from django.http import HttpRequest, QueryDict
 from django.test import TestCase, override_settings
 from django.utils.six.moves import queue
+if django.VERSION < (1, 10):
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 from test_haystack.core.models import AnotherMockModel, MockModel
 
 from haystack import connections, indexes

--- a/tox.ini
+++ b/tox.ini
@@ -6,27 +6,37 @@ envlist = docs,
         py34-django1.8-es1.x,
         py34-django1.9-es1.x,
         py34-django1.10-es1.x,
+        py34-django2.0-es1.x,
         py35-django1.8-es1.x,
         py35-django1.9-es1.x,
         py35-django1.10-es1.x,
+        py35-django2.0-es1.x,
         pypy-django1.8-es1.x,
         pypy-django1.9-es1.x,
         pypy-django1.10-es1.x,
+        pypy-django2.0-es1.x,
         py27-django1.8-es2.x,
         py27-django1.9-es2.x,
         py27-django1.10-es2.x,
         py34-django1.8-es2.x,
         py34-django1.9-es2.x,
         py34-django1.10-es2.x,
+        py34-django2.0-es2.x,
         py35-django1.8-es2.x,
         py35-django1.9-es2.x,
         py35-django1.10-es2.x,
+        py35-django2.0-es2.x,
         pypy-django1.8-es2.x,
         pypy-django1.9-es2.x,
         pypy-django1.10-es2.x,
+        pypy-django2.0-es2.x,
 
 [base]
 deps = requests
+
+[django1.10]
+deps =
+    Django>=2.0,<2.1
 
 [django1.10]
 deps =
@@ -121,6 +131,13 @@ deps =
     {[django1.10]deps}
     {[base]deps}
 
+[testenv:py34-django1.10-es1.x]
+basepython = python3.4
+setenv = VERSION_ES=>=1.0.0,<2.0.0
+deps =
+    {[django2.0]deps}
+    {[base]deps}
+
 [testenv:py35-django1.8-es1.x]
 basepython = python3.5
 setenv = VERSION_ES=>=1.0.0,<2.0.0
@@ -145,6 +162,14 @@ deps =
     {[django1.10]deps}
     {[base]deps}
 
+[testenv:py35-django2.0-es1.x]
+basepython = python3.5
+setenv = VERSION_ES=>=1.0.0,<2.0.0
+deps =
+    {[es1.x]deps}
+    {[django2.0]deps}
+    {[base]deps}
+
 [testenv:pypy-django1.8-es2.x]
 setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
@@ -164,6 +189,13 @@ setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
     {[es2.x]deps}
     {[django1.10]deps}
+    {[base]deps}
+
+[testenv:pypy-django2.0-es2.x]
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.0]deps}
     {[base]deps}
 
 [testenv:py27-django1.8-es2.x]
@@ -214,6 +246,14 @@ deps =
     {[django1.10]deps}
     {[base]deps}
 
+[testenv:py34-django2.0-es2.x]
+basepython = python3.4
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.0]deps}
+    {[base]deps}
+
 [testenv:py35-django1.8-es2.x]
 basepython = python3.5
 setenv = VERSION_ES=>=2.0.0,<3.0.0
@@ -236,6 +276,14 @@ setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
     {[es2.x]deps}
     {[django1.10]deps}
+    {[base]deps}
+
+[testenv:py35-django2.0-es2.x]
+basepython = python3.5
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.0]deps}
     {[base]deps}
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
 
 [django1.11]
 deps =
-    Django>=1.11,<1.12
+    Django>=1.11,<2.0
 
 [es2.x]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -131,7 +131,7 @@ deps =
     {[django1.10]deps}
     {[base]deps}
 
-[testenv:py34-django1.10-es1.x]
+[testenv:py34-django2.0-es1.x]
 basepython = python3.4
 setenv = VERSION_ES=>=1.0.0,<2.0.0
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,35 +1,20 @@
 [tox]
 envlist = docs,
-        py27-django1.8-es1.x,
-        py27-django1.9-es1.x,
-        py27-django1.10-es1.x,
         py27-django1.11-es1.x,
-        py34-django1.8-es1.x,
-        py34-django1.9-es1.x,
-        py34-django1.10-es1.x,
         py34-django1.11-es1.x,
         py34-django2.0-es1.x,
-        py35-django1.8-es1.x,
-        py35-django1.9-es1.x,
-        py35-django1.10-es1.x,
         py35-django1.11-es1.x,
         py35-django2.0-es1.x,
-        pypy-django1.10-es1.x,
+        pypy-django1.11-es1.x,
         pypy-django2.0-es1.x,
-        py27-django1.8-es2.x,
-        py27-django1.9-es2.x,
-        py27-django1.10-es2.x,
-        py34-django1.8-es2.x,
-        py34-django1.9-es2.x,
-        py34-django1.10-es2.x,
+        py27-django1.11-es2.x,
+        py34-django1.11-es2.x,
         py34-django2.0-es2.x,
-        py35-django1.8-es2.x,
-        py35-django1.9-es2.x,
-        py35-django1.10-es2.x,
+        py35-django1.11-es2.x,
         py35-django2.0-es2.x,
         py36-django1.11-es2.x,
         py36-django2.0-es2.x,
-        pypy-django1.10-es2.x,
+        pypy-django1.11-es2.x,
         pypy-django2.0-es2.x,
 
 [base]
@@ -42,18 +27,6 @@ deps =
 [django1.11]
 deps =
     Django>=1.11,<1.12
-
-[django1.10]
-deps =
-    Django>=1.10,<1.11
-
-[django1.9]
-deps =
-    Django>=1.9,<1.10
-
-[django1.8]
-deps =
-    Django>=1.8,<1.9
 
 [es2.x]
 deps =
@@ -68,72 +41,33 @@ commands =
     python test_haystack/solr_tests/server/wait-for-solr
     python {toxinidir}/setup.py test
 
-[testenv:pypy-django1.8-es1.x]
+[testenv:pypy-django1.11-es1.x]
 setenv = VERSION_ES=>=1.0.0,<2.0.0
 deps =
     {[es1.x]deps}
-    {[django1.8]deps}
+    {[django1.11]deps}
     {[base]deps}
 
-[testenv:pypy-django1.9-es1.x]
+[testenv:pypy-django2.0-es1.x]
 setenv = VERSION_ES=>=1.0.0,<2.0.0
 deps =
     {[es1.x]deps}
-    {[django1.9]deps}
+    {[django2.0]deps}
     {[base]deps}
 
-[testenv:pypy-django1.10-es1.x]
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[es1.x]deps}
-    {[django1.10]deps}
-    {[base]deps}
-
-[testenv:py27-django1.8-es1.x]
+[testenv:py27-django1.11-es1.x]
 basepython = python2.7
 setenv = VERSION_ES=>=1.0.0,<2.0.0
 deps =
     {[es1.x]deps}
-    {[django1.8]deps}
+    {[django1.11]deps}
     {[base]deps}
 
-[testenv:py27-django1.9-es1.x]
-basepython = python2.7
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[es1.x]deps}
-    {[django1.9]deps}
-    {[base]deps}
-
-[testenv:py27-django1.10-es1.x]
-basepython = python2.7
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[es1.x]deps}
-    {[django1.10]deps}
-    {[base]deps}
-
-[testenv:py34-django1.8-es1.x]
+[testenv:py34-django1.11-es1.x]
 basepython = python3.4
 setenv = VERSION_ES=>=1.0.0,<2.0.0
 deps =
-    {[es1.x]deps}
-    {[django1.8]deps}
-    {[base]deps}
-
-[testenv:py34-django1.9-es1.x]
-basepython = python3.4
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[es1.x]deps}
-    {[django1.9]deps}
-    {[base]deps}
-
-[testenv:py34-django1.10-es1.x]
-basepython = python3.4
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[django1.10]deps}
+    {[django1.11]deps}
     {[base]deps}
 
 [testenv:py34-django2.0-es1.x]
@@ -143,28 +77,12 @@ deps =
     {[django2.0]deps}
     {[base]deps}
 
-[testenv:py35-django1.8-es1.x]
+[testenv:py35-django1.11-es1.x]
 basepython = python3.5
 setenv = VERSION_ES=>=1.0.0,<2.0.0
 deps =
     {[es1.x]deps}
-    {[django1.8]deps}
-    {[base]deps}
-
-[testenv:py35-django1.9-es1.x]
-basepython = python3.5
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[es1.x]deps}
-    {[django1.9]deps}
-    {[base]deps}
-
-[testenv:py35-django1.10-es1.x]
-basepython = python3.5
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[es1.x]deps}
-    {[django1.10]deps}
+    {[django1.11]deps}
     {[base]deps}
 
 [testenv:py35-django2.0-es1.x]
@@ -175,25 +93,11 @@ deps =
     {[django2.0]deps}
     {[base]deps}
 
-[testenv:pypy-django1.8-es2.x]
+[testenv:pypy-django1.11-es2.x]
 setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
     {[es2.x]deps}
-    {[django1.8]deps}
-    {[base]deps}
-
-[testenv:pypy-django1.9-es2.x]
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.9]deps}
-    {[base]deps}
-
-[testenv:pypy-django1.10-es2.x]
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.10]deps}
+    {[django1.11]deps}
     {[base]deps}
 
 [testenv:pypy-django2.0-es2.x]
@@ -203,52 +107,20 @@ deps =
     {[django2.0]deps}
     {[base]deps}
 
-[testenv:py27-django1.8-es2.x]
+[testenv:py27-django1.11-es2.x]
 basepython = python2.7
 setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
     {[es2.x]deps}
-    {[django1.8]deps}
+    {[django1.11]deps}
     {[base]deps}
 
-[testenv:py27-django1.9-es2.x]
-basepython = python2.7
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.9]deps}
-    {[base]deps}
-
-[testenv:py27-django1.10-es2.x]
-basepython = python2.7
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.10]deps}
-    {[base]deps}
-
-[testenv:py34-django1.8-es2.x]
+[testenv:py34-django1.11-es2.x]
 basepython = python3.4
 setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
     {[es2.x]deps}
-    {[django1.8]deps}
-    {[base]deps}
-
-[testenv:py34-django1.9-es2.x]
-basepython = python3.4
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.9]deps}
-    {[base]deps}
-
-[testenv:py34-django1.10-es2.x]
-basepython = python3.4
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.10]deps}
+    {[django1.11]deps}
     {[base]deps}
 
 [testenv:py34-django2.0-es2.x]
@@ -259,28 +131,12 @@ deps =
     {[django2.0]deps}
     {[base]deps}
 
-[testenv:py35-django1.8-es2.x]
+[testenv:py35-django1.11-es2.x]
 basepython = python3.5
 setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
     {[es2.x]deps}
-    {[django1.8]deps}
-    {[base]deps}
-
-[testenv:py35-django1.9-es2.x]
-basepython = python3.5
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.9]deps}
-    {[base]deps}
-
-[testenv:py35-django1.10-es2.x]
-basepython = python3.5
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.10]deps}
+    {[django1.11]deps}
     {[base]deps}
 
 [testenv:py35-django2.0-es2.x]

--- a/tox.ini
+++ b/tox.ini
@@ -284,11 +284,12 @@ deps =
     {[base]deps}
 
 [testenv:py35-django2.0-es2.x]
-    basepython = python3.5
-    setenv = VERSION_ES=>=2.0.0,<3.0.0
-    deps =
-        {[es2.x]deps}
-        {[django2.0]deps}
+basepython = python3.5
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.0]deps}
+    {[base]deps}
 
 [testenv:py36-django1.11-es2.x]
 basepython = python3.6
@@ -299,12 +300,12 @@ deps =
     {[base]deps}
 
 [testenv:py36-django2.0-es2.x]
-    basepython = python3.6
-    setenv = VERSION_ES=>=2.0.0,<3.0.0
-    deps =
-        {[es2.x]deps}
-        {[django2.0]deps}
-        {[base]deps}
+basepython = python3.6
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.0]deps}
+    {[base]deps}
 
 [testenv:docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ envlist = docs,
 [base]
 deps = requests
 
-[django1.10]
+[django2.0]
 deps =
     Django>=2.0,<2.1
 


### PR DESCRIPTION
Hi, 
this PR adds Django 2.0 compatibility. 
As the PR https://github.com/django-haystack/django-haystack/pull/1557 did not see any progress recently I implemented everything needed for Django 2.0 compatibility here.

In particular I rewrote the rebuild_index command to strip certain arguments that are not used in the clear_index and update_index commands respectively. This is implemented in a relatively adhoc way, however looking at the amount of changes made to rebuild_index in the past I figured this might be the easiest way to implement this change.

Additionally I added Django 2.0 to the tests and excluded the combination Django2.0 + Python2.7 from the test suite so that the tests still pass. Maybe one should also consider adding python 3.6 to the test suite, however I did not do that yet.

Also note the change I made to `test_haystack/solr_tests/test_solr_backend.py`. This was necessary due to the recent update in pysolr. That update broke the django-haystack tests, as `pysolr.__version__` is now a string instead of a tuple. The fix I implemented should be backwards compatible.

Please let me know if there is anything this MR needs to get merged, cheers,
Martin