### PR TITLE
Allow sorting for admin views

### DIFF
--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -30,6 +30,10 @@ class SearchChangeList(ChangeList):
             .load_all()
         )
 
+        ordering = self.model_admin.get_ordering(request)
+        if ordering:
+            qs = qs.order_by(*ordering)
+
         paginator = Paginator(sqs, self.list_per_page)
         # Get the number of objects, with admin filters applied.
         result_count = paginator.count
@@ -60,6 +64,9 @@ class SearchChangeList(ChangeList):
 class SearchModelAdminMixin(object):
     # haystack connection to use for searching
     haystack_connection = DEFAULT_ALIAS
+
+    def get_ordering(self, request):
+        return ()
 
     @csrf_protect_m
     def changelist_view(self, request, extra_context=None):
@@ -106,7 +113,7 @@ class SearchModelAdminMixin(object):
             "list_max_show_all": self.list_max_show_all,
             "model_admin": self,
         }
-        if hasattr(self, 'get_sortable_by'):  # Django 2.1+
+        if hasattr(self, "get_sortable_by"):  # Django 2.1+
             kwargs["sortable_by"] = self.get_sortable_by(request)
         changelist = SearchChangeList(**kwargs)
         changelist.formset = None

--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -66,7 +66,9 @@ class SearchModelAdminMixin(object):
     haystack_connection = DEFAULT_ALIAS
 
     def get_ordering(self, request):
-        return ()
+        if SEARCH_VAR in request.GET:
+            return ()
+        return super(SearchModelAdminMixin, self).get_ordering(request)
 
     @csrf_protect_m
     def changelist_view(self, request, extra_context=None):

--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -32,7 +32,7 @@ class SearchChangeList(ChangeList):
 
         ordering = self.model_admin.get_ordering(request)
         if ordering:
-            qs = qs.order_by(*ordering)
+            sqs = sqs.order_by(*ordering)
 
         paginator = Paginator(sqs, self.list_per_page)
         # Get the number of objects, with admin filters applied.

--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -30,7 +30,7 @@ class SearchChangeList(ChangeList):
             .load_all()
         )
 
-        ordering = self.model_admin.get_ordering(request)
+        ordering = self.get_ordering(request, sqs)
         if ordering:
             sqs = sqs.order_by(*ordering)
 


### PR DESCRIPTION
Hey,
the admin changelist in `SearchModelAdminMixin` previously did not allow to sort. With this change in `SearchQuerySet` this becomes possible.
Adding this without further changes would alter the behaviour for some users as the sqs is now sorted. 
To avoid this I modified `SearchModelAdminIndex.get_ordering` to not sort if a query is given. This is a bit of a hack, but should keep full backwards compatibility. Alternatively one could just drop this change.
Tested with Xapian.
Cheers, Martin