### PR TITLE
List elasticsearch as an optional dependency

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -72,6 +72,9 @@ Example::
 
     pip install django-haystack
 
+When using elasticsearch, use::
+
+    pip install "django-haystack[elasticsearch]"
 
 Configuration
 =============

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,8 @@ setup(
     zip_safe=False,
     install_requires=install_requires,
     tests_require=tests_require,
+    extras_require={
+        "elasticsearch": ["elasticsearch>=5,<6"],
+    },
     test_suite="test_haystack.run_tests.run_all",
 )


### PR DESCRIPTION
Currently, if someone follows the tutorial using elasticsearch, they'll
end up with a broken setup that does not work. The error will indicate
that an additional, unlisted, dependency is required.

Upon installing `elasticsearch`, there's still some very unclear errors.
After digging through issues and the documentation, it turns out that a
**specific** version of the package is required.

This changeset lists `elasticsearch` as an extra ("optional")
dependency, and mentions it in the tutorial. This should make life a bit
easier for new users.