### PR TITLE
update_index:  Fix the backend in update_worker (trivial fix)

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -56,7 +56,7 @@ def update_worker(args):
     index = unified_index.get_index(model)
     backend = haystack_connections[using].get_backend()
 
-    qs = index.build_queryset(start_date=start_date, end_date=end_date)
+    qs = index.build_queryset(using=using, start_date=start_date, end_date=end_date)
     do_update(backend, index, qs, start, end, total, verbosity, commit, max_retries)
     return args
 


### PR DESCRIPTION
* [x] Tested with the latest Haystack release
* [x] Tested with the current Haystack master branch

## Expected behaviour

update_index must use the right backend when indexing with mutiple workers

## Actual behaviour

update_index use always the default backend when indexing with multiple workers even if there are mutiple backends.

## Configuration

* Operating system version: Debian/Buster
* Search engine version: EL 2.4.5
* Python version: 3.7
* Django version: 2.2.13
* Haystack version: 3.0b2 / 2.8.1