### PR TITLE
__unicode__ to __str__ in tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -54,7 +54,7 @@ note-taking application. Here is ``myapp/models.py``::
         title = models.CharField(max_length=200)
         body = models.TextField()
 
-        def __unicode__(self):
+        def __str__(self):
             return self.title
 
 Finally, before starting with Haystack, you will want to choose a search


### PR DESCRIPTION
`def __unicode__` has been obsolute since python 3 AFAIK, the tutorial still shows it