### PR TITLE
Fix unittest assert calls for Python 3.12

### DIFF
--- a/test_haystack/test_managers.py
+++ b/test_haystack/test_managers.py
@@ -242,11 +242,11 @@ class ManagerTestCase(TestCase):
 
     def test_values(self):
         sqs = self.search_index.objects.auto_query("test").values("id")
-        self.assertTrue(isinstance(sqs, ValuesSearchQuerySet))
+        self.assertIsInstance(sqs, ValuesSearchQuerySet)
 
     def test_valueslist(self):
         sqs = self.search_index.objects.auto_query("test").values_list("id")
-        self.assertTrue(isinstance(sqs, ValuesListSearchQuerySet))
+        self.assertIsInstance(sqs, ValuesListSearchQuerySet)
 
 
 class CustomManagerTestCase(TestCase):

--- a/test_haystack/test_managers.py
+++ b/test_haystack/test_managers.py
@@ -242,11 +242,11 @@ class ManagerTestCase(TestCase):
 
     def test_values(self):
         sqs = self.search_index.objects.auto_query("test").values("id")
-        self.assert_(isinstance(sqs, ValuesSearchQuerySet))
+        self.assertTrue(isinstance(sqs, ValuesSearchQuerySet))
 
     def test_valueslist(self):
         sqs = self.search_index.objects.auto_query("test").values_list("id")
-        self.assert_(isinstance(sqs, ValuesListSearchQuerySet))
+        self.assertTrue(isinstance(sqs, ValuesListSearchQuerySet))
 
 
 class CustomManagerTestCase(TestCase):

--- a/test_haystack/test_query.py
+++ b/test_haystack/test_query.py
@@ -442,7 +442,7 @@ class SearchQuerySetTestCase(TestCase):
     def test_repr(self):
         reset_search_queries()
         self.assertEqual(len(connections["default"].queries), 0)
-        self.assertRegexpMatches(
+        self.assertRegex(
             repr(self.msqs),
             r"^<SearchQuerySet: query=<test_haystack.mocks.MockSearchQuery object"
             r" at 0x[0-9A-Fa-f]+>, using=None>$",
@@ -967,18 +967,18 @@ class SearchQuerySetTestCase(TestCase):
 class ValuesQuerySetTestCase(SearchQuerySetTestCase):
     def test_values_sqs(self):
         sqs = self.msqs.auto_query("test").values("id")
-        self.assert_(isinstance(sqs, ValuesSearchQuerySet))
+        self.assertTrue(isinstance(sqs, ValuesSearchQuerySet))
 
         # We'll do a basic test to confirm that slicing works as expected:
-        self.assert_(isinstance(sqs[0], dict))
-        self.assert_(isinstance(sqs[0:5][0], dict))
+        self.assertTrue(isinstance(sqs[0], dict))
+        self.assertTrue(isinstance(sqs[0:5][0], dict))
 
     def test_valueslist_sqs(self):
         sqs = self.msqs.auto_query("test").values_list("id")
 
-        self.assert_(isinstance(sqs, ValuesListSearchQuerySet))
-        self.assert_(isinstance(sqs[0], (list, tuple)))
-        self.assert_(isinstance(sqs[0:1][0], (list, tuple)))
+        self.assertTrue(isinstance(sqs, ValuesListSearchQuerySet))
+        self.assertTrue(isinstance(sqs[0], (list, tuple)))
+        self.assertTrue(isinstance(sqs[0:1][0], (list, tuple)))
 
         self.assertRaises(
             TypeError,
@@ -989,12 +989,12 @@ class ValuesQuerySetTestCase(SearchQuerySetTestCase):
         )
 
         flat_sqs = self.msqs.auto_query("test").values_list("id", flat=True)
-        self.assert_(isinstance(sqs, ValuesListSearchQuerySet))
+        self.assertTrue(isinstance(sqs, ValuesListSearchQuerySet))
 
         # Note that this will actually be None because a mocked sqs lacks
         # anything else:
-        self.assert_(flat_sqs[0] is None)
-        self.assert_(flat_sqs[0:1][0] is None)
+        self.assertTrue(flat_sqs[0] is None)
+        self.assertTrue(flat_sqs[0:1][0] is None)
 
 
 class EmptySearchQuerySetTestCase(TestCase):

--- a/test_haystack/test_query.py
+++ b/test_haystack/test_query.py
@@ -967,18 +967,18 @@ class SearchQuerySetTestCase(TestCase):
 class ValuesQuerySetTestCase(SearchQuerySetTestCase):
     def test_values_sqs(self):
         sqs = self.msqs.auto_query("test").values("id")
-        self.assertTrue(isinstance(sqs, ValuesSearchQuerySet))
+        self.assertIsInstance(sqs, ValuesSearchQuerySet)
 
         # We'll do a basic test to confirm that slicing works as expected:
-        self.assertTrue(isinstance(sqs[0], dict))
-        self.assertTrue(isinstance(sqs[0:5][0], dict))
+        self.assertIsInstance(sqs[0], dict)
+        self.assertIsInstance(sqs[0:5][0], dict)
 
     def test_valueslist_sqs(self):
         sqs = self.msqs.auto_query("test").values_list("id")
 
-        self.assertTrue(isinstance(sqs, ValuesListSearchQuerySet))
-        self.assertTrue(isinstance(sqs[0], (list, tuple)))
-        self.assertTrue(isinstance(sqs[0:1][0], (list, tuple)))
+        self.assertIsInstance(sqs, ValuesListSearchQuerySet)
+        self.assertIsInstance(sqs[0], (list, tuple))
+        self.assertIsInstance(sqs[0:1][0], (list, tuple))
 
         self.assertRaises(
             TypeError,
@@ -989,12 +989,12 @@ class ValuesQuerySetTestCase(SearchQuerySetTestCase):
         )
 
         flat_sqs = self.msqs.auto_query("test").values_list("id", flat=True)
-        self.assertTrue(isinstance(sqs, ValuesListSearchQuerySet))
+        self.assertIsInstance(sqs, ValuesListSearchQuerySet)
 
         # Note that this will actually be None because a mocked sqs lacks
         # anything else:
-        self.assertTrue(flat_sqs[0] is None)
-        self.assertTrue(flat_sqs[0:1][0] is None)
+        self.assertIsNone(flat_sqs[0])
+        self.assertIsNone(flat_sqs[0:1][0])
 
 
 class EmptySearchQuerySetTestCase(TestCase):


### PR DESCRIPTION
Fix `unittest` assert calls for Python 3.12: https://docs.python.org/3/whatsnew/3.12.html#id3
* Deprecated in Python 3.2 and removed in Python 3.12.