### PR TITLE
Fix admin search_fields

### DIFF
--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -41,7 +41,7 @@ class SearchChangeList(ChangeList):
 
         # Get the list of objects to display on this page.
         try:
-            result_list = paginator.page(self.page_num + 1).object_list
+            result_list = paginator.page(self.page_num).object_list
             # Grab just the Django models, since that's what everything else is
             # expecting.
             result_list = [result.object for result in result_list]


### PR DESCRIPTION
Hello!

Using django admin and haystack for filtering, I noticed a bug with the returned query : haystack try to display all elements of the n+1 page, not the n page.

This bug was silent and a bit tricky because the list displays correctly that the "n-th page" is selected, although haystack return the element of the "n+1-th page".

It is particularly noticeable when the search query return only 1 result, but none pop ups in the list (correctly saying that 1 result was found by the way...).

Here the fix. A simple `page_num + 1` replaced by `page_num`.

It is related to old issue I guess: #1373 

