### PR TITLE
Added a fix for 'update_index --remove' to consider custom search index IDs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,3 +118,4 @@ Thanks to
     * João Junior (@joaojunior) and Bruno Marques (@ElSaico) for Elasticsearch 2.x support
     * Alex Tomkins (@tomkins) for various patches
     * Martin Pauly (@mpauly) for Django 2.0 support
+    * Jeremy Wandui (@butteredtoast) for a patch fixing ``update_index --remove`` ignoring custom index IDs

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -12,6 +12,7 @@ from django.db import close_old_connections, reset_queries
 from django.utils.encoding import force_text, smart_bytes
 from django.utils.timezone import now
 
+from haystack.constants import ID
 from haystack import connections as haystack_connections
 from haystack.exceptions import NotHandled
 from haystack.query import SearchQuerySet
@@ -387,7 +388,7 @@ class Command(BaseCommand):
                 # full list obtained from the database, and the id field, which will be used to delete the
                 # record should it be found to be stale.
                 index_pks = SearchQuerySet(using=backend.connection_alias).models(model)
-                index_pks = index_pks.values_list("pk", "id")
+                index_pks = index_pks.values_list("pk", ID)
 
                 # We'll collect all of the record IDs which are no longer present in the database and delete
                 # them after walking the entire index. This uses more memory than the incremental approach but


### PR DESCRIPTION
`django-haystack` provides a custom setting `HAYSTACK_ID_FIELD` that allows you to control what the unique field name used internally by Haystack is called. Its default is `id`. However `update_index --remove` presumes that the id field being used is `id`, when retrieving values from the search index. In the case where a custom ID field is being used, this leads to the following error:

```
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/etc/cravus/env/lib/python3.4/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/etc/cravus/env/lib/python3.4/site-packages/django/core/management/__init__.py", line 345, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/etc/cravus/env/lib/python3.4/site-packages/django/core/management/base.py", line 348, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/etc/cravus/env/lib/python3.4/site-packages/django/core/management/base.py", line 399, in execute
    output = self.handle(*args, **options)
  File "/etc/cravus/env/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 183, in handle
    return super(Command, self).handle(*items, **options)
  File "/etc/cravus/env/lib/python3.4/site-packages/django/core/management/base.py", line 548, in handle
    label_output = self.handle_label(label, **options)
  File "/etc/cravus/env/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 188, in handle_label
    self.update_backend(label, using)
  File "/etc/cravus/env/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 289, in update_backend
    backend.remove(rec_id, commit=self.commit)
  File "/etc/cravus/env/lib/python3.4/site-packages/haystack/backends/elasticsearch_backend.py", line 196, in remove
    doc_id = get_identifier(obj_or_string)
  File "/etc/cravus/env/lib/python3.4/site-packages/haystack/utils/__init__.py", line 37, in default_get_identifier
    return u"%s.%s" % (get_model_ct(obj_or_string), obj_or_string._get_pk_val())
  File "/etc/cravus/env/lib/python3.4/site-packages/haystack/utils/__init__.py", line 80, in get_model_ct
    return "%s.%s" % get_model_ct_tuple(model)
  File "/etc/cravus/env/lib/python3.4/site-packages/haystack/utils/__init__.py", line 74, in get_model_ct_tuple
    return (model._meta.app_label, model._meta.model_name)
AttributeError: 'int' object has no attribute '_meta'
```

To correct this, this PR modifies the `update_index` code to  use the `HAYSTACK_ID_FIELD` when retrieving the values from the search index. It fixes issues https://github.com/django-haystack/django-haystack/issues/1323 and https://github.com/django-haystack/django-haystack/issues/1667