### PR TITLE
Remove django.six, that has been deprecated with Django2, from loading.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: required
 dist: trusty
 language: python
 python:
-    - 2.7
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
     - pypy
 
 cache:

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -10,7 +10,6 @@ from collections import OrderedDict
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.module_loading import module_has_submodule
 
 from haystack import constants
@@ -163,7 +162,7 @@ class ConnectionRouter(object):
                 connection_to_use = action_callable(**hints)
 
                 if connection_to_use is not None:
-                    if isinstance(connection_to_use, six.string_types):
+                    if isinstance(connection_to_use, str):
                         conns.append(connection_to_use)
                     else:
                         conns.extend(connection_to_use)


### PR DESCRIPTION
- [x] Remove `six` import

Closes #1697 