### PR TITLE
add GitHub Actions as CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Test
+
+on: [pull_request, push]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        django-version: [2.2, 3.1, 3.2]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        elastic-version: [1.7, 2.4, 5.5]
+        include:
+          - django-version: 2.2
+            python-version: 3.5
+            elastic-version: 1.7
+          - django-version: 2.2
+            python-version: 3.5
+            elastic-version: 2.4
+          - django-version: 2.2
+            python-version: 3.5
+            elastic-version: 5.5
+    services:
+      elastic:
+        image: elasticsearch:${{ matrix.elastic-version }}
+        ports:
+          - 9200:9200
+      solr:
+        image: solr:6
+        ports:
+          - 9001:9001
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install system dependencies
+      run: sudo apt install --no-install-recommends -y gdal-bin
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install codecov coverage requests
+        pip install django==${{ matrix.django-version }} elasticsearch==${{ matrix.elastic-version }}
+        python setup.py clean build install
+    - name: Run test
+      run: coverage run setup.py test
+

--- a/AUTHORS
+++ b/AUTHORS
@@ -118,3 +118,4 @@ Thanks to
     * João Junior (@joaojunior) and Bruno Marques (@ElSaico) for Elasticsearch 2.x support
     * Alex Tomkins (@tomkins) for various patches
     * Martin Pauly (@mpauly) for Django 2.0 support
+    * Dulmandakh Sukhbaatar (@dulmandakh) for GitHub Actions support


### PR DESCRIPTION
This PR adds GitHub Actions as CI, which will reduce CI time and improve developer experience. Added Django 3.2 and Python 3.9, also removed Django 3.0 which is EOL.

@acdha please review and merge