### PR TITLE
mv setup_requires to install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ except ImportError:
 
 install_requires = [
     'Django>=1.11',
+    'setuptools_scm',
 ]
 
 tests_require = [
@@ -68,5 +69,4 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     test_suite="test_haystack.run_tests.run_all",
-    setup_requires=['setuptools_scm'],
 )


### PR DESCRIPTION
according to this [issue](https://github.com/pypa/pip/issues/4880) and this [one](https://github.com/django-haystack/django-haystack/issues/1571),  when install pypi with my custom pypi, it will raise DistutilsError, because my server can't access https://pypi.org/simple/,  because setuptools uses it's own logic to find the distributions mentioned in setup_requires. And, that logic is unable to fetch the distribution. so I move it to  install_requires.