### PR TITLE
Whoosh backend: join `AsyncWriter`s when they spawn threads

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -284,6 +284,8 @@ class WhooshSearchBackend(BaseSearchBackend):
         if len(iterable) > 0:
             # For now, commit no matter what, as we run into locking issues otherwise.
             writer.commit()
+            if writer.ident is not None:
+                writer.join()
 
     def remove(self, obj_or_string, commit=True):
         if not self.setup_complete:


### PR DESCRIPTION
`whoosh.writing.AsyncWriter` has two behaviors, depending on whether
or not it succeeds at getting a write lock on the index when it is
initialized.

If it succeeds in getting the lock, it behaves as if it were
essentially `whoosh.writing.IndexWriter`.

If it fails to the get the lock, it buffers the writes, and on
`commit()` it spawns a thread to loop on trying to get the lock and
make the necessary writes.

In the latter case, a thread is left un`join()`ed, and may cause data
loss if the process exits before the thread can finish. This is
causing data loss in update_index with --workers > 1.

`woosh.writing.AsyncWriter` is also a vanilla python
`threading.Thread`, and we can tell if it has been started if
`writer.ident` is not None. If that's the case, we should `join()` it
to prevent writing a partial index.

Fixes #1792