### PR TITLE
Replace type:'string' with type'text' for elasticsearch 5 compaitbility.

### DIFF
--- a/haystack/backends/elasticsearch5_backend.py
+++ b/haystack/backends/elasticsearch5_backend.py
@@ -28,6 +28,15 @@ except ImportError:
                             installation of 'elasticsearch>=5.0.0,<6.0.0'. \
                             Please refer to the documentation."
     )
+# We need to override some elasticsearch_backend settings as string type is
+# gone in elasticsearch 5.
+from haystack.backends import elasticsearch_backend
+elasticsearch_backend.DEFAULT_FIELD_MAPPING = {
+    "type": "text", "analyzer": "snowball"}
+elasticsearch_backend.FIELD_MAPPINGS["edge_ngram"] = {
+    "type": "text", "analyzer": "edgengram_analyzer"}
+elasticsearch_backend.FIELD_MAPPINGS["ngram"] = {
+    "type": "text", "analyzer": "ngram_analyzer"}
 
 
 class Elasticsearch5SearchBackend(ElasticsearchSearchBackend):


### PR DESCRIPTION
The `string` type is removed in elasticsearch 5. There is an automatic conversion to `text` but this doesn't support parameters like `boost`.

Attempts to PUT `_mapping/modelresult` with items like `'subject': {'type': 'string', 'analyzer': 'snowball', 'boost': 1.25},` result in a 400 error with the exception `{'error': {'root_cause': [{'type': 'illegal_argument_exception', 'reason': 'The [string] type is removed in 5.0 and automatic upgrade failed because parameters [boost] are not supported for automatic upgrades. You should now use either a [text] or [keyword] field instead for field [subject]'}], 'type': 'illegal_argument_exception', 'reason': 'The [string] type is removed in 5.0 and automatic upgrade failed because parameters [boost] are not supported for automatic upgrades. You should now use either a [text] or [keyword] field instead for field [subject]'}, 'status': 400}`

This PR modifies `backends/elasticsearch5_backend.py` to change `string` to `text` in the imported `backends/elasticsearch_backend.py` settings `DEFAULT_FIELD_MAPPING` and `FIELD_MAPPINGS`