### PR TITLE
Enable whoosh fuzzy search

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -966,7 +966,7 @@ class WhooshSearchQuery(BaseSearchQuery):
             "gte": "[%s to]",
             "lt": "{to %s}",
             "lte": "[to %s]",
-            'fuzzy': "%s~{}/{}".format(FUZZY_WHOOSH_MAX_EDITS, FUZZY_WHOOSH_MIN_PREFIX),
+            "fuzzy": "%s~{}/%d".format(FUZZY_WHOOSH_MAX_EDITS),
         }
 
         if value.post_process is False:
@@ -994,10 +994,23 @@ class WhooshSearchQuery(BaseSearchQuery):
                         possible_values = [prepared_value]
 
                     for possible_value in possible_values:
-                        terms.append(
-                            filter_types[filter_type]
-                            % self.backend._from_python(possible_value)
+                        possible_value_str = self.backend._from_python(
+                            possible_value
                         )
+                        if filter_type == "fuzzy":
+                            terms.append(
+                                filter_types[filter_type] % (
+                                    possible_value_str,
+                                    min(
+                                        FUZZY_WHOOSH_MIN_PREFIX,
+                                        len(possible_value_str)
+                                    )
+                                )
+                            )
+                        else:
+                            terms.append(
+                                filter_types[filter_type] % possible_value_str
+                            )
 
                     if len(terms) == 1:
                         query_frag = terms[0]

--- a/haystack/constants.py
+++ b/haystack/constants.py
@@ -20,6 +20,10 @@ FUZZINESS = getattr(settings, "HAYSTACK_FUZZINESS", "AUTO")
 FUZZY_MIN_SIM = getattr(settings, "HAYSTACK_FUZZY_MIN_SIM", 0.5)
 FUZZY_MAX_EXPANSIONS = getattr(settings, "HAYSTACK_FUZZY_MAX_EXPANSIONS", 50)
 
+# Default values on whoosh
+FUZZY_WHOOSH_MIN_PREFIX = getattr(settings, 'HAYSTACK_FUZZY_WHOOSH_MIN_PREFIX', 3)
+FUZZY_WHOOSH_MAX_EDITS = getattr(settings, 'HAYSTACK_FUZZY_WHOOSH_MAX_EDITS', 2)
+
 # Valid expression extensions.
 VALID_FILTERS = set(
     [

--- a/test_haystack/whoosh_tests/test_whoosh_query.py
+++ b/test_haystack/whoosh_tests/test_whoosh_query.py
@@ -115,7 +115,7 @@ class WhooshSearchQueryTestCase(WhooshTestCase):
     def test_build_query_fuzzy_filter_types(self):
         self.sq.add_filter(SQ(content="why"))
         self.sq.add_filter(SQ(title__fuzzy="haystack"))
-        self.assertEqual(self.sq.build_query(), "((why) AND title:(haystack~))")
+        self.assertEqual(self.sq.build_query(), "((why) AND title:(haystack~2/3))")
 
     def test_build_query_with_contains(self):
         self.sq.add_filter(SQ(content="circular"))


### PR DESCRIPTION
Except for including the fuzzy search plugin, I've added also extra options for the search.

Caveat: the fuzzy search will still not work for n-gram fields, because of bug in the whoosh package (`FuzzyTerm` is not taken into account when parsing query; `Term` is used instead); see: https://github.com/mchaput/whoosh/pull/7 .