### PR TITLE
Add Elasticsearch example for adjusting highlight tags.

### DIFF
--- a/docs/searchqueryset_api.rst
+++ b/docs/searchqueryset_api.rst
@@ -252,6 +252,14 @@ instead of normal keyword arguments::
     result = sqs[0]
     result.highlighted['other_field'][0] # u'Two computer scientists walk into a bar. The bartender says "<span class="highlighted">Foo</span>!".'
 
+Elasticsearch accepts keyword arguments::
+
+    # Use the ``pre_tag`` and ``post_tag`` keywords and pass the desired tags as lists.
+    sqs = SearchQuerySet().filter(content='foo').highlight(
+        pre_tags=['<strong>'], post_tags=['</strong>'])
+    result_example = " ".join(sqs[0].highlighted)
+    # u'Two <strong>foo</strong> computer scientists walk into a bar. The bartender says "<strong>Foo</strong>!"'
+
 ``models``
 ~~~~~~~~~~
 


### PR DESCRIPTION
The docs give an example for Solr but not for Elasticsearch, and they differ.

This addresses Issue #1627 

