### PR TITLE
Make setuptools-scm requirement pip-compatible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,7 @@ ignore = E203, E501, W503
 line_length=88
 default_section=THIRDPARTY
 known_first_party=haystack
+
+[options]
+setup_requires =
+  setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,4 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     test_suite="test_haystack.run_tests.run_all",
-    setup_requires=["setuptools_scm"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-# n.b. we can't have unicode_literals here due to http://bugs.python.org/setuptools/issue152
-from __future__ import absolute_import, division, print_function
-
-try:
-    from setuptools import setup
-except ImportError:
-    from ez_setup import use_setuptools
-
-    use_setuptools()
-    from setuptools import setup
+from setuptools import setup
 
 install_requires = ["Django>=1.11"]
 


### PR DESCRIPTION
django-haystack is not installable when you use a non-standard PyPI repo. This changes setup_requires to a format that pip understands.

Also removes unused imports

Fixes #1571 

A different solution was attempted in #1603

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.