### PR TITLE
feat: add optional ending open-ended range to rance facet query result

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,3 +125,4 @@ Thanks to
     * Jens Kadenbach (audax) for updating and testing Whoosh faceting support
     * Alejandro Sedeño (asedeno) trying the Whoosh faceting thing again
     * Fábio Piovam (fabiopiovam) for date_facet on Solr 6.6+
+    * Julie Rymer (Chadys) for adding open-ended range to range facet result

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -502,6 +502,11 @@ class SolrSearchBackend(BaseSearchBackend):
 
             for key in ["ranges"]:
                 for facet_field in facets[key]:
+                    # keep track of optional open-ended range result
+                    ending_range = (
+                        facets[key][facet_field].get("end"),
+                        facets[key][facet_field].get("after"),
+                    )
                     # Convert to a two-tuple, as Solr's json format returns a list of
                     # pairs.
                     facets[key][facet_field] = list(
@@ -510,6 +515,8 @@ class SolrSearchBackend(BaseSearchBackend):
                             facets[key][facet_field]["counts"][1::2],
                         )
                     )
+                    if all(value is not None for value in ending_range):
+                        facets[key][facet_field].append(ending_range)
 
         if self.include_spelling and hasattr(raw_results, "spellcheck"):
             try:


### PR DESCRIPTION
Fix upper bounds issue described in #1857