### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,10 @@ setup(
     author_email="daniel@toastdriven.com",
     long_description=open("README.rst", "r").read(),
     url="http://haystacksearch.org/",
+    project_urls={
+        "Documentation": "https://django-haystack.readthedocs.io",
+        "Source": "https://github.com/django-haystack/django-haystack",
+    },
     packages=[
         "haystack",
         "haystack.backends",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)