### PR TITLE
Add support for custom field types w/ Solr backend

### DIFF
--- a/docs/searchindex_api.rst
+++ b/docs/searchindex_api.rst
@@ -148,6 +148,21 @@ And finally, in ``search/search.html``::
     {% endfor %}
 
 
+Custom field types
+==================
+
+For some use-cases it may be necessary to use other pre-defined field-types or 
+even custom field-types, e.g. `text_general`. Therefor you must derive a custom
+type which defines a method `get_field_type` which returns the name of the 
+field-type you want to use.
+
+Within ``myapp/search_indexes.py``::
+
+    class TextGeneralField(CharField):
+        def get_field_type(self):
+            return 'text_general'
+
+
 Keeping The Index Fresh
 =======================
 

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -544,23 +544,23 @@ class SolrSearchBackend(BaseSearchBackend):
             if field_class.document is True:
                 content_field_name = field_class.index_fieldname
 
-            # DRL_FIXME: Perhaps move to something where, if none of these
-            #            checks succeed, call a custom method on the form that
-            #            returns, per-backend, the right type of storage?
-            if field_class.field_type in ['date', 'datetime']:
-                field_data['type'] = 'date'
-            elif field_class.field_type == 'integer':
-                field_data['type'] = 'long'
-            elif field_class.field_type == 'float':
-                field_data['type'] = 'float'
-            elif field_class.field_type == 'boolean':
-                field_data['type'] = 'boolean'
-            elif field_class.field_type == 'ngram':
-                field_data['type'] = 'ngram'
-            elif field_class.field_type == 'edge_ngram':
-                field_data['type'] = 'edge_ngram'
-            elif field_class.field_type == 'location':
-                field_data['type'] = 'location'
+            try:
+                field_data['type'] = field_class.get_field_type()
+            except AttributeError:
+                if field_class.field_type in ['date', 'datetime']:
+                    field_data['type'] = 'date'
+                elif field_class.field_type == 'integer':
+                    field_data['type'] = 'long'
+                elif field_class.field_type == 'float':
+                    field_data['type'] = 'float'
+                elif field_class.field_type == 'boolean':
+                    field_data['type'] = 'boolean'
+                elif field_class.field_type == 'ngram':
+                    field_data['type'] = 'ngram'
+                elif field_class.field_type == 'edge_ngram':
+                    field_data['type'] = 'edge_ngram'
+                elif field_class.field_type == 'location':
+                    field_data['type'] = 'location'
 
             if field_class.is_multivalued:
                 field_data['multi_valued'] = 'true'


### PR DESCRIPTION
The Solr backend supported only `text_en` for `CharField` which is not appropriate for some use-cases. There you can now derive a custom Field with a get_field_type method which delivery the required field-type.