### PR TITLE
Add testing for Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 python:
     - 2.7
     - 3.4
     - 3.5
     - 3.6
-    - pypy
+    - pypy2.7-6.0
 
 cache:
     apt: true
@@ -17,17 +17,17 @@ cache:
 addons:
     apt_packages:
         - binutils
-        - default-jdk
+        - openjdk-8-jdk
         - gdal-bin
-        - libgdal1h
-        - libgeos-c1
+        - libgdal1i
+        - libgeos-c1v5
         - libproj-dev
-        - libxapian22
+        - libxapian22v5
         - python-xapian
         - wajig
 
 before_install:
-    - sudo apt-get install -qy default-jre
+    - sudo apt-get install -qy openjdk-8-jre
     - mkdir -p $HOME/download-cache
     # See https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html#deb-repo
     - wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
@@ -56,6 +56,8 @@ install:
     - python setup.py clean build install
 
 before_script:
+     # Solr < 7.3 doesn't detect Java 10 or later and says "Java is too old".
+    - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     - BACKGROUND_SOLR=true test_haystack/solr_tests/server/start-solr-test-server.sh
 
 script:
@@ -78,7 +80,7 @@ env:
         - DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=5.0.0,<6.0.0"
 matrix:
     allow_failures:
-        - python: 'pypy'
+        - python: 'pypy2.7-6.0'
     exclude:
         - python: 2.7
           env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=5.0.0,<6.0.0"
@@ -98,17 +100,17 @@ matrix:
           env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=2.0.0,<3.0.0"
         - python: 3.4
           env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=1.0.0,<2.0.0"
-        - python: pypy
+        - python: pypy2.7-6.0
           env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=5.0.0,<6.0.0"
-        - python: pypy
+        - python: pypy2.7-6.0
           env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
-        - python: pypy
+        - python: pypy2.7-6.0
           env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=1.0.0,<2.0.0"
-        - python: pypy
+        - python: pypy2.7-6.0
           env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=5.0.0,<6.0.0"
-        - python: pypy
+        - python: pypy2.7-6.0
           env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=2.0.0,<3.0.0"
-        - python: pypy
+        - python: pypy2.7-6.0
           env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=1.0.0,<2.0.0"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,12 +72,15 @@ env:
         - DJANGO_VERSION=">=1.11,<2.0" VERSION_ES=">=1.0.0,<2.0.0"
         - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=1.0.0,<2.0.0"
         - DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=1.0.0,<2.0.0"
+        - DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=1.0.0,<2.0.0"
         - DJANGO_VERSION=">=1.11,<2.0" VERSION_ES=">=2.0.0,<3.0.0"
         - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
         - DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=2.0.0,<3.0.0"
+        - DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=2.0.0,<3.0.0"
         - DJANGO_VERSION=">=1.11,<2.0" VERSION_ES=">=5.0.0,<6.0.0"
         - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=5.0.0,<6.0.0"
         - DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=5.0.0,<6.0.0"
+        - DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=5.0.0,<6.0.0"
 matrix:
     allow_failures:
         - python: 'pypy2.7-6.0'
@@ -100,6 +103,18 @@ matrix:
           env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=2.0.0,<3.0.0"
         - python: 3.4
           env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=1.0.0,<2.0.0"
+        - python: 2.7
+          env: DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=5.0.0,<6.0.0"
+        - python: 2.7
+          env: DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=2.0.0,<3.0.0"
+        - python: 2.7
+          env: DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=1.0.0,<2.0.0"
+        - python: 3.4
+          env: DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=5.0.0,<6.0.0"
+        - python: 3.4
+          env: DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=2.0.0,<3.0.0"
+        - python: 3.4
+          env: DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=1.0.0,<2.0.0"
         - python: pypy2.7-6.0
           env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=5.0.0,<6.0.0"
         - python: pypy2.7-6.0
@@ -112,6 +127,12 @@ matrix:
           env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=2.0.0,<3.0.0"
         - python: pypy2.7-6.0
           env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=1.0.0,<2.0.0"
+        - python: pypy2.7-6.0
+          env: DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=5.0.0,<6.0.0"
+        - python: pypy2.7-6.0
+          env: DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=2.0.0,<3.0.0"
+        - python: pypy2.7-6.0
+          env: DJANGO_VERSION=">=2.2a1,<3.0" VERSION_ES=">=1.0.0,<2.0.0"
 
 notifications:
     irc: 'irc.freenode.org#haystack'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -93,7 +93,7 @@ Changelog
 
   Add max-retries argument to rebuild_index managment command. This is useful for debug at development time
 
-  Add Django 2.1 compatibility. [Tim Graham]
+  Add Django 2.1 and 2.2 compatibility. [Tim Graham]
 
 
 v2.8.1 (2018-03-16)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/test_haystack/settings.py
+++ b/test_haystack/settings.py
@@ -16,6 +16,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.messages",
     "django.contrib.sessions",
     "haystack",
     "test_haystack.discovery",
@@ -36,7 +37,10 @@ TEMPLATES = [
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "APP_DIRS": True,
         "OPTIONS": {
-            "context_processors": ["django.contrib.auth.context_processors.auth"]
+            "context_processors": [
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ]
         },
     }
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist = docs,
         py35-django1.11-es1.x,
         py35-django2.0-es1.x,
         py35-django2.1-es1.x,
+        py35-django2.2-es1.x,
         pypy-django1.11-es1.x,
         py27-django1.11-es2.x,
         py34-django1.11-es2.x,
@@ -13,18 +14,24 @@ envlist = docs,
         py35-django1.11-es2.x,
         py35-django2.0-es2.x,
         py35-django2.1-es2.x,
+        py35-django2.2-es2.x,
         py36-django1.11-es2.x,
         py36-django2.0-es2.x,
         py36-django2.1-es2.x,
+        py36-django2.2-es2.x,
         pypy-django1.11-es2.x,
         py27-django1.11-es5.x,
         py36-django1.11-es5.x,
         py36-django2.0-es5.x,
         py36-django2.1-es5.x,
+        py36-django2.2-es5.x,
         pypy-django1.11-es5.x,
 
 [base]
 deps = requests
+
+[django2.2]
+deps = Django>=2.2a1,<3.0
 
 [django2.1]
 deps = Django>=2.1,<2.2
@@ -107,6 +114,14 @@ deps =
     {[django2.1]deps}
     {[base]deps}
 
+[testenv:py35-django2.2-es1.x]
+basepython = python3.5
+setenv = VERSION_ES=>=1.0.0,<2.0.0
+deps =
+    {[es1.x]deps}
+    {[django2.2]deps}
+    {[base]deps}
+
 [testenv:pypy-django1.11-es2.x]
 setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
@@ -162,6 +177,14 @@ deps =
     {[django2.1]deps}
     {[base]deps}
 
+[testenv:py35-django2.2-es2.x]
+basepython = python3.5
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.2]deps}
+    {[base]deps}
+
 [testenv:py36-django1.11-es2.x]
 basepython = python3.6
 setenv = VERSION_ES=>=2.0.0,<3.0.0
@@ -184,6 +207,14 @@ setenv = VERSION_ES=>=2.0.0,<3.0.0
 deps =
     {[es2.x]deps}
     {[django2.1]deps}
+    {[base]deps}
+
+[testenv:py36-django2.2-es2.x]
+basepython = python3.6
+setenv = VERSION_ES=>=2.0.0,<3.0.0
+deps =
+    {[es2.x]deps}
+    {[django2.2]deps}
     {[base]deps}
 
 [testenv:pypy-django1.11-es5.x]
@@ -223,6 +254,14 @@ setenv = VERSION_ES=>=5.0.0,<6.0.0
 deps =
     {[es5.x]deps}
     {[django2.1]deps}
+    {[base]deps}
+
+[testenv:py36-django2.2-es5.x]
+basepython = python3.6
+setenv = VERSION_ES=>=5.0.0,<6.0.0
+deps =
+    {[es5.x]deps}
+    {[django2.2]deps}
     {[base]deps}
 
 [testenv:docs]


### PR DESCRIPTION
Django 2.2 drops support for GDAL 1.9 and 1.10 so the trusty travis builder is too old.

This is working except for some regressions with pypy (build is marked allowed failure, however). Tests run but some fail with contrib.gis import failures.