### PR TITLE
Defined new way to override standard field type for string

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -656,9 +656,14 @@ class SolrSearchBackend(BaseSearchBackend):
         schema_fields = []
 
         for field_name, field_class in fields.items():
+            # check field_type_raw to allow specification of custom string fields (not-standard tokenization, stemming etc)
+            if hasattr(field_class, 'field_type_raw'):
+                field_type = field_class.field_type_raw
+            else:
+                field_type = 'text_en'
             field_data = {
                 "field_name": field_class.index_fieldname,
-                "type": "text_en",
+                "type": field_type,
                 "indexed": "true",
                 "stored": "true",
                 "multi_valued": "false",


### PR DESCRIPTION
Only english fields were allowed by default, it is now possible to define a custom string field to use not standard tokenization.
A new class can be specified which inherit from CharField and define a new class field field_type_raw with the required field type.

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.