### PR TITLE
Fix issue duplicate-test-names found at https://codereview.doctor

### DIFF
--- a/test_haystack/test_management_commands.py
+++ b/test_haystack/test_management_commands.py
@@ -92,7 +92,7 @@ class CoreManagementCommandsTestCase(TestCase):
 
     @patch("haystack.management.commands.clear_index.Command.handle", return_value="")
     @patch("haystack.management.commands.update_index.Command.handle", return_value="")
-    def test_rebuild_index_nocommit(self, update_mock, clear_mock):
+    def test_rebuild_index_nocommit_two(self, update_mock, clear_mock):
         """
         Confirm that command-line option parsing produces the same results as using call_command() directly,
         mostly as a sanity check for the logic in rebuild_index which combines the option_lists for its


### PR DESCRIPTION
Fixes #1840

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.
