### PR TITLE
expose FaceDateField in haystack.indexes (regression)

### DIFF
--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -17,6 +17,7 @@ from haystack.fields import (  # NOQA — exposed as a public export
     DecimalField,
     EdgeNgramField,
     FacetCharField,
+    FacetDateField,
     FacetDateTimeField,
     FacetIntegerField,
     FloatField,


### PR DESCRIPTION
* [x] Tested with the latest Haystack release
* [x] Tested with the current Haystack master branch

This is a regression between v2.8.1 & v3.0b2

## Expected behaviour

FacetDateField must be exposed by haystack.indexes as before.

## Actual behaviour

FacetDateField is not exposed by haystack.indexes

## Configuration

* Operating system version: Debian/Buster
* Search engine version: EL 2.4.5
* Python version: 3.7
* Django version: 2.2.13
* Haystack version: 3.0b2