### PR TITLE
update index

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -323,6 +323,19 @@ class Command(BaseCommand):
 
             total = qs.count()
 
+            # Stores the id of the valid instances, to eventually use in remove.
+            valid_pks = None
+            if self.remove:
+                if self.start_date or self.end_date or total <= 0:
+                    # They're using a reduced set, which may not incorporate
+                    # all pks. Rebuild the list with everything.
+                    remove_qs = index.index_queryset(using=using).values_list("pk", flat=True)
+                    valid_pks = {smart_bytes(pk) for pk in remove_qs}
+                else:
+                    valid_pks = {
+                        smart_bytes(pk) for pk in qs.values_list("pk", flat=True)
+                    }
+
             if self.verbosity >= 1:
                 self.stdout.write(
                     "Indexing %d %s"
@@ -385,16 +398,6 @@ class Command(BaseCommand):
                 pool.join()
 
             if self.remove:
-                if self.start_date or self.end_date or total <= 0:
-                    # They're using a reduced set, which may not incorporate
-                    # all pks. Rebuild the list with everything.
-                    qs = index.index_queryset(using=using).values_list("pk", flat=True)
-                    database_pks = {smart_bytes(pk) for pk in qs}
-                else:
-                    database_pks = {
-                        smart_bytes(pk) for pk in qs.values_list("pk", flat=True)
-                    }
-
                 # Since records may still be in the search index but not the local database
                 # we'll use that to create batches for processing.
                 # See https://github.com/django-haystack/django-haystack/issues/1186
@@ -420,7 +423,7 @@ class Command(BaseCommand):
 
                     # If the database pk is no longer present, queue the index key for removal:
                     for pk, rec_id in index_pks[start:upper_bound]:
-                        if smart_bytes(pk) not in database_pks:
+                        if smart_bytes(pk) not in valid_pks:
                             stale_records.add(rec_id)
 
                 if stale_records:

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -329,7 +329,9 @@ class Command(BaseCommand):
                 if self.start_date or self.end_date or total <= 0:
                     # They're using a reduced set, which may not incorporate
                     # all pks. Rebuild the list with everything.
-                    remove_qs = index.index_queryset(using=using).values_list("pk", flat=True)
+                    remove_qs = index.index_queryset(using=using).values_list(
+                        "pk", flat=True
+                    )
                     valid_pks = {smart_bytes(pk) for pk in remove_qs}
                 else:
                     valid_pks = {


### PR DESCRIPTION
With the multiprocessing enabled (-k) the queryset connection can be not valid after the workers ended their job.
So I calculate the list of valid pks, before the execution of the update.


# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://github.com/django-haystack/django-haystack/actions/workflows/test.yml. Pull requests with passing tests are far more likely to be reviewed and merged.
