### PR TITLE
Construct django_ct based on model instead of object

### DIFF
--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -189,7 +189,7 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
         """
         self.prepared_data = {
             ID: get_identifier(obj),
-            DJANGO_CT: get_model_ct(obj),
+            DJANGO_CT: get_model_ct(self.get_model()),
             DJANGO_ID: force_text(obj.pk),
         }
 

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -28,12 +28,14 @@ class MockModel(models.Model):
     def hello(self):
         return 'World!'
 
+
 class UUIDMockModel(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     characteristics = models.TextField()
 
     def __unicode__(self):
         return str(self.id)
+
 
 class AnotherMockModel(models.Model):
     author = models.CharField(max_length=255)


### PR DESCRIPTION
This solves issue #1611 - delete stale polymorphic model documents.

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.