### PR TITLE
Allow per-field configuration of Whoosh analyzers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -120,3 +120,4 @@ Thanks to
     * Martin Pauly (@mpauly) for Django 2.0 support
     * Ryan Jarvis (@cabalist) for some code cleanup
     * Dulmandakh Sukhbaatar (@dulmandakh) for GitHub Actions support, and flake8, black, isort checks.
+    * Deniz Dogan (@denizdogan) for adding support for the ``analyzer`` parameter for the Whoosh backend

--- a/docs/backend_support.rst
+++ b/docs/backend_support.rst
@@ -64,6 +64,7 @@ Whoosh
 * Stored (non-indexed) fields
 * Highlighting
 * Requires: whoosh (2.0.0+)
+* Per-field analyzers
 
 Xapian
 ------

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -226,7 +226,7 @@ class WhooshSearchBackend(BaseSearchBackend):
             else:
                 schema_fields[field_class.index_fieldname] = TEXT(
                     stored=True,
-                    analyzer=StemmingAnalyzer(),
+                    analyzer=field_class.analyzer,
                     field_boost=field_class.boost,
                     sortable=True,
                 )

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -3,6 +3,7 @@ from inspect import ismethod
 
 from django.template import loader
 from django.utils import datetime_safe
+from whoosh import analysis
 
 from haystack.exceptions import SearchFieldError
 from haystack.utils import get_model_ct_tuple
@@ -45,6 +46,7 @@ class SearchField(object):
         facet_class=None,
         boost=1.0,
         weight=None,
+        analyzer=NOT_PROVIDED,
     ):
         # Track what the index thinks this field is called.
         self.instance_name = None
@@ -59,6 +61,7 @@ class SearchField(object):
         self.null = null
         self.index_fieldname = index_fieldname
         self.boost = weight or boost
+        self._analyzer = analyzer
         self.is_multivalued = False
 
         # We supply the facet_class for making it easy to create a faceted
@@ -69,6 +72,12 @@ class SearchField(object):
             self.facet_class = FacetCharField
 
         self.set_instance_name(None)
+
+    @property
+    def analyzer(self):
+        if self._analyzer is NOT_PROVIDED:
+            return None
+        return self._analyzer
 
     def set_instance_name(self, instance_name):
         self.instance_name = instance_name
@@ -224,9 +233,12 @@ class SearchField(object):
 class CharField(SearchField):
     field_type = "string"
 
-    def __init__(self, **kwargs):
+    def __init__(self, analyzer=NOT_PROVIDED, **kwargs):
         if kwargs.get("facet_class") is None:
             kwargs["facet_class"] = FacetCharField
+
+        # use StemmingAnalyzer by default
+        kwargs["analyzer"] = analysis.StemmingAnalyzer() if analyzer is NOT_PROVIDED else analyzer
 
         super().__init__(**kwargs)
 

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -238,7 +238,9 @@ class CharField(SearchField):
             kwargs["facet_class"] = FacetCharField
 
         # use StemmingAnalyzer by default
-        kwargs["analyzer"] = analysis.StemmingAnalyzer() if analyzer is NOT_PROVIDED else analyzer
+        kwargs["analyzer"] = (
+            analysis.StemmingAnalyzer() if analyzer is NOT_PROVIDED else analyzer
+        )
 
         super().__init__(**kwargs)
 

--- a/test_haystack/whoosh_tests/test_whoosh_backend.py
+++ b/test_haystack/whoosh_tests/test_whoosh_backend.py
@@ -29,7 +29,7 @@ class WhooshMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
     pub_date = indexes.DateTimeField(model_attr="pub_date")
     name_analyzed = indexes.CharField(
         model_attr="author",
-        analyzer=SpaceSeparatedTokenizer() | SubstitutionFilter(r"\d+", "")
+        analyzer=SpaceSeparatedTokenizer() | SubstitutionFilter(r"\d+", ""),
     )
 
     def get_model(self):

--- a/test_haystack/whoosh_tests/test_whoosh_backend.py
+++ b/test_haystack/whoosh_tests/test_whoosh_backend.py
@@ -18,9 +18,9 @@ from haystack.models import SearchResult
 from haystack.query import SQ, SearchQuerySet
 from haystack.utils.loading import UnifiedIndex
 
-from test_haystack.core.models import AFourthMockModel, AnotherMockModel, MockModel
-from test_haystack.mocks import MockSearchResult
-from test_haystack.whoosh_tests.testcases import WhooshTestCase
+from ..core.models import AFourthMockModel, AnotherMockModel, MockModel
+from ..mocks import MockSearchResult
+from .testcases import WhooshTestCase
 
 
 class WhooshMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
@@ -757,9 +757,9 @@ class WhooshSearchBackendTestCase(WhooshTestCase):
             ["0.40", "0.40", "0.40"],
         )
 
-    def test_analyzed_fields(self):  # TODO: rename to test_analyzed_fields
+    def test_analyzed_fields(self):
         self.sb.update(self.wmmi, self.sample_objs)
-        results = self.whoosh_search("name_analyzed:daniel")
+        results = self.whoosh_search("name_analyzed:1234daniel5678")
         self.assertEqual(len(results), 23)
 
 


### PR DESCRIPTION
Add a keyword argument, `analyzer`, for Whoosh fields to specify the analyzer for that field.

The default behavior remains the same, defaulting to `StemmingAnalyzer()` as the only analyzer. That's a default that I'm very keen on changing, but it's out of scope for this PR. (Issue #327)

I had a hard time figuring out how the unit tests were related, but I think I managed to add one in the right place. I decided to add an analyzed field for the authors in the bulk data file, which uses a regular expression to remove the digits from the names. In other words, daniel1, daniel2, and daniel3 are indexed as just "daniel".

Replaces PR's #452, #1037, and #1584. @acdha, if you find the time to look at this, please let me know what your thoughts are. This issue is pretty much a blocker for the project that I'm currently working on. Many thanks!