### PR TITLE
Fix Whoosh bitbucket link (404) with Github link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Elasticsearch_, Whoosh_, Xapian_, etc.) without having to modify your code.
 
 .. _Solr: http://lucene.apache.org/solr/
 .. _Elasticsearch: https://www.elastic.co/products/elasticsearch
-.. _Whoosh: https://bitbucket.org/mchaput/whoosh/
+.. _Whoosh: https://github.com/mchaput/whoosh/
 .. _Xapian: http://xapian.org/
 
 Haystack is BSD licensed, plays nicely with third-party app without needing to


### PR DESCRIPTION
## Fixing a broken link in the README.md

The original https://bitbucket.org/mchaput/whoosh/ is not available anymore, but the same user seems to have migrated it to Github, so just linking to that instead: https://github.com/mchaput/whoosh/
