### PR TITLE
make workflow/flake8 happy - on-top of PR#1870

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -132,7 +132,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         if self.use_file_storage and not os.path.exists(self.path):
             try:
                 os.makedirs(self.path)
-            except Exception:
+            except BaseException:
                 raise IOError(
                     "The directory of your Whoosh index '%s' (cwd='%s') cannot be created for the current user/group."
                     % (self.path, os.getcwd())


### PR DESCRIPTION
This hoefully fixes currently broken test workflow triggered by https://github.com/django-haystack/django-haystack/pull/1870


haystack/backends/whoosh_backend.py:135:1: B001 Do not use bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on.  Prefer `except Exception:`.  If you're sure what you're doing, be explicit and write `except BaseException:`.