### PR TITLE
Add the ability to add custom field type for solr backend 

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -658,7 +658,7 @@ class SolrSearchBackend(BaseSearchBackend):
         for field_name, field_class in fields.items():
             field_data = {
                 "field_name": field_class.index_fieldname,
-                "type": "text_en",
+                "type": field_class.field_type,
                 "indexed": "true",
                 "stored": "true",
                 "multi_valued": "false",
@@ -697,13 +697,13 @@ class SolrSearchBackend(BaseSearchBackend):
 
                 # If it's text and not being indexed, we probably don't want
                 # to do the normal lowercase/tokenize/stemming/etc. dance.
-                if field_data["type"] == "text_en":
+                if field_data['type'].startswith("text"):
                     field_data["type"] = "string"
 
             # If it's a ``FacetField``, make sure we don't postprocess it.
             if hasattr(field_class, "facet_for"):
                 # If it's text, it ought to be a string.
-                if field_data["type"] == "text_en":
+                if field_data['type'].startswith("text"):
                     field_data["type"] = "string"
 
             schema_fields.append(field_data)

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -48,6 +48,7 @@ class SearchField(object):
         facet_class=None,
         boost=1.0,
         weight=None,
+        field_type="text_en"
     ):
         # Track what the index thinks this field is called.
         self.instance_name = None
@@ -63,6 +64,7 @@ class SearchField(object):
         self.index_fieldname = index_fieldname
         self.boost = weight or boost
         self.is_multivalued = False
+        self.field_type = field_type
 
         # We supply the facet_class for making it easy to create a faceted
         # field based off of this field.


### PR DESCRIPTION
Add the ability to change the default field type "text_en" for solr to user defined value using attr "field_type", to support different field types of solr that have different analyzers.

`name = indexes.CharField(model_attr='name', field_type="text_ar", null=True)`

now name will have the solr field type of "text_ar" and Arabic analyzer will be applied on it.