### PR TITLE
Fix UnicodeDecodeError in error message

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -107,7 +107,7 @@ class SearchField(object):
         for current_object in current_objects:
             if not hasattr(current_object, attributes[0]):
                 raise SearchFieldError(
-                    "The model '%s' does not have a model_attr '%s'." % (repr(current_object), attributes[0])
+                    "The model '%r' does not have a model_attr '%s'." % (repr(current_object), attributes[0])
                 )
 
             if len(attributes) > 1:

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -12,6 +12,9 @@ from django.db import models
 class MockTag(models.Model):
     name = models.CharField(max_length=32)
 
+    def __unicode__(self):
+        return self.name
+
 
 class MockModel(models.Model):
     author = models.CharField(max_length=255)

--- a/test_haystack/test_fields.py
+++ b/test_haystack/test_fields.py
@@ -152,6 +152,16 @@ class CharFieldTestCase(TestCase):
 
         self.assertRaises(SearchFieldError, tag_slug.prepare, mock)
 
+        # Simulate failed lookups and ensure we don't get a UnicodeDecodeError
+        # in the error message.
+        mock_tag = MockTag.objects.create(name=u'básico')
+
+        mock = MockModel()
+        mock.tag = mock_tag
+        tag_slug = CharField(model_attr='tag__slug')
+
+        self.assertRaises(SearchFieldError, tag_slug.prepare, mock)
+
         # Simulate default='foo'.
         mock = MockModel()
         default = CharField(default='foo')


### PR DESCRIPTION
Because of the way the default `__repr__` works in Django models, we can get a
`UnicodeDecodeError` when creating the `SearchFieldError` if a model does not have
an attribute. eg:

`UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 11: ordinal not in range(128)`
and this hides the real problem.

I have left alone the other `SearchFieldError` in this method because current_obj is always
None. The error message is a bit strange in this case but it won't suffer from the same problem.