### PR TITLE
Fix deprecated default_app_config warning.

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -18,7 +18,7 @@ except DistributionNotFound:
 
 
 if django.VERSION < (3, 2):
-    # default_app_config is deprecated since django 3.2. 
+    # default_app_config is deprecated since django 3.2.
     default_app_config = "haystack.apps.HaystackConfig"
 
 

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -1,3 +1,4 @@
+import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from pkg_resources import DistributionNotFound, get_distribution, parse_version
@@ -15,7 +16,10 @@ except DistributionNotFound:
     __version__ = "0.0.dev0"
     version_info = parse_version(__version__)
 
-default_app_config = "haystack.apps.HaystackConfig"
+
+if django.VERSION < (3, 2):
+    # default_app_config is deprecated since django 3.2. 
+    default_app_config = "haystack.apps.HaystackConfig"
 
 
 # Help people clean up from 1.X.

--- a/test_haystack/test_django_config_detection.py
+++ b/test_haystack/test_django_config_detection.py
@@ -1,19 +1,24 @@
 """"""
-from django.test import TestCase
 import unittest
+
 import django
+from django.test import TestCase
 
 import haystack
 
 
 class AppConfigCompatibilityTestCase(TestCase):
-    @unittest.skipIf(django.VERSION >= (3, 2), "default_app_config is deprecated since django 3.2.")
+    @unittest.skipIf(
+        django.VERSION >= (3, 2), "default_app_config is deprecated since django 3.2."
+    )
     def testDefaultAppConfigIsDefined_whenDjangoVersionIsLessThan3_2(self):
-        has_default_appconfig_attr =  hasattr(haystack, "default_app_config")
+        has_default_appconfig_attr = hasattr(haystack, "default_app_config")
         self.assertTrue(has_default_appconfig_attr)
 
-    @unittest.skipIf(django.VERSION < (3, 2), "default_app_config should be used in versions prior to django 3.2.")
+    @unittest.skipIf(
+        django.VERSION < (3, 2),
+        "default_app_config should be used in versions prior to django 3.2.",
+    )
     def testDefaultAppConfigIsDefined_whenDjangoVersionIsMoreThan3_2(self):
-        has_default_appconfig_attr =  hasattr(haystack, "default_app_config")
+        has_default_appconfig_attr = hasattr(haystack, "default_app_config")
         self.assertFalse(has_default_appconfig_attr)
-

--- a/test_haystack/test_django_config_detection.py
+++ b/test_haystack/test_django_config_detection.py
@@ -1,0 +1,19 @@
+""""""
+from django.test import TestCase
+import unittest
+import django
+
+import haystack
+
+
+class AppConfigCompatibilityTestCase(TestCase):
+    @unittest.skipIf(django.VERSION >= (3, 2), "default_app_config is deprecated since django 3.2.")
+    def testDefaultAppConfigIsDefined_whenDjangoVersionIsLessThan3_2(self):
+        has_default_appconfig_attr =  hasattr(haystack, "default_app_config")
+        self.assertTrue(has_default_appconfig_attr)
+
+    @unittest.skipIf(django.VERSION < (3, 2), "default_app_config should be used in versions prior to django 3.2.")
+    def testDefaultAppConfigIsDefined_whenDjangoVersionIsMoreThan3_2(self):
+        has_default_appconfig_attr =  hasattr(haystack, "default_app_config")
+        self.assertFalse(has_default_appconfig_attr)
+


### PR DESCRIPTION
This PR is a fix for [issue](https://github.com/django-haystack/django-haystack/issues/1844)

## The problem:
Running pytest in a django3.2 application that uses django-haystack generates a RemovedInDjango41Warning warning.

## The fix:
Checks for the current django version, & if more than django3.2 : remove the "default_app_config" option.
