### PR TITLE
Fixed index re-obtaining for every result entry field when searching by ElasticSearch backend

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -625,8 +625,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             model = haystack_get_model(app_label, model_name)
 
             if model and model in indexed_models:
+                index = source and unified_index.get_index(model)
                 for key, value in source.items():
-                    index = unified_index.get_index(model)
                     string_key = str(key)
 
                     if string_key in index.fields and hasattr(index.fields[string_key], 'convert'):


### PR DESCRIPTION
Looks like one line of code in elasticsearch `_process_results` is misplaced.
It results in obtaining index on every! field per each result entry. That's useless overhead anyway. Also it may work much slower if you have overridden .get_index in your custom UnifiedIndex