### PR TITLE
Update rebuild_index.py

### DIFF
--- a/haystack/management/commands/rebuild_index.py
+++ b/haystack/management/commands/rebuild_index.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
+from .update_index import DEFAULT_MAX_RETRIES
+
 
 class Command(BaseCommand):
     help = "Completely rebuilds the search index by removing the old data and then updating."
@@ -30,11 +32,16 @@ class Command(BaseCommand):
             '-b', '--batch-size', dest='batchsize', type=int,
             help='Number of items to index at once.'
         )
+        parser.add_argument(
+            '-t', '--max-retries', action='store', dest='max_retries',
+            type=int, default=DEFAULT_MAX_RETRIES,
+            help='Maximum number of attempts to write to the backend when an error occurs.'
+        )
 
     def handle(self, **options):
         clear_options = options.copy()
         update_options = options.copy()
-        for key in ('batchsize', 'workers'):
+        for key in ('batchsize', 'workers', 'max_retries'):
             del clear_options[key]
         for key in ('interactive', ):
             del update_options[key]


### PR DESCRIPTION
Add max-retries argument to rebuild_index managment command. This is useful for debug at development time

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.