### PR TITLE
Use `iter()` to check for iterability

### DIFF
--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -180,7 +180,9 @@ class SearchField(object):
                 return current_objects.all()
             return []
 
-        elif not hasattr(current_objects, "__iter__"):
+        try:
+            iter(current_objects)
+        except TypeError:
             current_objects = [current_objects]
 
         return current_objects


### PR DESCRIPTION
instead of checking for an `__iter__` attribute, which Django 1.9+ includes in `LazyObject`s that are not necessarily iterable. Fixes #1662.