### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/searchindex_api.rst
+++ b/docs/searchindex_api.rst
@@ -352,7 +352,7 @@ non-existent), merely an example of how to extend existing fields.
 
 .. note::
 
-   This method is analagous to Django's ``Field.clean`` methods.
+   This method is analogous to Django's ``Field.clean`` methods.
 
 
 Adding New Fields

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -305,7 +305,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 for model in models:
                     models_to_delete.append("%s:%s" % (DJANGO_CT, get_model_ct(model)))
 
-                # Delete by query in Elasticsearch asssumes you're dealing with
+                # Delete by query in Elasticsearch assumes you're dealing with
                 # a ``query`` root object. :/
                 query = {
                     "query": {"query_string": {"query": " OR ".join(models_to_delete)}}
@@ -971,7 +971,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
                 if value.input_type_name == "exact":
                     query_frag = prepared_value
                 else:
-                    # Iterate over terms & incorportate the converted form of each into the query.
+                    # Iterate over terms & incorporate the converted form of each into the query.
                     terms = []
 
                     if isinstance(prepared_value, str):

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -819,7 +819,7 @@ class SolrSearchQuery(BaseSearchQuery):
                 if value.input_type_name == "exact":
                     query_frag = prepared_value
                 else:
-                    # Iterate over terms & incorportate the converted form of each into the query.
+                    # Iterate over terms & incorporate the converted form of each into the query.
                     terms = []
 
                     for possible_value in prepared_value.split(" "):

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -1019,7 +1019,7 @@ class WhooshSearchQuery(BaseSearchQuery):
                 if value.input_type_name == "exact":
                     query_frag = prepared_value
                 else:
-                    # Iterate over terms & incorportate the converted form of each into the query.
+                    # Iterate over terms & incorporate the converted form of each into the query.
                     terms = []
 
                     if isinstance(prepared_value, str):


### PR DESCRIPTION
There are small typos in:
- docs/searchindex_api.rst
- haystack/backends/elasticsearch_backend.py
- haystack/backends/solr_backend.py
- haystack/backends/whoosh_backend.py

Fixes:
- Should read `incorporate` rather than `incorportate`.
- Should read `assumes` rather than `asssumes`.
- Should read `analogous` rather than `analagous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md