### PR TITLE
docs: use ‘stable’ tag in Django URLs | fix outdated URLs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -900,7 +900,7 @@ Other
   Add python 3.5 to tests
 - Add python 3.5 to tests. [Marco Badan]
 
-  ref: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django
+  ref: https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
 - SearchQuerySet: don’t trigger backend access in __repr__ [Chris Adams]
 
   This can lead to confusing errors or performance issues by

--- a/docs/python3.rst
+++ b/docs/python3.rst
@@ -15,7 +15,7 @@ Virtually all tests pass under both Python 2 & 3, with a small number of
 expected failures under Python (typically related to ordering, see below).
 
 .. _`six`: http://pythonhosted.org/six/
-.. _`Django`: https://docs.djangoproject.com/en/1.5/topics/python3/#str-and-unicode-methods
+.. _`Django`: https://docs.djangoproject.com/en/stable/topics/python3/#str-and-unicode-methods
 
 
 Supported Backends

--- a/docs/running_tests.rst
+++ b/docs/running_tests.rst
@@ -67,4 +67,4 @@ If you want to run the geo-django tests you may need to review the
 	cd test_haystack
 	./run_tests.py elasticsearch_tests
 
-.. _GeoDjango GEOS and GDAL settings: https://docs.djangoproject.com/en/1.7/ref/contrib/gis/install/geolibs/#geos-library-path
+.. _GeoDjango GEOS and GDAL settings: https://docs.djangoproject.com/en/stable/ref/contrib/gis/install/geolibs/#geos-library-path

--- a/docs/spatial.rst
+++ b/docs/spatial.rst
@@ -14,7 +14,7 @@ close to GeoDjango_ as possible. There are some differences, which we'll
 highlight throughout this guide. Additionally, while the support isn't as
 comprehensive as PostGIS (for example), it is still quite useful.
 
-.. _GeoDjango: https://docs.djangoproject.com/en/1.11/ref/contrib/gis/
+.. _GeoDjango: https://docs.djangoproject.com/en/stable/ref/contrib/gis/
 
 
 Additional Requirements

--- a/docs/views_and_forms.rst
+++ b/docs/views_and_forms.rst
@@ -11,7 +11,7 @@ Views & Forms
     which use the standard Django `class-based views`_ which are available in
     every version of Django which is supported by Haystack.
 
-.. _class-based views: https://docs.djangoproject.com/en/1.7/topics/class-based-views/
+.. _class-based views: https://docs.djangoproject.com/en/stable/topics/class-based-views/
 
 Haystack comes with some default, simple views & forms as well as some
 django-style views to help you get started and to cover the common cases.
@@ -137,7 +137,7 @@ Views
     which use the standard Django `class-based views`_ which are available in
     every version of Django which is supported by Haystack.
 
-.. _class-based views: https://docs.djangoproject.com/en/1.7/topics/class-based-views/
+.. _class-based views: https://docs.djangoproject.com/en/stable/topics/class-based-views/
 
 New Django Class Based Views
 ----------------------------
@@ -145,7 +145,7 @@ New Django Class Based Views
  .. versionadded:: 2.4.0
 
 The views in ``haystack.generic_views.SearchView`` inherit from Django’s standard
-`FormView <https://docs.djangoproject.com/en/1.7/ref/class-based-views/generic-editing/#formview>`_.
+`FormView <https://docs.djangoproject.com/en/stable/ref/class-based-views/generic-editing/#formview>`_.
 The example views can be customized like any other Django class-based view as
 demonstrated in this example which filters the search results in ``get_queryset``::
 
@@ -232,9 +232,9 @@ preprocess the values returned by Haystack, that code would move to ``get_contex
 | ``get_query()``       | `get_queryset()`_                         |
 +-----------------------+-------------------------------------------+
 
-.. _get_context_data(): https://docs.djangoproject.com/en/1.7/ref/class-based-views/mixins-simple/#django.views.generic.base.ContextMixin.get_context_data
-.. _dispatch(): https://docs.djangoproject.com/en/1.7/ref/class-based-views/base/#django.views.generic.base.View.dispatch
-.. _get_queryset(): https://docs.djangoproject.com/en/1.7/ref/class-based-views/mixins-multiple-object/#django.views.generic.list.MultipleObjectMixin.get_queryset
+.. _get_context_data(): https://docs.djangoproject.com/en/stable/ref/class-based-views/mixins-simple/#django.views.generic.base.ContextMixin.get_context_data
+.. _dispatch(): https://docs.djangoproject.com/en/stable/ref/class-based-views/base/#django.views.generic.base.View.dispatch
+.. _get_queryset(): https://docs.djangoproject.com/en/stable/ref/class-based-views/mixins-multiple-object/#django.views.generic.list.MultipleObjectMixin.get_queryset
 
 
 Old-Style Views


### PR DESCRIPTION
In URLs that point to pages in django
documentation, use 'stable' tag in order to
always point to the latest version of the documentation. Previously, hard-coded django versions (e.g. 1.7)
were used in hyperlinks which are now outdated (throw 404) e.g. this link: https://docs.djangoproject.com/en/1.7/topics/class-based-views/ is no longer valid- used in [views_and_forms.html](https://django-haystack.readthedocs.io/en/master/views_and_forms.html)
page.

Using 'stable' tag will ensure those
links never become outdated.

