### PR TITLE
Whoosh official source has moved

### DIFF
--- a/docs/installing_search_engines.rst
+++ b/docs/installing_search_engines.rst
@@ -169,7 +169,7 @@ appropriate backend version — for example::
 Whoosh
 ======
 
-Official Download Location: http://bitbucket.org/mchaput/whoosh/
+Official Download Location: https://github.com/whoosh-community/whoosh
 
 Whoosh is pure Python, so it's a great option for getting started quickly and
 for development, though it does work for small scale live deployments. The


### PR DESCRIPTION
Official Whoosh source has moved to https://github.com/whoosh-community/whoosh

No change to source just documentation so no testing required.  