### PR TITLE
Support queryset.models() for Elasticsearch 5

### DIFF
--- a/haystack/backends/elasticsearch5_backend.py
+++ b/haystack/backends/elasticsearch5_backend.py
@@ -258,6 +258,23 @@ class Elasticsearch5SearchBackend(ElasticsearchSearchBackend):
                     "filter": {"query_string": {"query": value}},
                 }
 
+        if limit_to_registered_models is None:
+            limit_to_registered_models = getattr(
+                settings, "HAYSTACK_LIMIT_TO_REGISTERED_MODELS", True
+            )
+
+        if models and len(models):
+            model_choices = sorted(get_model_ct(model) for model in models)
+        elif limit_to_registered_models:
+            # Using narrow queries, limit the results to only models handled
+            # with the current routers.
+            model_choices = self.build_models_list()
+        else:
+            model_choices = []
+
+        if len(model_choices) > 0:
+            filters.append({"terms": {DJANGO_CT: model_choices}})
+
         for q in narrow_queries:
             filters.append({"query_string": {"query": q}})
 


### PR DESCRIPTION
`search_queryset.models(User)` does not work with Elasticsearch 5; just copied lines of code from `haystack/backends/elasticsearch_backend.py` to haystack/backends/elasticsearch5_backend.py`.