### PR TITLE
using six replace django six

### DIFF
--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
 import copy
 from copy import deepcopy
 from time import time
+
+import six
+
 from django.conf import settings
 from django.db.models import Q
 from django.db.models.base import ModelBase
-from django.utils import six
 from django.utils import tree
 from django.utils.encoding import force_text
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -6,9 +6,9 @@ import re
 import warnings
 from datetime import datetime, timedelta
 
+import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 
 import haystack
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query

--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from warnings import warn
 
+import six
 from django.db.models import Q
-from django.utils import six
 
 from haystack import connections
 from haystack.backends import (

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import warnings
 
+import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 
 import haystack
 from haystack.backends import (

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -9,9 +9,9 @@ import shutil
 import threading
 import warnings
 
+import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.datetime_safe import datetime
 from django.utils.encoding import force_text
 

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -4,8 +4,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import re
 from inspect import ismethod
 
+import six
 from django.template import loader
-from django.utils import datetime_safe, six
+from django.utils import datetime_safe
 
 from haystack.exceptions import SearchFieldError
 from haystack.utils import get_model_ct_tuple

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -8,7 +8,7 @@ import warnings
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.encoding import force_text
-from django.utils.six import with_metaclass
+from six import with_metaclass
 
 from haystack import connection_router, connections
 from haystack.constants import Indexable  # NOQA — exposed as a public export

--- a/haystack/inputs.py
+++ b/haystack/inputs.py
@@ -5,7 +5,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import re
 import warnings
 
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -2,8 +2,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import six
 from django.core.management.base import BaseCommand
-from django.utils import six
 
 from haystack import connections
 

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -4,8 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import six
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.text import capfirst
 

--- a/haystack/panels.py
+++ b/haystack/panels.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import datetime
 
+import six
 from debug_toolbar.panels import DebugPanel
 from django.template.loader import render_to_string
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 from haystack import connections

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import operator
 import warnings
 
-from django.utils import six
+import six
 
 from haystack import connection_router, connections
 from haystack.backends import SQ

--- a/haystack/templatetags/highlight.py
+++ b/haystack/templatetags/highlight.py
@@ -2,10 +2,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import six
 from django import template
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 
 from haystack.utils import importlib
 

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 import importlib
 import re
 
+import six
 from django.conf import settings
-from django.utils import six
 
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID
 from haystack.utils.highlighting import Highlighter

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -8,9 +8,9 @@ import threading
 import warnings
 from collections import OrderedDict
 
+import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.module_loading import module_has_submodule
 
 from haystack import constants

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     use_setuptools()
     from setuptools import setup
 
-install_requires = ["Django>=1.11"]
+install_requires = ["Django>=1.11", "six==1.12.0"]
 
 tests_require = [
     "pysolr>=3.7.0",

--- a/test_haystack/test_indexes.py
+++ b/test_haystack/test_indexes.py
@@ -7,7 +7,7 @@ import time
 from threading import Thread
 
 from django.test import TestCase
-from django.utils.six.moves import queue
+from six.moves import queue
 from test_haystack.core.models import (
     AFifthMockModel,
     AnotherMockModel,
@@ -17,7 +17,7 @@ from test_haystack.core.models import (
     MockModel,
 )
 
-from haystack import connection_router, connections, indexes
+from haystack import connections, indexes
 from haystack.exceptions import SearchFieldError
 from haystack.utils.loading import UnifiedIndex
 

--- a/test_haystack/test_views.py
+++ b/test_haystack/test_views.py
@@ -9,7 +9,7 @@ from django import forms
 from django.http import HttpRequest, QueryDict
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from django.utils.six.moves import queue
+from six.moves import queue
 from test_haystack.core.models import AnotherMockModel, MockModel
 
 from haystack import connections, indexes


### PR DESCRIPTION
ref: https://docs.djangoproject.com/en/dev/releases/3.0/#removed-private-python-2-compatibility-apis