### PR TITLE
__len__() should return >= 0  error fixed

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -90,7 +90,7 @@ class SearchQuerySet(object):
                 self._result_count = 0
 
         # This needs to return the actual number of hits, not what's in the cache.
-        return self._result_count - self._ignored_result_count
+        return max([self._result_count - self._ignored_result_count, 0])
 
     def __iter__(self):
         if self._cache_is_full():


### PR DESCRIPTION
python2.7/site-packages/haystack/query.py” in count

522.         return len(self)
Exception Type: ValueError at /search/ Exception Value: __len__() should return >= 0 Request information: USER: AnonymousUser

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.