### PR TITLE
Add ruff to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,11 @@
 exclude: ".*/vendor/.*"
 repos:
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: v0.0.261
+      hooks:
+          - id: ruff
+            # args: [ --fix, --exit-non-zero-on-fix ]
+
     - repo: https://github.com/PyCQA/isort
       rev: 5.12.0
       hooks:
@@ -21,6 +27,7 @@ repos:
           - id: check-json
           - id: check-merge-conflict
           - id: check-symlinks
+          - id: check-toml
           - id: check-xml
           - id: check-yaml
           - id: debug-statements


### PR DESCRIPTION
Add ruff to pre-commit.  https://beta.ruff.rs/docs/usage/#pre-commit

`pre-commit` passes so the other test runs can be safely canceled to save time and resources.