### PR TITLE
Fix for issue #1697 Django 3.0

### DIFF
--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import importlib
+import six
 import re
 
 from django.conf import settings
@@ -21,7 +22,7 @@ def default_get_identifier(obj_or_string):
 
     If not overridden, uses <app_label>.<object_name>.<pk>.
     """
-    if type(obj_or_string) == str:
+    if isinstance(obj_or_string, six.string_types):
         if not IDENTIFIER_REGEX.match(obj_or_string):
             raise AttributeError(
                 "Provided string '%s' is not a valid identifier." % obj_or_string

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -6,7 +6,6 @@ import importlib
 import re
 
 from django.conf import settings
-from django.utils import six
 
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID
 from haystack.utils.highlighting import Highlighter
@@ -22,7 +21,7 @@ def default_get_identifier(obj_or_string):
 
     If not overridden, uses <app_label>.<object_name>.<pk>.
     """
-    if isinstance(obj_or_string, six.string_types):
+    if type(obj_or_string) == str::
         if not IDENTIFIER_REGEX.match(obj_or_string):
             raise AttributeError(
                 "Provided string '%s' is not a valid identifier." % obj_or_string

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -21,7 +21,7 @@ def default_get_identifier(obj_or_string):
 
     If not overridden, uses <app_label>.<object_name>.<pk>.
     """
-    if type(obj_or_string) == str::
+    if type(obj_or_string) == str:
         if not IDENTIFIER_REGEX.match(obj_or_string):
             raise AttributeError(
                 "Provided string '%s' is not a valid identifier." % obj_or_string

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup
 
-install_requires = ["Django>=1.11"]
+install_requires = ["Django>=1.11", "six"]
 
 tests_require = [
     "pysolr>=3.7.0",


### PR DESCRIPTION
The Django 3.0.0 [release notes]("https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis") specify that certain private Python 2 compatibility APIs were removed. Among those was django.utils.six.