### PR TITLE
deprecate ES 1.x, 2.x support

### DIFF
--- a/haystack/backends/elasticsearch2_backend.py
+++ b/haystack/backends/elasticsearch2_backend.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+import warnings
 
 from django.conf import settings
 
@@ -19,6 +20,7 @@ try:
     if not ((2, 0, 0) <= elasticsearch.__version__ < (3, 0, 0)):
         raise ImportError
     from elasticsearch.helpers import bulk, scan
+    warnings.warn("ElasticSearch 2.x support deprecated, will be removed in 4.0", DeprecationWarning)
 except ImportError:
     raise MissingDependency(
         "The 'elasticsearch2' backend requires the \

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -26,6 +26,9 @@ from haystack.utils.app_loading import haystack_get_model
 try:
     import elasticsearch
 
+    if  (1, 0, 0) <= elasticsearch.__version__ < (2, 0, 0):
+        warnings.warn("ElasticSearch 1.x support deprecated, will be removed in 4.0", DeprecationWarning)
+
     try:
         # let's try this, for elasticsearch > 1.7.0
         from elasticsearch.helpers import bulk


### PR DESCRIPTION
I propose to deprecate ES 1.x (EOL 2017-01-16) and 2.x (EOL 2018-02-28) support, and remove it in next major version. Please see https://www.elastic.co/support/eol. Also I would like to work to add support for 7.x.