### PR TITLE
Update test matrix for django v5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,31 +7,31 @@ on:
     branches: [master]
 
 jobs:
-  ruff:  # https://beta.ruff.rs
+  ruff:  # https://docs.astral.sh/ruff
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - run: pip install --user ruff
-    - run: ruff --output-format=github .
+    - run: ruff --output-format=github
 
   test:
     runs-on: ubuntu-latest
     needs: ruff  # Do not run the tests if linting fails.
     strategy:
       fail-fast: false
-      matrix:  # https://docs.djangoproject.com/en/4.1/faq/install
-        django-version: ["3.2", "4.0", "4.1"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        elastic-version: ["1.7", "2.4", "5.5", "7.13.1"]
+      matrix:  # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
+        django-version: ["3.2", "4.2", "5.0"]
+        python-version: ["3.8", "3.9"]  # , "3.10", "3.11", "3.12"]  # Whoosh issues with Py3.10+
+        elastic-version: ["7.17.9"]
         exclude:
-          - django-version: "4.0"
-            python-version: "3.7"
-          - django-version: "4.1"
-            python-version: "3.7"
-        include:
-          - django-version: "4.1"
+          - django-version: "3.2"
             python-version: "3.11"
-            elastic-version: "7.13.1"
+          - django-version: "3.2"
+            python-version: "3.12"
+          - django-version: "5.0"
+            python-version: "3.8"
+          - django-version: "5.0"
+            python-version: "3.9"
     services:
       elastic:
         image: elasticsearch:${{ matrix.elastic-version }}
@@ -47,11 +47,11 @@ jobs:
       solr:
         image: solr:6
         ports:
-          - 9001:9001
+          - 9001:8983
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install system dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ write_to = "haystack/version.py"
 exclude = ["test_haystack"]
 ignore = ["B018", "B028", "B904", "B905"]
 line-length = 162
-select = ["ASYNC", "B", "C4", "E", "F", "G", "PLR091", "W"]
+select = ["ASYNC", "B", "C4", "DJ", "E", "F", "G", "PLR091", "W"]
 show-source = true
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.isort]
 known-first-party = ["haystack", "test_haystack"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     docs
-    py{38,39,310,311,312,py3}-django{3.2,4.2,5.0}-es{1.x,2.x,5.x,7.x}
+    py{38,39,310,311,312,py3}-django{3.2,4.2,5.0}-es7.x
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     docs
-    py{36,37,38,39,310,py}-django{2.2,3.0,3.1,3.2,4.0}-es{1.x,2.x,5.x,7.x}
+    py{38,39,310,311,312,py3}-django{3.2,4.2,5.0}-es{1.x,2.x,5.x,7.x}
 
 
 [testenv]
@@ -15,11 +15,9 @@ deps =
     geopy==2.0.0
     coverage
     requests
-    django2.2: Django>=2.2,<3.0
-    django3.0: Django>=3.0,<3.1
-    django3.1: Django>=3.1,<3.2
     django3.2: Django>=3.2,<3.3
-    django4.0: Django>=4.0,<4.1
+    django4.2: Django>=4.2,<4.3
+    django5.0: Django>=5.0,<5.1
     es1.x: elasticsearch>=1,<2
     es2.x: elasticsearch>=2,<3
     es5.x: elasticsearch>=5,<6


### PR DESCRIPTION
https://pypi.org/project/Django

https://www.djangoproject.com/weblog/2023/dec/04/django-50-released

> Django 4.1 has reached the end of extended support. The final security release ([4.1.13](https://docs.djangoproject.com/en/stable/releases/4.1.13/)) was issued on November 1st. All Django 4.1 users are encouraged to [upgrade](https://docs.djangoproject.com/en/dev/howto/upgrade-version/) to Django 4.2 or later.

https://docs.djangoproject.com/en/5.0/releases/5.0
> Django 5.0 supports Python 3.10, 3.11, and 3.12.

https://docs.djangoproject.com/en/5.0/faq/install/#what-python-version-can-i-use-with-django

### Whoosh issues with Python 3.10+ are fixed in #1928 or #1929
* #1928
* #1929