### PR TITLE
Move import into function to avoid GDAL as a global dependency

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import re
 from inspect import ismethod
 
-from django.contrib.gis.geos import Point
 from django.template import loader
 from django.utils import datetime_safe, six
 
@@ -260,6 +259,7 @@ class LocationField(SearchField):
         return "%s,%s" % (pnt_lat, pnt_lng)
 
     def convert(self, value):
+        from django.contrib.gis.geos import Point
         from haystack.utils.geo import ensure_point
 
         if value is None:

--- a/test_haystack/elasticsearch2_tests/test_backend.py
+++ b/test_haystack/elasticsearch2_tests/test_backend.py
@@ -10,7 +10,6 @@ from decimal import Decimal
 import elasticsearch
 from django.apps import apps
 from django.conf import settings
-from django.contrib.gis.geos import Point
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -582,6 +581,7 @@ class Elasticsearch2SearchBackendTestCase(TestCase):
         settings.HAYSTACK_LIMIT_TO_REGISTERED_MODELS = old_limit_to_registered_models
 
     def test_spatial_search_parameters(self):
+        from django.contrib.gis.geos import Point
         p1 = Point(1.23, 4.56)
         kwargs = self.sb.build_search_kwargs(
             "*:*",

--- a/test_haystack/elasticsearch2_tests/test_query.py
+++ b/test_haystack/elasticsearch2_tests/test_query.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 
 import elasticsearch
-from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.test import TestCase
 
@@ -140,7 +139,7 @@ class Elasticsearch2SearchQueryTestCase(TestCase):
         self.assertEqual(self.sq.clean("hello AND world"), "hello and world")
         self.assertEqual(
             self.sq.clean(
-                'hello AND OR NOT TO + - && || ! ( ) { } [ ] ^ " ~ * ? : \ / world'
+                r'hello AND OR NOT TO + - && || ! ( ) { } [ ] ^ " ~ * ? : \ / world'
             ),
             'hello and or not to \\+ \\- \\&& \\|| \\! \\( \\) \\{ \\} \\[ \\] \\^ \\" \\~ \\* \\? \\: \\\\ \\/ world',
         )
@@ -198,6 +197,8 @@ class Elasticsearch2SearchQuerySpatialBeforeReleaseTestCase(TestCase):
         """
         Test build_search_kwargs with dwithin range for Elasticsearch versions < 1.0.0
         """
+        from django.contrib.gis.geos import Point
+
         search_kwargs = self.backend.build_search_kwargs(
             "where",
             dwithin={
@@ -228,6 +229,8 @@ class Elasticsearch2SearchQuerySpatialAfterReleaseTestCase(TestCase):
         """
         Test build_search_kwargs with dwithin range for Elasticsearch versions >= 1.0.0
         """
+        from django.contrib.gis.geos import Point
+
         search_kwargs = self.backend.build_search_kwargs(
             "where",
             dwithin={

--- a/test_haystack/elasticsearch5_tests/test_backend.py
+++ b/test_haystack/elasticsearch5_tests/test_backend.py
@@ -10,7 +10,6 @@ from decimal import Decimal
 import elasticsearch
 from django.apps import apps
 from django.conf import settings
-from django.contrib.gis.geos import Point
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -582,6 +581,8 @@ class Elasticsearch5SearchBackendTestCase(TestCase):
         settings.HAYSTACK_LIMIT_TO_REGISTERED_MODELS = old_limit_to_registered_models
 
     def test_spatial_search_parameters(self):
+        from django.contrib.gis.geos import Point
+
         p1 = Point(1.23, 4.56)
         kwargs = self.sb.build_search_kwargs(
             "*:*",

--- a/test_haystack/elasticsearch5_tests/test_query.py
+++ b/test_haystack/elasticsearch5_tests/test_query.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import datetime
 
-import elasticsearch
-from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.test import TestCase
 
@@ -140,7 +138,7 @@ class Elasticsearch5SearchQueryTestCase(TestCase):
         self.assertEqual(self.sq.clean("hello AND world"), "hello and world")
         self.assertEqual(
             self.sq.clean(
-                'hello AND OR NOT TO + - && || ! ( ) { } [ ] ^ " ~ * ? : \ / world'
+                r'hello AND OR NOT TO + - && || ! ( ) { } [ ] ^ " ~ * ? : \ / world'
             ),
             'hello and or not to \\+ \\- \\&& \\|| \\! \\( \\) \\{ \\} \\[ \\] \\^ \\" \\~ \\* \\? \\: \\\\ \\/ world',
         )
@@ -184,6 +182,8 @@ class Elasticsearch5SearchQueryTestCase(TestCase):
         self.assertEqual(sqs.query.narrow_queries.pop(), "foo:(moof)")
 
     def test_build_query_with_dwithin_range(self):
+        from django.contrib.gis.geos import Point
+
         backend = connections["elasticsearch"].get_backend()
         search_kwargs = backend.build_search_kwargs(
             "where",

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -11,7 +11,6 @@ from decimal import Decimal
 import elasticsearch
 from django.apps import apps
 from django.conf import settings
-from django.contrib.gis.geos import Point
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -622,6 +621,8 @@ class ElasticsearchSearchBackendTestCase(TestCase):
         settings.HAYSTACK_LIMIT_TO_REGISTERED_MODELS = old_limit_to_registered_models
 
     def test_spatial_search_parameters(self):
+        from django.contrib.gis.geos import Point
+
         p1 = Point(1.23, 4.56)
         kwargs = self.sb.build_search_kwargs(
             "*:*",

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 
 import elasticsearch
-from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.test import TestCase
 
@@ -153,7 +152,7 @@ class ElasticsearchSearchQueryTestCase(TestCase):
         self.assertEqual(self.sq.clean("hello AND world"), "hello and world")
         self.assertEqual(
             self.sq.clean(
-                'hello AND OR NOT TO + - && || ! ( ) { } [ ] ^ " ~ * ? : \ / world'
+                r'hello AND OR NOT TO + - && || ! ( ) { } [ ] ^ " ~ * ? : \ / world'
             ),
             'hello and or not to \\+ \\- \\&& \\|| \\! \\( \\) \\{ \\} \\[ \\] \\^ \\" \\~ \\* \\? \\: \\\\ \\/ world',
         )
@@ -220,6 +219,8 @@ class ElasticsearchSearchQuerySpatialBeforeReleaseTestCase(TestCase):
         """
         Test build_search_kwargs with dwithin range for Elasticsearch versions < 1.0.0
         """
+        from django.contrib.gis.geos import Point
+
         search_kwargs = self.backend.build_search_kwargs(
             "where",
             dwithin={
@@ -250,6 +251,8 @@ class ElasticsearchSearchQuerySpatialAfterReleaseTestCase(TestCase):
         """
         Test build_search_kwargs with dwithin range for Elasticsearch versions >= 1.0.0
         """
+        from django.contrib.gis.geos import Point
+
         search_kwargs = self.backend.build_search_kwargs(
             "where",
             dwithin={

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 
 import pysolr
 from django.conf import settings
-from django.contrib.gis.geos import Point
 from django.test import TestCase
 from django.test.utils import override_settings
 from mock import patch
@@ -561,6 +560,8 @@ class SolrSearchBackendTestCase(TestCase):
         )
 
     def test_spatial_search_parameters(self):
+        from django.contrib.gis.geos import Point
+
         p1 = Point(1.23, 4.56)
         kwargs = self.sb.build_search_kwargs(
             "*:*",

--- a/test_haystack/spatial/test_spatial.py
+++ b/test_haystack/spatial/test_spatial.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from django.contrib.gis.geos import GEOSGeometry, Point
 from django.contrib.gis.measure import D
 from django.test import TestCase
 
@@ -22,6 +21,8 @@ from .models import Checkin
 
 class SpatialUtilitiesTestCase(TestCase):
     def test_ensure_geometry(self):
+        from django.contrib.gis.geos import GEOSGeometry, Point
+
         self.assertRaises(
             SpatialError, ensure_geometry, [38.97127105172941, -95.23592948913574]
         )
@@ -30,6 +31,8 @@ class SpatialUtilitiesTestCase(TestCase):
         ensure_geometry(Point(-95.23592948913574, 38.97127105172941))
 
     def test_ensure_point(self):
+        from django.contrib.gis.geos import GEOSGeometry, Point
+
         self.assertRaises(
             SpatialError, ensure_point, [38.97127105172941, -95.23592948913574]
         )
@@ -41,6 +44,8 @@ class SpatialUtilitiesTestCase(TestCase):
         ensure_point(Point(-95.23592948913574, 38.97127105172941))
 
     def test_ensure_wgs84(self):
+        from django.contrib.gis.geos import GEOSGeometry, Point
+
         self.assertRaises(
             SpatialError,
             ensure_wgs84,
@@ -70,6 +75,8 @@ class SpatialUtilitiesTestCase(TestCase):
         ensure_distance(D(mi=5))
 
     def test_generate_bounding_box(self):
+        from django.contrib.gis.geos import Point
+
         downtown_bottom_left = Point(-95.23947, 38.9637903)
         downtown_top_right = Point(-95.23362278938293, 38.973081081164715)
         ((min_lat, min_lng), (max_lat, max_lng)) = generate_bounding_box(
@@ -81,6 +88,8 @@ class SpatialUtilitiesTestCase(TestCase):
         self.assertEqual(max_lng, -95.23362278938293)
 
     def test_generate_bounding_box_crossing_line_date(self):
+        from django.contrib.gis.geos import Point
+
         downtown_bottom_left = Point(95.23947, 38.9637903)
         downtown_top_right = Point(-95.23362278938293, 38.973081081164715)
         ((south, west), (north, east)) = generate_bounding_box(
@@ -97,6 +106,8 @@ class SpatialSolrTestCase(TestCase):
     using = "solr"
 
     def setUp(self):
+        from django.contrib.gis.geos import Point
+
         super(SpatialSolrTestCase, self).setUp()
         self.ui = connections[self.using].get_unified_index()
         self.checkindex = self.ui.get_index(Checkin)

--- a/test_haystack/test_managers.py
+++ b/test_haystack/test_managers.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import datetime
 
-from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.test import TestCase
 from test_haystack.core.models import MockModel
@@ -86,6 +85,8 @@ class ManagerTestCase(TestCase):
         self.assertTrue("foo" in sqs.query.order_by)
 
     def test_order_by_distance(self):
+        from django.contrib.gis.geos import Point
+
         p = Point(1.23, 4.56)
         sqs = self.search_index.objects.distance("location", p).order_by("distance")
         self.assertTrue(isinstance(sqs, SearchQuerySet))
@@ -115,6 +116,8 @@ class ManagerTestCase(TestCase):
         self.assertEqual(len(sqs.query.facets), 1)
 
     def test_within(self):
+        from django.contrib.gis.geos import Point
+
         # This is a meaningless query but we're just confirming that the manager updates the parameters here:
         p1 = Point(-90, -90)
         p2 = Point(90, 90)
@@ -129,6 +132,8 @@ class ManagerTestCase(TestCase):
         )
 
     def test_dwithin(self):
+        from django.contrib.gis.geos import Point
+
         p = Point(0, 0)
         distance = D(mi=500)
         sqs = self.search_index.objects.dwithin("location", p, distance)
@@ -142,6 +147,8 @@ class ManagerTestCase(TestCase):
         )
 
     def test_distance(self):
+        from django.contrib.gis.geos import Point
+
         p = Point(0, 0)
         sqs = self.search_index.objects.distance("location", p)
         self.assertTrue(isinstance(sqs, SearchQuerySet))


### PR DESCRIPTION
Hi, 
this should fix #1631 - The problem arises because in commit 39c2adcd720485410c289601d696473027539358 an import was moved from within a function to the top level in `haystack/fields.py`. The import references `django.contrib.gis.geos`. That import in turn causes a lot of other imports that end in a call to GDAL. This call fails if GDAL is not installed. The fix is simple: Just move the import back to the function. The fix is tested in one of our installations (without GDAL).
Cheers,
Martin