### PR TITLE
Drop support for Python 2 and old versions of Django. Add support for Django 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
     - pypy3
 services:
     - docker
@@ -29,10 +30,10 @@ addons:
 before_install:
     - mkdir -p $HOME/download-cache
     - >
-        if [[ $VERSION_ES == '>=2.0.0,<3.0.0' ]];
+        if [[ $VERSION_ES == '>=2,<3' ]];
         then
           docker run -d -p 9200:9200 elasticsearch:2.4.6-alpine
-        elif [[ $VERSION_ES == '>=5.0.0,<6.0.0' ]];
+        elif [[ $VERSION_ES == '>=5,<6' ]];
         then
           docker run -d -p 9200:9200 elasticsearch:5.6.10-alpine
         else
@@ -59,31 +60,34 @@ env:
     global:
         - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     jobs:
-        - DJANGO_VERSION=">=1.11,<2.0" VERSION_ES=">=1.0.0,<2.0.0"
-        - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=1.0.0,<2.0.0"
-        - DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=1.0.0,<2.0.0"
-        - DJANGO_VERSION=">=1.11,<2.0" VERSION_ES=">=2.0.0,<3.0.0"
-        - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
-        - DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=2.0.0,<3.0.0"
-        - DJANGO_VERSION=">=1.11,<2.0" VERSION_ES=">=5.0.0,<6.0.0"
-        - DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=5.0.0,<6.0.0"
-        - DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=5.0.0,<6.0.0"
+        - DJANGO_VERSION=">=2.2,<3.0" VERSION_ES=">=1,<2"
+        - DJANGO_VERSION=">=3.0,<3.1" VERSION_ES=">=1,<2"
+        - DJANGO_VERSION=">=2.2,<3.0" VERSION_ES=">=2,<3"
+        - DJANGO_VERSION=">=3.0,<3.1" VERSION_ES=">=2,<3"
+        - DJANGO_VERSION=">=2.2,<3.0" VERSION_ES=">=5,<6"
+        - DJANGO_VERSION=">=3.0,<3.1" VERSION_ES=">=5,<6"
 jobs:
     allow_failures:
         - python: 'pypy3'
     exclude:
         - python: pypy3
-          env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=5.0.0,<6.0.0"
+          env: DJANGO_VERSION=">=2.2,<3.0" VERSION_ES=">=5,<6"
         - python: pypy3
-          env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=2.0.0,<3.0.0"
+          env: DJANGO_VERSION=">=2.2,<3.0" VERSION_ES=">=2,<3"
         - python: pypy3
-          env: DJANGO_VERSION=">=2.0,<2.1" VERSION_ES=">=1.0.0,<2.0.0"
+          env: DJANGO_VERSION=">=2.2,<3.0" VERSION_ES=">=1,<2"
         - python: pypy3
-          env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=5.0.0,<6.0.0"
+          env: DJANGO_VERSION=">=3.0,<3.1" VERSION_ES=">=5,<6"
         - python: pypy3
-          env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=2.0.0,<3.0.0"
+          env: DJANGO_VERSION=">=3.0,<3.1" VERSION_ES=">=2,<3"
         - python: pypy3
-          env: DJANGO_VERSION=">=2.1,<2.2" VERSION_ES=">=1.0.0,<2.0.0"
+          env: DJANGO_VERSION=">=3.0,<3.1" VERSION_ES=">=1,<2"
+        - python: 3.5
+          env: DJANGO_VERSION=">=3.0,<3.1" VERSION_ES=">=1,<2"
+        - python: 3.5
+          env: DJANGO_VERSION=">=3.0,<3.1" VERSION_ES=">=2,<3"
+        - python: 3.5
+          env: DJANGO_VERSION=">=3.0,<3.1" VERSION_ES=">=5,<6"
 
 notifications:
     irc: 'irc.freenode.org#haystack'

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Requirements
 
 Haystack has a relatively easily-met set of requirements.
 
-* Python 2.7+ or Python 3.3+
+* Python 3.5+
 * A supported version of Django: https://www.djangoproject.com/download/#supported-versions
 
 Additionally, each backend has its own requirements. You should refer to

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import sys
 

--- a/docs/searchindex_api.rst
+++ b/docs/searchindex_api.rst
@@ -332,7 +332,6 @@ object and write its ``prepare`` method to populate/alter the data any way you
 choose. For instance, a (naive) user-created ``GeoPointField`` might look
 something like::
 
-    from django.utils import six
     from haystack import indexes
 
     class GeoPointField(indexes.CharField):
@@ -341,7 +340,7 @@ something like::
             super(GeoPointField, self).__init__(**kwargs)
 
         def prepare(self, obj):
-            return six.text_type("%s-%s" % (obj.latitude, obj.longitude))
+            return "%s-%s" % (obj.latitude, obj.longitude)
 
 The ``prepare`` method simply returns the value to be used for that field. It's
 entirely possible to include data that's not directly referenced to the object
@@ -615,4 +614,3 @@ For the impatient::
         def index_queryset(self, using=None):
             "Used when the entire index for model is updated."
             return Note.objects.filter(pub_date__lte=datetime.datetime.now())
-

--- a/example_project/bare_bones_app/models.py
+++ b/example_project/bare_bones_app/models.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 from django.db import models
@@ -14,7 +11,7 @@ class Cat(models.Model):
     created = models.DateTimeField(default=datetime.datetime.now)
     updated = models.DateTimeField(default=datetime.datetime.now)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     @models.permalink

--- a/example_project/bare_bones_app/search_indexes.py
+++ b/example_project/bare_bones_app/search_indexes.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from bare_bones_app.models import Cat
 
 from haystack import indexes

--- a/example_project/regular_app/models.py
+++ b/example_project/regular_app/models.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 from django.db import models
@@ -25,7 +22,7 @@ class Dog(models.Model):
     created = models.DateTimeField(default=datetime.datetime.now)
     updated = models.DateTimeField(default=datetime.datetime.now)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.full_name()
 
     @models.permalink
@@ -43,5 +40,5 @@ class Toy(models.Model):
     dog = models.ForeignKey(Dog, related_name="toys")
     name = models.CharField(max_length=60)
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s's %s" % (self.dog.name, self.name)

--- a/example_project/regular_app/search_indexes.py
+++ b/example_project/regular_app/search_indexes.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from regular_app.models import Dog
 
 from haystack import indexes

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 
 from django.conf import settings

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from pkg_resources import DistributionNotFound, get_distribution, parse_version

--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -1,13 +1,10 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.contrib.admin.options import ModelAdmin, csrf_protect_m
 from django.contrib.admin.views.main import SEARCH_VAR, ChangeList
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import InvalidPage, Paginator
 from django.shortcuts import render
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import ungettext
 
 from haystack import connections
@@ -135,7 +132,7 @@ class SearchModelAdminMixin(object):
         )
 
         context = {
-            "module_name": force_text(self.model._meta.verbose_name_plural),
+            "module_name": force_str(self.model._meta.verbose_name_plural),
             "selection_note": selection_note % {"count": len(changelist.result_list)},
             "selection_note_all": selection_note_all
             % {"total_count": changelist.result_count},

--- a/haystack/apps.py
+++ b/haystack/apps.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 
 from django.apps import AppConfig

--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -1,17 +1,13 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import copy
 from copy import deepcopy
 from time import time
-
-import six
 
 from django.conf import settings
 from django.db.models import Q
 from django.db.models.base import ModelBase
 from django.utils import tree
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from haystack.constants import VALID_FILTERS, FILTER_SEPARATOR, DEFAULT_ALIAS
 from haystack.exceptions import MoreLikeThisError, FacetingError
@@ -163,7 +159,7 @@ class BaseSearchBackend(object):
         Hook to give the backend a chance to prep an attribute value before
         sending it to the search engine. By default, just force it to unicode.
         """
-        return force_text(value)
+        return force_str(value)
 
     def more_like_this(
         self, model_instance, additional_query_string=None, result_class=None
@@ -315,9 +311,6 @@ class SearchNode(tree.Node):
         """
         return bool(self.children)
 
-    def __nonzero__(self):  # Python 2 compatibility
-        return type(self).__bool__(self)
-
     def __contains__(self, other):
         """
         Returns True is 'other' is a direct child of this instance.
@@ -407,12 +400,7 @@ class SearchNode(tree.Node):
         )
 
     def _repr_query_fragment_callback(self, field, filter_type, value):
-        if six.PY3:
-            value = force_text(value)
-        else:
-            value = force_text(value).encode("utf8")
-
-        return "%s%s%s=%s" % (field, FILTER_SEPARATOR, filter_type, value)
+        return "%s%s%s=%s" % (field, FILTER_SEPARATOR, filter_type, force_str(value))
 
     def as_query_string(self, query_fragment_callback):
         """
@@ -785,7 +773,7 @@ class BaseSearchQuery(object):
 
         A basic (override-able) implementation is provided.
         """
-        if not isinstance(query_fragment, six.string_types):
+        if not isinstance(query_fragment, str):
             return query_fragment
 
         words = query_fragment.split()

--- a/haystack/backends/elasticsearch2_backend.py
+++ b/haystack/backends/elasticsearch2_backend.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 from django.conf import settings

--- a/haystack/backends/elasticsearch5_backend.py
+++ b/haystack/backends/elasticsearch5_backend.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 import warnings
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -1,12 +1,8 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import re
 import warnings
 from datetime import datetime, timedelta
 
-import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -813,9 +809,9 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         iso = self._iso_datetime(value)
         if iso:
             return iso
-        elif isinstance(value, six.binary_type):
+        elif isinstance(value, bytes):
             # TODO: Be stricter.
-            return six.text_type(value, errors="replace")
+            return str(value, errors="replace")
         elif isinstance(value, set):
             return list(value)
         return value
@@ -825,7 +821,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         if isinstance(value, (int, float, complex, list, tuple, bool)):
             return value
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             possible_datetime = DATETIME_REGEX.search(value)
 
             if possible_datetime:
@@ -894,7 +890,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             if hasattr(value, "values_list"):
                 value = list(value)
 
-            if isinstance(value, six.string_types):
+            if isinstance(value, str):
                 # It's not an ``InputType``. Assume ``Clean``.
                 value = Clean(value)
             else:
@@ -945,7 +941,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
                     # Iterate over terms & incorportate the converted form of each into the query.
                     terms = []
 
-                    if isinstance(prepared_value, six.string_types):
+                    if isinstance(prepared_value, str):
                         for possible_value in prepared_value.split(" "):
                             terms.append(
                                 filter_types[filter_type]
@@ -1002,7 +998,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
         kwarg_bits = []
 
         for key in sorted(kwargs.keys()):
-            if isinstance(kwargs[key], six.string_types) and " " in kwargs[key]:
+            if isinstance(kwargs[key], str) and " " in kwargs[key]:
                 kwarg_bits.append("%s='%s'" % (key, kwargs[key]))
             else:
                 kwarg_bits.append("%s=%s" % (key, kwargs[key]))

--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -2,12 +2,9 @@
 """
 A very basic, ORM-based backend for simple search during tests.
 """
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+from functools import reduce
 from warnings import warn
 
-import six
 from django.db.models import Q
 
 from haystack import connections
@@ -71,7 +68,7 @@ class SimpleSearchBackend(BaseSearchBackend):
 
                         if queries:
                             qs = model.objects.filter(
-                                six.moves.reduce(lambda x, y: x | y, queries)
+                                reduce(lambda x, y: x | y, queries)
                             )
                         else:
                             qs = []
@@ -128,7 +125,7 @@ class SimpleSearchQuery(BaseSearchQuery):
 
                 term_list.append(value.prepare(self))
 
-        return (" ").join(map(six.text_type, term_list))
+        return (" ").join(map(str, term_list))
 
 
 class SimpleEngine(BaseEngine):

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -1,10 +1,6 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
 
-import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -518,7 +514,7 @@ class SolrSearchBackend(BaseSearchBackend):
             if spelling_suggestions:
                 # Maintain compatibility with older versions of Haystack which returned a single suggestion:
                 spelling_suggestion = spelling_suggestions[-1]
-                assert isinstance(spelling_suggestion, six.string_types)
+                assert isinstance(spelling_suggestion, str)
             else:
                 spelling_suggestion = None
 
@@ -609,7 +605,7 @@ class SolrSearchBackend(BaseSearchBackend):
             if isinstance(collations, dict):
                 # Solr 6.5
                 collation_values = collations["collation"]
-                if isinstance(collation_values, six.string_types):
+                if isinstance(collation_values, str):
                     collation_values = [collation_values]
                 elif isinstance(collation_values, dict):
                     # spellcheck.collateExtendedResults changes the format to a dictionary:
@@ -634,7 +630,7 @@ class SolrSearchBackend(BaseSearchBackend):
                             spelling_suggestions.append(j["word"])
                         else:
                             spelling_suggestions.append(j)
-            elif isinstance(suggestions[0], six.string_types) and isinstance(
+            elif isinstance(suggestions[0], str) and isinstance(
                 suggestions[1], dict
             ):
                 # Solr 6.4 uses a list of paired (word, dictionary) pairs:
@@ -761,7 +757,7 @@ class SolrSearchQuery(BaseSearchQuery):
             if hasattr(value, "values_list"):
                 value = list(value)
 
-            if isinstance(value, six.string_types):
+            if isinstance(value, str):
                 # It's not an ``InputType``. Assume ``Clean``.
                 value = Clean(value)
             else:
@@ -863,7 +859,7 @@ class SolrSearchQuery(BaseSearchQuery):
         kwarg_bits = []
 
         for key in sorted(kwargs.keys()):
-            if isinstance(kwargs[key], six.string_types) and " " in kwargs[key]:
+            if isinstance(kwargs[key], str) and " " in kwargs[key]:
                 kwarg_bits.append("%s='%s'" % (key, kwargs[key]))
             else:
                 kwarg_bits.append("%s=%s" % (key, kwargs[key]))

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import json
 import os
 import re
@@ -9,11 +6,10 @@ import shutil
 import threading
 import warnings
 
-import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.datetime_safe import datetime
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from haystack.backends import (
     BaseEngine,
@@ -428,7 +424,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         if len(query_string) == 0:
             return {"results": [], "hits": 0}
 
-        query_string = force_text(query_string)
+        query_string = force_str(query_string)
 
         # A one-character query (non-wildcard) gets nabbed by a stopwords
         # filter and should yield zero results.
@@ -514,7 +510,7 @@ class WhooshSearchBackend(BaseSearchBackend):
 
             for nq in narrow_queries:
                 recent_narrowed_results = narrow_searcher.search(
-                    self.parser.parse(force_text(nq)), limit=None
+                    self.parser.parse(force_str(nq)), limit=None
                 )
 
                 if len(recent_narrowed_results) <= 0:
@@ -642,7 +638,7 @@ class WhooshSearchBackend(BaseSearchBackend):
 
             for nq in narrow_queries:
                 recent_narrowed_results = narrow_searcher.search(
-                    self.parser.parse(force_text(nq)), limit=None
+                    self.parser.parse(force_str(nq)), limit=None
                 )
 
                 if len(recent_narrowed_results) <= 0:
@@ -793,7 +789,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         spelling_suggestion = None
         reader = self.index.reader()
         corrector = reader.corrector(self.content_field_name)
-        cleaned_query = force_text(query_string)
+        cleaned_query = force_str(query_string)
 
         if not query_string:
             return spelling_suggestion
@@ -833,12 +829,12 @@ class WhooshSearchBackend(BaseSearchBackend):
             else:
                 value = "false"
         elif isinstance(value, (list, tuple)):
-            value = ",".join([force_text(v) for v in value])
-        elif isinstance(value, (six.integer_types, float)):
+            value = ",".join([force_str(v) for v in value])
+        elif isinstance(value, (int, float)):
             # Leave it alone.
             pass
         else:
-            value = force_text(value)
+            value = force_str(value)
         return value
 
     def _to_python(self, value):
@@ -852,7 +848,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         elif value == "false":
             return False
 
-        if value and isinstance(value, six.string_types):
+        if value and isinstance(value, str):
             possible_datetime = DATETIME_REGEX.search(value)
 
             if possible_datetime:
@@ -877,7 +873,7 @@ class WhooshSearchBackend(BaseSearchBackend):
             # Try to handle most built-in types.
             if isinstance(
                 converted_value,
-                (list, tuple, set, dict, six.integer_types, float, complex),
+                (list, tuple, set, dict, int, float, complex),
             ):
                 return converted_value
         except:
@@ -891,9 +887,9 @@ class WhooshSearchBackend(BaseSearchBackend):
 class WhooshSearchQuery(BaseSearchQuery):
     def _convert_datetime(self, date):
         if hasattr(date, "hour"):
-            return force_text(date.strftime("%Y%m%d%H%M%S"))
+            return force_str(date.strftime("%Y%m%d%H%M%S"))
         else:
-            return force_text(date.strftime("%Y%m%d000000"))
+            return force_str(date.strftime("%Y%m%d000000"))
 
     def clean(self, query_fragment):
         """
@@ -934,7 +930,7 @@ class WhooshSearchQuery(BaseSearchQuery):
             if hasattr(value, "strftime"):
                 is_datetime = True
 
-            if isinstance(value, six.string_types) and value != " ":
+            if isinstance(value, str) and value != " ":
                 # It's not an ``InputType``. Assume ``Clean``.
                 value = Clean(value)
             else:
@@ -985,7 +981,7 @@ class WhooshSearchQuery(BaseSearchQuery):
                     # Iterate over terms & incorportate the converted form of each into the query.
                     terms = []
 
-                    if isinstance(prepared_value, six.string_types):
+                    if isinstance(prepared_value, str):
                         possible_values = prepared_value.split(" ")
                     else:
                         if is_datetime is True:
@@ -1030,7 +1026,7 @@ class WhooshSearchQuery(BaseSearchQuery):
                     if is_datetime is True:
                         pv = self._convert_datetime(pv)
 
-                    if isinstance(pv, six.string_types) and not is_datetime:
+                    if isinstance(pv, str) and not is_datetime:
                         in_options.append('"%s"' % pv)
                     else:
                         in_options.append("%s" % pv)

--- a/haystack/constants.py
+++ b/haystack/constants.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf import settings
 
 DEFAULT_ALIAS = "default"

--- a/haystack/exceptions.py
+++ b/haystack/exceptions.py
@@ -1,8 +1,5 @@
 # encoding: utf-8
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-
 class HaystackError(Exception):
     """A generic exception for all others to extend."""
 

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -1,10 +1,7 @@
 # encoding: utf-8
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import re
 from inspect import ismethod
 
-import six
 from django.template import loader
 from django.utils import datetime_safe
 
@@ -241,7 +238,7 @@ class CharField(SearchField):
         if value is None:
             return None
 
-        return six.text_type(value)
+        return str(value)
 
 
 class LocationField(SearchField):
@@ -270,7 +267,7 @@ class LocationField(SearchField):
             value = ensure_point(value)
             return value
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             lat, lng = value.split(",")
         elif isinstance(value, (list, tuple)):
             # GeoJSON-alike
@@ -353,7 +350,7 @@ class DecimalField(SearchField):
         if value is None:
             return None
 
-        return six.text_type(value)
+        return str(value)
 
 
 class BooleanField(SearchField):
@@ -391,7 +388,7 @@ class DateField(SearchField):
         if value is None:
             return None
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             match = DATE_REGEX.search(value)
 
             if match:
@@ -424,7 +421,7 @@ class DateTimeField(SearchField):
         if value is None:
             return None
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             match = DATETIME_REGEX.search(value)
 
             if match:
@@ -469,7 +466,7 @@ class MultiValueField(SearchField):
         if value is None:
             return None
 
-        if hasattr(value, "__iter__") and not isinstance(value, six.text_type):
+        if hasattr(value, "__iter__") and not isinstance(value, str):
             return value
 
         return [value]

--- a/haystack/forms.py
+++ b/haystack/forms.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django import forms
 from django.utils.encoding import smart_text
 from django.utils.text import capfirst

--- a/haystack/generic_views.py
+++ b/haystack/generic_views.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf import settings
 from django.core.paginator import Paginator
 from django.views.generic import FormView

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -1,14 +1,10 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import copy
 import threading
 import warnings
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import force_text
-from six import with_metaclass
+from django.utils.encoding import force_str
 
 from haystack import connection_router, connections
 from haystack.constants import Indexable  # NOQA — exposed as a public export
@@ -95,7 +91,7 @@ class DeclarativeMetaclass(type):
         return super(DeclarativeMetaclass, cls).__new__(cls, name, bases, attrs)
 
 
-class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
+class SearchIndex(threading.local, metaclass=DeclarativeMetaclass):
     """
     Base class for building indexes.
 
@@ -221,7 +217,7 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
         self.prepared_data = {
             ID: get_identifier(obj),
             DJANGO_CT: get_model_ct(self.get_model()),
-            DJANGO_ID: force_text(obj.pk),
+            DJANGO_ID: force_str(obj.pk),
         }
 
         for field_name, field in self.fields.items():

--- a/haystack/inputs.py
+++ b/haystack/inputs.py
@@ -1,15 +1,10 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import re
 import warnings
 
-from django.utils.encoding import force_text
-from six import python_2_unicode_compatible
+from django.utils.encoding import force_str
 
 
-@python_2_unicode_compatible
 class BaseInput(object):
     """
     The base input type. Doesn't do much. You want ``Raw`` instead.
@@ -26,7 +21,7 @@ class BaseInput(object):
         return "<%s '%s'>" % (self.__class__.__name__, self)
 
     def __str__(self):
-        return force_text(self.query_string)
+        return force_str(self.query_string)
 
     def prepare(self, query_obj):
         return self.query_string

--- a/haystack/management/commands/build_solr_schema.py
+++ b/haystack/management/commands/build_solr_schema.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 
 import requests

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -1,8 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import six
 from django.core.management.base import BaseCommand
 
 from haystack import connections
@@ -53,7 +49,7 @@ class Command(BaseCommand):
                 "Your choices after this are to restore from backups or rebuild via the `rebuild_index` command."
             )
 
-            yes_or_no = six.moves.input("Are you sure you wish to continue? [y/N] ")
+            yes_or_no = input("Are you sure you wish to continue? [y/N] ")
 
             if not yes_or_no.lower().startswith("y"):
                 self.stdout.write("No action taken.")

--- a/haystack/management/commands/haystack_info.py
+++ b/haystack/management/commands/haystack_info.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.core.management.base import BaseCommand
 
 from haystack import connections

--- a/haystack/management/commands/rebuild_index.py
+++ b/haystack/management/commands/rebuild_index.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import logging
 import multiprocessing
 import os
@@ -9,7 +7,7 @@ from datetime import timedelta
 
 from django.core.management.base import BaseCommand
 from django.db import close_old_connections, reset_queries
-from django.utils.encoding import force_text, smart_bytes
+from django.utils.encoding import force_str, smart_bytes
 from django.utils.timezone import now
 
 from haystack import connections as haystack_connections
@@ -305,7 +303,7 @@ class Command(BaseCommand):
             if self.verbosity >= 1:
                 self.stdout.write(
                     "Indexing %d %s"
-                    % (total, force_text(model._meta.verbose_name_plural))
+                    % (total, force_str(model._meta.verbose_name_plural))
                 )
 
             batch_size = self.batchsize or backend.batch_size

--- a/haystack/manager.py
+++ b/haystack/manager.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from haystack.query import EmptySearchQuerySet, SearchQuerySet
 
 

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -1,12 +1,8 @@
 # encoding: utf-8
 
 # "Hey, Django! Look at me, I'm an app! For Serious!"
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import six
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import capfirst
 
 from haystack.exceptions import NotHandled, SpatialError
@@ -59,8 +55,8 @@ class SearchResult(object):
             self.pk,
         )
 
-    def __unicode__(self):
-        return force_text(self.__repr__())
+    def __str__(self):
+        return force_str(self.__repr__())
 
     def __getattr__(self, attr):
         if attr == "__getnewargs__":
@@ -169,7 +165,7 @@ class SearchResult(object):
             self.log.error("Model could not be found for SearchResult '%s'.", self)
             return ""
 
-        return force_text(capfirst(self.model._meta.verbose_name))
+        return force_str(capfirst(self.model._meta.verbose_name))
 
     verbose_name = property(_get_verbose_name)
 
@@ -178,7 +174,7 @@ class SearchResult(object):
             self.log.error("Model could not be found for SearchResult '%s'.", self)
             return ""
 
-        return force_text(capfirst(self.model._meta.verbose_name_plural))
+        return force_str(capfirst(self.model._meta.verbose_name_plural))
 
     verbose_name_plural = property(_get_verbose_name_plural)
 
@@ -188,7 +184,7 @@ class SearchResult(object):
             self.log.error("Model could not be found for SearchResult '%s'.", self)
             return ""
 
-        return six.text_type(self.model._meta)
+        return str(self.model._meta)
 
     def get_additional_fields(self):
         """

--- a/haystack/panels.py
+++ b/haystack/panels.py
@@ -1,10 +1,6 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
-import six
 from debug_toolbar.panels import DebugPanel
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
@@ -70,7 +66,7 @@ class HaystackDebugPanel(DebugPanel):
 
             if query.get("additional_kwargs"):
                 if query["additional_kwargs"].get("result_class"):
-                    query["additional_kwargs"]["result_class"] = six.text_type(
+                    query["additional_kwargs"]["result_class"] = str(
                         query["additional_kwargs"]["result_class"]
                     )
 

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -1,11 +1,7 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+from functools import reduce
 import operator
 import warnings
-
-import six
 
 from haystack import connection_router, connections
 from haystack.backends import SQ
@@ -283,7 +279,7 @@ class SearchQuerySet(object):
         """
         Retrieves an item or slice from the set of results.
         """
-        if not isinstance(k, (slice, six.integer_types)):
+        if not isinstance(k, (slice, int)):
             raise TypeError
         assert (not isinstance(k, slice) and (k >= 0)) or (
             isinstance(k, slice)
@@ -513,7 +509,7 @@ class SearchQuerySet(object):
                     kwargs = {field_name: bit}
                     query_bits.append(SQ(**kwargs))
 
-        return clone.filter(six.moves.reduce(operator.__and__, query_bits))
+        return clone.filter(reduce(operator.__and__, query_bits))
 
     def using(self, connection_name):
         """

--- a/haystack/routers.py
+++ b/haystack/routers.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from haystack.constants import DEFAULT_ALIAS
 
 

--- a/haystack/signals.py
+++ b/haystack/signals.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db import models
 
 from haystack.exceptions import NotHandled

--- a/haystack/templatetags/highlight.py
+++ b/haystack/templatetags/highlight.py
@@ -1,8 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import six
 from django import template
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -125,12 +121,12 @@ def highlight(parser, token):
 
     for bit in arg_bits:
         if bit == "css_class":
-            kwargs["css_class"] = six.next(arg_bits)
+            kwargs["css_class"] = next(arg_bits)
 
         if bit == "html_tag":
-            kwargs["html_tag"] = six.next(arg_bits)
+            kwargs["html_tag"] = next(arg_bits)
 
         if bit == "max_length":
-            kwargs["max_length"] = six.next(arg_bits)
+            kwargs["max_length"] = next(arg_bits)
 
     return HighlightNode(text_block, query, **kwargs)

--- a/haystack/templatetags/more_like_this.py
+++ b/haystack/templatetags/more_like_this.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import logging
 
 from django import template

--- a/haystack/urls.py
+++ b/haystack/urls.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf.urls import url
 
 from haystack.views import SearchView

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -1,12 +1,7 @@
 # encoding: utf-8
-
-from __future__ import unicode_literals
-
 import importlib
-import six
 import re
 
-import six
 from django.conf import settings
 
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID
@@ -23,7 +18,7 @@ def default_get_identifier(obj_or_string):
 
     If not overridden, uses <app_label>.<object_name>.<pk>.
     """
-    if isinstance(obj_or_string, six.string_types):
+    if isinstance(obj_or_string, str):
         if not IDENTIFIER_REGEX.match(obj_or_string):
             raise AttributeError(
                 "Provided string '%s' is not a valid identifier." % obj_or_string

--- a/haystack/utils/app_loading.py
+++ b/haystack/utils/app_loading.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 

--- a/haystack/utils/geo.py
+++ b/haystack/utils/geo.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from haystack.constants import WGS_84_SRID
 from haystack.exceptions import SpatialError
 

--- a/haystack/utils/highlighting.py
+++ b/haystack/utils/highlighting.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.utils.html import strip_tags
 
 

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -1,14 +1,10 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import copy
 import inspect
 import threading
 import warnings
 from collections import OrderedDict
 
-import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import module_has_submodule

--- a/haystack/utils/log.py
+++ b/haystack/utils/log.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import logging
 
 from django.conf import settings

--- a/haystack/views.py
+++ b/haystack/views.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf import settings
 from django.core.paginator import InvalidPage, Paginator
 from django.http import Http404

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     use_setuptools()
     from setuptools import setup
 
-install_requires = ["Django>=1.11", "six>=1.12.0"]
+install_requires = ["Django>=2.2"]
 
 tests_require = [
     "pysolr>=3.7.0",
@@ -19,7 +19,6 @@ tests_require = [
     "python-dateutil",
     "geopy==0.95.1",
     "nose",
-    "mock",
     "coverage",
     "requests",
 ]
@@ -47,15 +46,17 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.0",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Utilities",
     ],
     zip_safe=False,

--- a/test_haystack/__init__.py
+++ b/test_haystack/__init__.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import
-
 import os
 
 test_runner = None

--- a/test_haystack/core/admin.py
+++ b/test_haystack/core/admin.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.contrib import admin
 
 from haystack.admin import SearchModelAdmin

--- a/test_haystack/core/custom_identifier.py
+++ b/test_haystack/core/custom_identifier.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import hashlib
 
 

--- a/test_haystack/core/models.py
+++ b/test_haystack/core/models.py
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
 # A couple models for Haystack to test with.
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 import uuid
 
@@ -12,7 +10,7 @@ from django.db import models
 class MockTag(models.Model):
     name = models.CharField(max_length=32)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -22,7 +20,7 @@ class MockModel(models.Model):
     pub_date = models.DateTimeField(default=datetime.datetime.now)
     tag = models.ForeignKey(MockTag, models.CASCADE)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.author
 
     def hello(self):
@@ -33,7 +31,7 @@ class UUIDMockModel(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     characteristics = models.TextField()
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.id)
 
 
@@ -41,7 +39,7 @@ class AnotherMockModel(models.Model):
     author = models.CharField(max_length=255)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.author
 
 
@@ -59,7 +57,7 @@ class AFourthMockModel(models.Model):
     editor = models.CharField(max_length=255)
     pub_date = models.DateTimeField(default=datetime.datetime.now)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.author
 
 
@@ -77,7 +75,7 @@ class AFifthMockModel(models.Model):
 
     objects = SoftDeleteManager()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.author
 
 
@@ -86,14 +84,14 @@ class ASixthMockModel(models.Model):
     lat = models.FloatField()
     lon = models.FloatField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
 class ScoreMockModel(models.Model):
     score = models.CharField(max_length=10)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.score
 
 
@@ -104,7 +102,7 @@ class ManyToManyLeftSideModel(models.Model):
 class ManyToManyRightSideModel(models.Model):
     name = models.CharField(max_length=32, default="Default name")
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 

--- a/test_haystack/core/urls.py
+++ b/test_haystack/core/urls.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf.urls import include, url
 from django.contrib import admin
 

--- a/test_haystack/discovery/models.py
+++ b/test_haystack/discovery/models.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db import models
 
 
@@ -9,7 +6,7 @@ class Foo(models.Model):
     title = models.CharField(max_length=255)
     body = models.TextField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
 
@@ -17,5 +14,5 @@ class Bar(models.Model):
     author = models.CharField(max_length=255)
     content = models.TextField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.author

--- a/test_haystack/discovery/search_indexes.py
+++ b/test_haystack/discovery/search_indexes.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from test_haystack.discovery.models import Bar, Foo
 
 from haystack import indexes

--- a/test_haystack/elasticsearch2_tests/test_backend.py
+++ b/test_haystack/elasticsearch2_tests/test_backend.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 import logging as std_logging
 import operator

--- a/test_haystack/elasticsearch2_tests/test_inputs.py
+++ b/test_haystack/elasticsearch2_tests/test_inputs.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 
 from haystack import connections, inputs

--- a/test_haystack/elasticsearch2_tests/test_query.py
+++ b/test_haystack/elasticsearch2_tests/test_query.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 import elasticsearch

--- a/test_haystack/elasticsearch5_tests/test_backend.py
+++ b/test_haystack/elasticsearch5_tests/test_backend.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 import logging as std_logging
 import operator

--- a/test_haystack/elasticsearch5_tests/test_inputs.py
+++ b/test_haystack/elasticsearch5_tests/test_inputs.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 
 from haystack import connections, inputs

--- a/test_haystack/elasticsearch5_tests/test_query.py
+++ b/test_haystack/elasticsearch5_tests/test_query.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 from django.contrib.gis.measure import D

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 import logging as std_logging
 import operator

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 import elasticsearch

--- a/test_haystack/elasticsearch_tests/test_inputs.py
+++ b/test_haystack/elasticsearch_tests/test_inputs.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 
 from haystack import connections, inputs

--- a/test_haystack/mocks.py
+++ b/test_haystack/mocks.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.apps import apps
 
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query

--- a/test_haystack/multipleindex/__init__.py
+++ b/test_haystack/multipleindex/__init__.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import haystack
 from haystack.signals import RealtimeSignalProcessor
 

--- a/test_haystack/multipleindex/models.py
+++ b/test_haystack/multipleindex/models.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db import models
 
 
@@ -9,7 +6,7 @@ class Foo(models.Model):
     title = models.CharField(max_length=255)
     body = models.TextField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
 
@@ -17,5 +14,5 @@ class Bar(models.Model):
     author = models.CharField(max_length=255)
     content = models.TextField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.author

--- a/test_haystack/multipleindex/routers.py
+++ b/test_haystack/multipleindex/routers.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from haystack.routers import BaseRouter
 
 

--- a/test_haystack/multipleindex/search_indexes.py
+++ b/test_haystack/multipleindex/search_indexes.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from haystack import indexes
 from haystack.indexes import Indexable, SearchIndex
 

--- a/test_haystack/multipleindex/tests.py
+++ b/test_haystack/multipleindex/tests.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db import models
 
 from haystack import connections

--- a/test_haystack/results_per_page_urls.py
+++ b/test_haystack/results_per_page_urls.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf.urls import url
 
 from haystack.views import SearchView

--- a/test_haystack/run_tests.py
+++ b/test_haystack/run_tests.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 from os.path import abspath, dirname
 

--- a/test_haystack/settings.py
+++ b/test_haystack/settings.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 from tempfile import mkdtemp
 
@@ -17,6 +14,7 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
+    "django.contrib.messages",
     "haystack",
     "test_haystack.discovery",
     "test_haystack.core",
@@ -36,7 +34,10 @@ TEMPLATES = [
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "APP_DIRS": True,
         "OPTIONS": {
-            "context_processors": ["django.contrib.auth.context_processors.auth"]
+            "context_processors": [
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ]
         },
     }
 ]

--- a/test_haystack/simple_tests/search_indexes.py
+++ b/test_haystack/simple_tests/search_indexes.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from haystack import indexes
 
 from ..core.models import MockModel, ScoreMockModel

--- a/test_haystack/simple_tests/test_simple_backend.py
+++ b/test_haystack/simple_tests/test_simple_backend.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from datetime import date
 
 from django.conf import settings

--- a/test_haystack/simple_tests/test_simple_query.py
+++ b/test_haystack/simple_tests/test_simple_query.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 
 from haystack import connections

--- a/test_haystack/solr_tests/server/get-solr-download-url.py
+++ b/test_haystack/solr_tests/server/get-solr-download-url.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 from itertools import chain
 

--- a/test_haystack/solr_tests/server/wait-for-solr
+++ b/test_haystack/solr_tests/server/wait-for-solr
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """Simple throttle to wait for Solr to start on busy test servers"""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import sys
 import time
 

--- a/test_haystack/solr_tests/test_admin.py
+++ b/test_haystack/solr_tests/test_admin.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase

--- a/test_haystack/solr_tests/test_inputs.py
+++ b/test_haystack/solr_tests/test_inputs.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 
 from haystack import connections, inputs

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 import logging as std_logging
 import os
 import unittest
 from decimal import Decimal
+from unittest.mock import patch
 
 import pysolr
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from mock import patch
 from pkg_resources import parse_version
 
 from haystack import connections, indexes, reset_search_queries

--- a/test_haystack/solr_tests/test_solr_management_commands.py
+++ b/test_haystack/solr_tests/test_solr_management_commands.py
@@ -1,10 +1,8 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 import os
 from tempfile import mkdtemp
+from unittest.mock import patch
 
 import pysolr
 from django.conf import settings
@@ -12,7 +10,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
-from mock import patch
 
 from haystack import connections, constants, indexes
 from haystack.utils.loading import UnifiedIndex

--- a/test_haystack/solr_tests/test_solr_query.py
+++ b/test_haystack/solr_tests/test_solr_query.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 from django.test import TestCase

--- a/test_haystack/solr_tests/test_templatetags.py
+++ b/test_haystack/solr_tests/test_templatetags.py
@@ -1,11 +1,9 @@
 # encoding: utf-8
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import unittest
+from unittest.mock import call, patch
 
 from django.template import Context, Template
 from django.test import TestCase
-from mock import call, patch
 
 from ..core.models import MockModel
 

--- a/test_haystack/spatial/__init__.py
+++ b/test_haystack/spatial/__init__.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from ..utils import check_solr
 
 

--- a/test_haystack/spatial/models.py
+++ b/test_haystack/spatial/models.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 from django.db import models

--- a/test_haystack/spatial/search_indexes.py
+++ b/test_haystack/spatial/search_indexes.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from haystack import indexes
 
 from .models import Checkin

--- a/test_haystack/spatial/test_spatial.py
+++ b/test_haystack/spatial/test_spatial.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.contrib.gis.measure import D
 from django.test import TestCase
 

--- a/test_haystack/test_altered_internal_names.py
+++ b/test_haystack/test_altered_internal_names.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf import settings
 from django.test import TestCase
 from test_haystack.core.models import AnotherMockModel, MockModel

--- a/test_haystack/test_app_loading.py
+++ b/test_haystack/test_app_loading.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from types import GeneratorType, ModuleType
 
 from django.test import TestCase

--- a/test_haystack/test_app_using_appconfig/__init__.py
+++ b/test_haystack/test_app_using_appconfig/__init__.py
@@ -1,5 +1,2 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 default_app_config = "test_app_using_appconfig.apps.SimpleTestAppConfig"

--- a/test_haystack/test_app_using_appconfig/apps.py
+++ b/test_haystack/test_app_using_appconfig/apps.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.apps import AppConfig
 
 

--- a/test_haystack/test_app_using_appconfig/migrations/0001_initial.py
+++ b/test_haystack/test_app_using_appconfig/migrations/0001_initial.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db import migrations, models
 
 

--- a/test_haystack/test_app_using_appconfig/models.py
+++ b/test_haystack/test_app_using_appconfig/models.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db.models import CharField, Model
 
 

--- a/test_haystack/test_app_using_appconfig/search_indexes.py
+++ b/test_haystack/test_app_using_appconfig/search_indexes.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from haystack import indexes
 
 from .models import MicroBlogPost

--- a/test_haystack/test_app_using_appconfig/tests.py
+++ b/test_haystack/test_app_using_appconfig/tests.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 
 from .models import MicroBlogPost

--- a/test_haystack/test_app_with_hierarchy/contrib/django/hierarchal_app_django/models.py
+++ b/test_haystack/test_app_with_hierarchy/contrib/django/hierarchal_app_django/models.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db.models import BooleanField, CharField, Model
 
 

--- a/test_haystack/test_app_without_models/urls.py
+++ b/test_haystack/test_app_without_models/urls.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf.urls import url
 
 from .views import simple_view

--- a/test_haystack/test_app_without_models/views.py
+++ b/test_haystack/test_app_without_models/views.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.http import HttpResponse
 
 

--- a/test_haystack/test_backends.py
+++ b/test_haystack/test_backends.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
 
 from django.core.exceptions import ImproperlyConfigured

--- a/test_haystack/test_discovery.py
+++ b/test_haystack/test_discovery.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 from test_haystack.discovery.search_indexes import FooIndex
 

--- a/test_haystack/test_fields.py
+++ b/test_haystack/test_fields.py
@@ -1,13 +1,10 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 from decimal import Decimal
+from unittest.mock import Mock
 
 from django.template import TemplateDoesNotExist
 from django.test import TestCase
-from mock import Mock
 from test_haystack.core.models import (
     ManyToManyLeftSideModel,
     ManyToManyRightSideModel,

--- a/test_haystack/test_forms.py
+++ b/test_haystack/test_forms.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 from test_haystack.core.models import AnotherMockModel, MockModel
 from test_haystack.test_views import (

--- a/test_haystack/test_generic_views.py
+++ b/test_haystack/test_generic_views.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test.client import RequestFactory
 from django.test.testcases import TestCase
 

--- a/test_haystack/test_indexes.py
+++ b/test_haystack/test_indexes.py
@@ -1,13 +1,10 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
+import queue
 import time
 from threading import Thread
 
 from django.test import TestCase
-from six.moves import queue
 from test_haystack.core.models import (
     AFifthMockModel,
     AnotherMockModel,

--- a/test_haystack/test_inputs.py
+++ b/test_haystack/test_inputs.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 
 from haystack import connections, inputs

--- a/test_haystack/test_loading.py
+++ b/test_haystack/test_loading.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import unittest
 
 from django.conf import settings

--- a/test_haystack/test_management_commands.py
+++ b/test_haystack/test_management_commands.py
@@ -1,11 +1,9 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from unittest.mock import call, patch
 
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
-from mock import call, patch
 
 __all__ = ["CoreManagementCommandsTestCase"]
 

--- a/test_haystack/test_managers.py
+++ b/test_haystack/test_managers.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 from django.contrib.gis.measure import D

--- a/test_haystack/test_models.py
+++ b/test_haystack/test_models.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import logging as std_logging
 import pickle
 
@@ -95,14 +92,14 @@ class SearchResultTestCase(TestCase):
 
     def test_unicode(self):
         self.assertEqual(
-            self.no_data_sr.__unicode__(), "<SearchResult: haystack.mockmodel (pk='1')>"
+            self.no_data_sr.__str__(), "<SearchResult: haystack.mockmodel (pk='1')>"
         )
         self.assertEqual(
-            self.extra_data_sr.__unicode__(),
+            self.extra_data_sr.__str__(),
             "<SearchResult: haystack.mockmodel (pk='1')>",
         )
         self.assertEqual(
-            self.no_overwrite_data_sr.__unicode__(),
+            self.no_overwrite_data_sr.__str__(),
             "<SearchResult: haystack.mockmodel (pk='1')>",
         )
 

--- a/test_haystack/test_query.py
+++ b/test_haystack/test_query.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 import unittest
 

--- a/test_haystack/test_templatetags.py
+++ b/test_haystack/test_templatetags.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.template import Context, Template

--- a/test_haystack/test_utils.py
+++ b/test_haystack/test_utils.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 from django.test.utils import override_settings
 from test_haystack.core.models import MockModel

--- a/test_haystack/test_views.py
+++ b/test_haystack/test_views.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+import queue
 import time
 from threading import Thread
 
@@ -9,7 +7,6 @@ from django import forms
 from django.http import HttpRequest, QueryDict
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from six.moves import queue
 from test_haystack.core.models import AnotherMockModel, MockModel
 
 from haystack import connections, indexes

--- a/test_haystack/utils.py
+++ b/test_haystack/utils.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import unittest
 
 from django.conf import settings

--- a/test_haystack/whoosh_tests/test_forms.py
+++ b/test_haystack/whoosh_tests/test_forms.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 """Tests for Whoosh spelling suggestions"""
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf import settings
 from django.http import HttpRequest
 

--- a/test_haystack/whoosh_tests/test_inputs.py
+++ b/test_haystack/whoosh_tests/test_inputs.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import TestCase
 
 from haystack import connections, inputs

--- a/test_haystack/whoosh_tests/test_whoosh_backend.py
+++ b/test_haystack/whoosh_tests/test_whoosh_backend.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import unittest
 from datetime import timedelta

--- a/test_haystack/whoosh_tests/test_whoosh_query.py
+++ b/test_haystack/whoosh_tests/test_whoosh_query.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 from haystack import connections

--- a/test_haystack/whoosh_tests/testcases.py
+++ b/test_haystack/whoosh_tests/testcases.py
@@ -1,7 +1,4 @@
 # encoding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import shutil
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,222 +1,26 @@
 [tox]
-envlist = docs,
-        py35-django1.11-es1.x,
-        py35-django2.0-es1.x,
-        py35-django2.1-es1.x,
-        pypy-django1.11-es1.x,
-        py35-django1.11-es2.x,
-        py35-django2.0-es2.x,
-        py35-django2.1-es2.x,
-        py36-django1.11-es2.x,
-        py36-django2.0-es2.x,
-        py36-django2.1-es2.x,
-        py37-django1.11-es2.x,
-        py37-django2.0-es2.x,
-        py37-django2.1-es2.x,
-        pypy-django1.11-es2.x,
-        py36-django1.11-es5.x,
-        py36-django2.0-es5.x,
-        py36-django2.1-es5.x,
-        py37-django1.11-es5.x,
-        py37-django2.0-es5.x,
-        py37-django2.1-es5.x,
-        pypy-django1.11-es5.x,
+envlist =
+    docs
+    py35-django2.2-es{1.x,2.x,5.x}
+    py{36,37,38,py}-django{2.2,3.0}-es{1.x,2.x,5.x}
 
-[base]
-deps = requests
-
-[django2.1]
-deps = Django>=2.1,<2.2
-
-[django2.0]
-deps =
-    Django>=2.0,<2.1
-
-[django1.11]
-deps =
-    Django>=1.11,<2.0
-
-[es5.x]
-deps =
-    elasticsearch>=5.0.0,<6.0.0
-
-[es2.x]
-deps =
-    elasticsearch>=2.0.0,<3.0.0
-
-[es1.x]
-deps =
-    elasticsearch>=1.0.0,<2.0.0
 
 [testenv]
 commands =
     python test_haystack/solr_tests/server/wait-for-solr
     python {toxinidir}/setup.py test
-
-[testenv:pypy-django1.11-es1.x]
-setenv = VERSION_ES=>=1.0.0,<2.0.0
 deps =
-    {[es1.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
+    requests
+    django2.2: Django>=2.2,<3.0
+    django3.0: Django>=3.0,<3.1
+    es1.x: elasticsearch>=1,<2
+    es2.x: elasticsearch>=2,<3
+    es5.x: elasticsearch>=5,<6
+setenv =
+    es1.x: VERSION_ES=>=1,<2
+    es2.x: VERSION_ES=>=2,<3
+    es5.x: VERSION_ES=>=5,<6
 
-[testenv:py35-django1.11-es1.x]
-basepython = python3.5
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[es1.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:py35-django2.0-es1.x]
-basepython = python3.5
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[es1.x]deps}
-    {[django2.0]deps}
-    {[base]deps}
-
-[testenv:py35-django2.1-es1.x]
-basepython = python3.5
-setenv = VERSION_ES=>=1.0.0,<2.0.0
-deps =
-    {[es1.x]deps}
-    {[django2.1]deps}
-    {[base]deps}
-
-[testenv:pypy-django1.11-es2.x]
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:py35-django1.11-es2.x]
-basepython = python3.5
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:py35-django2.0-es2.x]
-basepython = python3.5
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django2.0]deps}
-    {[base]deps}
-
-[testenv:py35-django2.1-es2.x]
-basepython = python3.5
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django2.1]deps}
-    {[base]deps}
-
-[testenv:py36-django1.11-es2.x]
-basepython = python3.6
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:py36-django2.0-es2.x]
-basepython = python3.6
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django2.0]deps}
-    {[base]deps}
-
-[testenv:py36-django2.1-es2.x]
-basepython = python3.6
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django2.1]deps}
-    {[base]deps}
-
-[testenv:py37-django1.11-es2.x]
-basepython = python3.7
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:py37-django2.0-es2.x]
-basepython = python3.7
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django2.0]deps}
-    {[base]deps}
-
-[testenv:py37-django2.1-es2.x]
-basepython = python3.7
-setenv = VERSION_ES=>=2.0.0,<3.0.0
-deps =
-    {[es2.x]deps}
-    {[django2.1]deps}
-    {[base]deps}
-
-[testenv:pypy-django1.11-es5.x]
-setenv = VERSION_ES=>=5.0.0,<6.0.0
-deps =
-    {[es5.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:py36-django1.11-es5.x]
-basepython = python3.6
-setenv = VERSION_ES=>=5.0.0,<6.0.0
-deps =
-    {[es5.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:py36-django2.0-es5.x]
-basepython = python3.6
-setenv = VERSION_ES=>=5.0.0,<6.0.0
-deps =
-    {[es5.x]deps}
-    {[django2.0]deps}
-    {[base]deps}
-
-[testenv:py36-django2.1-es5.x]
-basepython = python3.6
-setenv = VERSION_ES=>=5.0.0,<6.0.0
-deps =
-    {[es5.x]deps}
-    {[django2.1]deps}
-    {[base]deps}
-
-[testenv:py37-django1.11-es5.x]
-basepython = python3.7
-setenv = VERSION_ES=>=5.0.0,<6.0.0
-deps =
-    {[es5.x]deps}
-    {[django1.11]deps}
-    {[base]deps}
-
-[testenv:py37-django2.0-es5.x]
-basepython = python3.7
-setenv = VERSION_ES=>=5.0.0,<6.0.0
-deps =
-    {[es5.x]deps}
-    {[django2.0]deps}
-    {[base]deps}
-
-[testenv:py37-django2.1-es5.x]
-basepython = python3.7
-setenv = VERSION_ES=>=5.0.0,<6.0.0
-deps =
-    {[es5.x]deps}
-    {[django2.1]deps}
-    {[base]deps}
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
Hi there!

This PR does the following:

1. Drops support for Python 2 which is now end of life. This includes dropping all `__future__` imports and reliance on `six`, and replacing all Python 2 specific code (e.g., `__unicode__`) with the Python 3 equivalents (`__str__`).

2. Drops support for all versions of Django prior to version 2.2, [as recommended by the Django project](https://docs.djangoproject.com/en/3.0/releases/3.0/#third-party-library-support-for-older-version-of-django).

3. Adds support for Django 3.0.

4. Adds support for Python 3.8.

5. Substantially DRY out the `tox` configuration.