### PR TITLE
Added EnergySage

### DIFF
--- a/docs/who_uses.rst
+++ b/docs/who_uses.rst
@@ -365,3 +365,15 @@ provide search across users and lessons.
 Using: Solr
 
 * http://www.educreations.com/browse/
+
+
+EnergySage
+----------
+
+EnergySage is an unbiased solar matchmaker,
+connecting homeowners with a network of pre-screened solar installers.
+
+Using: Solr
+
+* https://www.energysage.com/supplier/search
+


### PR DESCRIPTION
Adding EnergySage which has been using django+haystack+solar since 2012 to power the supplier search feature.

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.