### PR TITLE
catch makedirs problem in early state

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -130,7 +130,13 @@ class WhooshSearchBackend(BaseSearchBackend):
 
         # Make sure the index is there.
         if self.use_file_storage and not os.path.exists(self.path):
-            os.makedirs(self.path)
+            try:
+                os.makedirs(self.path)
+            except:
+                raise IOError(
+                    "The directory of your Whoosh index '%s' (cwd='%s') cannot be created for the current user/group."
+                    % (self.path, os.getcwd())
+                )
             new_index = True
 
         if self.use_file_storage and not os.access(self.path, os.W_OK):


### PR DESCRIPTION
during mailman3 test setup it was found that error in `os.makedirs` step is not catched. This PR catches such error with a proper message.