### PR TITLE
Order queryset by pk in update batching

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -66,7 +66,8 @@ def do_update(backend, index, qs, start, end, total, verbosity=1, commit=True,
 
     # Get a clone of the QuerySet so that the cache doesn't bloat up
     # in memory. Useful when reindexing large amounts of data.
-    small_cache_qs = qs.all()
+    # the query must be ordered by PK in order to get the max PK in each batch
+    small_cache_qs = qs.all().order_by('pk')
 
     # If we got the max seen PK from last batch, use it to restrict the qs
     # to values above; this optimises the query for Postgres as not to


### PR DESCRIPTION
This solves #1615

The queryset is not ordered by pk by default, however the batching filter relies on the results being ordered.
When the results are not ordered by pk, some objects are not indexed.
This can happen when the underlying database doesn't have default ordering by pk, or when the model or index_queryset() have a different ordering.

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.