### PR TITLE
Fix Elasticsearch 5 test broken in #1788

### DIFF
--- a/test_haystack/elasticsearch5_tests/test_query.py
+++ b/test_haystack/elasticsearch5_tests/test_query.py
@@ -191,7 +191,7 @@ class Elasticsearch5SearchQueryTestCase(TestCase):
             },
         )
         self.assertEqual(
-            search_kwargs["query"]["bool"]["filter"]["geo_distance"],
+            search_kwargs["query"]["bool"]["filter"]["bool"]["must"][1]["geo_distance"],
             {
                 "distance": "0.500000km",
                 "location_field": {"lat": 2.3456789, "lon": 1.2345678},


### PR DESCRIPTION
Adding model restrictions changed the form of the query. This copies over the expected form from older Elasticsearch tests, adjusting for changes in Elasticsearch.
