### PR TITLE
Fixed collection of deep attributes through m2m relation

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -112,7 +112,8 @@ class SearchField(object):
 
             if len(attributes) > 1:
                 current_objects_in_attr = self.get_iterable_objects(getattr(current_object, attributes[0]))
-                return self.resolve_attributes_lookup(current_objects_in_attr, attributes[1:])
+                values.extend(self.resolve_attributes_lookup(current_objects_in_attr, attributes[1:]))
+                continue
 
             current_object = getattr(current_object, attributes[0])
 

--- a/test_haystack/test_fields.py
+++ b/test_haystack/test_fields.py
@@ -85,6 +85,26 @@ class SearchFieldTestCase(TestCase):
 
         self.assertEqual([1, 1], field.resolve_attributes_lookup([obj], ['related', 'related', 'value']))
 
+    def test_resolve_attributes_lookup_with_deep_relationship_through_m2m(self):
+        # obj.related2m:
+        #   - related1
+        #        .deep1
+        #            .value = 1
+        #   - related2
+        #        .deep2
+        #            .value = 2
+        #   - related3
+        #        .deep3
+        #            .value = 3
+        values = [1, 2, 3]
+        deep1, deep2, deep3 = (Mock(spec=['value'], value=x) for x in values)
+        related1, related2, related3 = (Mock(spec=['related'], related=x) for x in (deep1, deep2, deep3))
+        m2m_rel = Mock(spec=['__iter__'], __iter__=lambda self: iter([related1, related2, related3]))
+        obj = Mock(spec=['related_m2m'], related_m2m=m2m_rel)
+        field = SearchField()
+        self.assertEqual(values, field.resolve_attributes_lookup([obj], ['related_m2m', 'related', 'value']))
+
+
     def test_prepare_with_null_django_onetomany_rel(self):
         left_model = OneToManyLeftSideModel.objects.create()
 


### PR DESCRIPTION
When model `A` has a Many-to-Many relation `B` which has another relation `C`, the `A` index field with `model_attr='b__c__some_attr'` works improperly - only first item is collected.

That's because in `resolve_attributes_lookup` there is a `return` for first object:

    for current_object in current_objects:
            # ...
            if len(attributes) > 1:
                return .... # resolved only for current_object

As result, further objects are not looked into.
