### PR TITLE
Edited docs for Solr 6.X

### DIFF
--- a/docs/installing_search_engines.rst
+++ b/docs/installing_search_engines.rst
@@ -17,9 +17,11 @@ Solr 4.x+ with a little effort. Installation is relatively simple:
 For Solr 6.X::
 
     curl -LO https://archive.apache.org/dist/lucene/solr/x.Y.0/solr-X.Y.0.tgz
+    mkdir solr
     tar -C solr -xf solr-X.Y.0.tgz --strip-components=1
     cd solr
-    ./bin/solr create -c tester -n basic_config
+    ./bin/solr start                                    # start solr
+    ./bin/solr create -c tester -n basic_config         # create core named 'tester'
 
 By default this will create a core with a managed schema.  This setup is dynamic
 but not useful for haystack, and we'll need to configure solr to use a static

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -112,7 +112,7 @@ the following:
 Solr
 ~~~~
 
-Example::
+Example (Solr 4.X)::
 
     HAYSTACK_CONNECTIONS = {
         'default': {
@@ -123,6 +123,17 @@ Example::
         },
     }
 
+Example (Solr 6.X)::
+
+    HAYSTACK_CONNECTIONS = {
+        'default': {
+            'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
+            'URL': 'http://127.0.0.1:8983/solr/tester',                 # Assuming you created a core named 'tester' as described in installing search engines.
+            'ADMIN_URL': 'http://127.0.0.1:8983/solr/admin/cores'
+            # ...or for multicore...
+            # 'URL': 'http://127.0.0.1:8983/solr/mysite',
+        },
+    }
 
 Elasticsearch
 ~~~~~~~~~~~~~
@@ -146,6 +157,7 @@ Example (ElasticSearch 2.x)::
             'INDEX_NAME': 'haystack',
         },
     }
+
 
 Whoosh
 ~~~~~~


### PR DESCRIPTION
Added example settings for Solr 6.X in tutorial.rst.

The url setting has to include the core, at least in my setup, otherwise:
`pysolr.SolrError: Solr responded with an error (HTTP 404) `

I think that the change occurred since Solr 5.X but I'm unsure, see https://stackoverflow.com/questions/29361639/django-haystack-failed-to-add-documents-to-solr-reason-error-404-not-found

I must say that the docs explaining the old Solr 4.X installation were a lot smoother experience for me. The lines `./manage.py build_solr_schema --configure-directory=<CoreConfigDif> --reload-core` didn't work for me, resulting in
`manage.py build_solr_schema: error: argument -r/--reload-core: expected one argument`

I had to run `./manage.py build_solr_schema --configure-directory=<CoreConfigDif>` and reload core and restart solr separately. If others are reporting the same problems, I suggest changing the docs. 

Also, I think that the Solr 4.X way of creating the schema.xml and solrconfig.xml locally and then moving them was easier to explain and its also safer to save a copy of these files in your project. Users that are using the `more like this` or `spelling suggestions` will also need to edit these files, so again, I think it's better that the the installing_search_engines.rst won't use `configure-directory`.

Setup: 
django-haystack 2.8.1
django 2.0.4
solr: 6.6.3
debian 9