### PR TITLE
ci: build docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Build docs
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: pip install sphinx
+    - name: Build docs
+      run: cd docs && make html


### PR DESCRIPTION
Make sure that docs build successfully. We can even deploy to static site hosting providers like Netlify for preview.