### PR TITLE
Test updates

### DIFF
--- a/test_haystack/test_managers.py
+++ b/test_haystack/test_managers.py
@@ -1,6 +1,8 @@
 import datetime
+import unittest
 
 from django.contrib.gis.measure import D
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
 from haystack import connections
@@ -16,6 +18,13 @@ from test_haystack.core.models import MockModel
 
 from .mocks import CharPKMockSearchBackend
 from .test_views import BasicAnotherMockModelSearchIndex, BasicMockModelSearchIndex
+
+try:
+    from django.contrib.gis.geos import Point
+
+    HAVE_GDAL = True
+except ImproperlyConfigured:
+    HAVE_GDAL = False
 
 
 class CustomManager(SearchIndexManager):
@@ -80,9 +89,8 @@ class ManagerTestCase(TestCase):
         self.assertTrue(isinstance(sqs, SearchQuerySet))
         self.assertTrue("foo" in sqs.query.order_by)
 
+    @unittest.skipUnless(HAVE_GDAL, "Requires gdal library")
     def test_order_by_distance(self):
-        from django.contrib.gis.geos import Point
-
         p = Point(1.23, 4.56)
         sqs = self.search_index.objects.distance("location", p).order_by("distance")
         self.assertTrue(isinstance(sqs, SearchQuerySet))
@@ -111,9 +119,8 @@ class ManagerTestCase(TestCase):
         self.assertTrue(isinstance(sqs, SearchQuerySet))
         self.assertEqual(len(sqs.query.facets), 1)
 
+    @unittest.skipUnless(HAVE_GDAL, "Requires gdal library")
     def test_within(self):
-        from django.contrib.gis.geos import Point
-
         # This is a meaningless query but we're just confirming that the manager updates the parameters here:
         p1 = Point(-90, -90)
         p2 = Point(90, 90)
@@ -127,9 +134,8 @@ class ManagerTestCase(TestCase):
             params["within"], {"field": "location", "point_1": p1, "point_2": p2}
         )
 
+    @unittest.skipUnless(HAVE_GDAL, "Requires gdal library")
     def test_dwithin(self):
-        from django.contrib.gis.geos import Point
-
         p = Point(0, 0)
         distance = D(mi=500)
         sqs = self.search_index.objects.dwithin("location", p, distance)
@@ -142,9 +148,8 @@ class ManagerTestCase(TestCase):
             params["dwithin"], {"field": "location", "point": p, "distance": distance}
         )
 
+    @unittest.skipUnless(HAVE_GDAL, "Requires gdal library")
     def test_distance(self):
-        from django.contrib.gis.geos import Point
-
         p = Point(0, 0)
         sqs = self.search_index.objects.distance("location", p)
         self.assertTrue(isinstance(sqs, SearchQuerySet))

--- a/test_haystack/whoosh_tests/test_whoosh_management_commands.py
+++ b/test_haystack/whoosh_tests/test_whoosh_management_commands.py
@@ -1,0 +1,111 @@
+import datetime
+import os
+import unittest
+from io import StringIO
+from tempfile import mkdtemp
+from unittest.mock import patch
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management import call_command as real_call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from whoosh.qparser import QueryParser
+
+from haystack import connections, constants, indexes
+from haystack.utils.loading import UnifiedIndex
+
+from ..core.models import MockModel
+from .test_whoosh_backend import WhooshMockSearchIndex
+from .testcases import WhooshTestCase
+
+
+def call_command(*args, **kwargs):
+    kwargs["using"] = ["whoosh"]
+    print(args, kwargs)
+    real_call_command(*args, **kwargs)
+
+
+class ManagementCommandTestCase(WhooshTestCase):
+    fixtures = ["bulk_data"]
+
+    def setUp(self):
+        super().setUp()
+
+        self.old_ui = connections["whoosh"].get_unified_index()
+        self.ui = UnifiedIndex()
+        self.wmmi = WhooshMockSearchIndex()
+        self.ui.build(indexes=[self.wmmi])
+        self.sb = connections["whoosh"].get_backend()
+        connections["whoosh"]._index = self.ui
+
+        self.sb.setup()
+        self.raw_whoosh = self.sb.index
+        self.parser = QueryParser(self.sb.content_field_name, schema=self.sb.schema)
+        self.sb.delete_index()
+
+        self.sample_objs = MockModel.objects.all()
+
+    def tearDown(self):
+        connections["whoosh"]._index = self.old_ui
+        super().tearDown()
+
+    def verify_indexed_document_count(self, expected):
+        with self.raw_whoosh.searcher() as searcher:
+            count = searcher.doc_count()
+            self.assertEqual(count, expected)
+
+    def verify_indexed_documents(self):
+        """Confirm that the documents in the search index match the database"""
+
+        with self.raw_whoosh.searcher() as searcher:
+            count = searcher.doc_count()
+            self.assertEqual(count, 23)
+
+            indexed_doc_ids = set(i["id"] for i in searcher.documents())
+            expected_doc_ids = set(
+                "core.mockmodel.%d" % i
+                for i in MockModel.objects.values_list("pk", flat=True)
+            )
+            self.assertSetEqual(indexed_doc_ids, expected_doc_ids)
+
+    def test_basic_commands(self):
+        call_command("clear_index", interactive=False, verbosity=0)
+        self.verify_indexed_document_count(0)
+
+        call_command("update_index", verbosity=0)
+        self.verify_indexed_documents()
+
+        call_command("clear_index", interactive=False, verbosity=0)
+        self.verify_indexed_document_count(0)
+
+        call_command("rebuild_index", interactive=False, verbosity=0)
+        self.verify_indexed_documents()
+
+    def test_remove(self):
+        call_command("clear_index", interactive=False, verbosity=0)
+        self.verify_indexed_document_count(0)
+
+        call_command("update_index", verbosity=0)
+        self.verify_indexed_documents()
+
+        # Remove several instances.
+        MockModel.objects.get(pk=1).delete()
+        MockModel.objects.get(pk=2).delete()
+        MockModel.objects.get(pk=8).delete()
+        self.verify_indexed_document_count(23)
+
+        # Plain ``update_index`` doesn't fix it.
+        call_command("update_index", verbosity=0)
+        self.verify_indexed_document_count(23)
+
+        # … but remove does:
+        call_command("update_index", remove=True, verbosity=0)
+        self.verify_indexed_document_count(20)
+
+    def test_multiprocessing(self):
+        call_command("clear_index", interactive=False, verbosity=0)
+        self.verify_indexed_document_count(0)
+
+        call_command("update_index", verbosity=2, workers=2, batchsize=5)
+        self.verify_indexed_documents()


### PR DESCRIPTION
Two commits here so far:
1) skipping tests that require gdal when it's not available
2) tests for #1792 / #1793 regressions and some other management commands against whoosh, ported over from solr test suite.