### PR TITLE
pre-commit: format files with prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ charset = utf-8
 [Makefile]
 indent_style = tab
 
+[*.{yaml,yml}]
+indent_size = 2
+
 # We don't want to apply our defaults to third-party code or minified bundles:
 [**/{external,vendor}/**,**.min.{js,css}]
 indent_style = ignore

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,28 +1,28 @@
 name: "CodeQL"
 
 on:
-    push:
-        branches: [master]
-    pull_request:
-        # The branches below must be a subset of the branches above
-        branches: [master]
-    schedule:
-        - cron: "0 6 * * 5"
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+  schedule:
+    - cron: "0 6 * * 5"
 
 jobs:
-    analyze:
-        name: Analyze
-        runs-on: ubuntu-latest
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-            # Initializes the CodeQL tools for scanning.
-            - name: Initialize CodeQL
-              uses: github/codeql-action/init@v1
-              with:
-                  languages: python
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: python
 
-            - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,28 +1,28 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [master, ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
-  schedule:
-    - cron: '0 6 * * 5'
+    push:
+        branches: [master]
+    pull_request:
+        # The branches below must be a subset of the branches above
+        branches: [master]
+    schedule:
+        - cron: "0 6 * * 5"
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
+    analyze:
+        name: Analyze
+        runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: python
+            # Initializes the CodeQL tools for scanning.
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v1
+              with:
+                  languages: python
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,15 +3,15 @@ name: Build docs
 on: [pull_request, push]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.x
-    - name: Install dependencies
-      run: pip install sphinx
-    - name: Build docs
-      run: cd docs && make html
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.x
+            - name: Install dependencies
+              run: pip install sphinx
+            - name: Build docs
+              run: cd docs && make html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,15 +3,15 @@ name: Build docs
 on: [pull_request, push]
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - name: Set up Python
-              uses: actions/setup-python@v4
-              with:
-                  python-version: 3.x
-            - name: Install dependencies
-              run: pip install sphinx
-            - name: Build docs
-              run: cd docs && make html
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: pip install sphinx
+      - name: Build docs
+        run: cd docs && make html

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -3,36 +3,36 @@ name: "PyPI releases"
 on: release
 
 jobs:
-    build_sdist:
-        name: Build Python source distribution
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
+  build_sdist:
+    name: Build Python source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-            - name: Build sdist
-              run: pipx run build --sdist
+      - name: Build sdist
+        run: pipx run build --sdist
 
-            - uses: actions/upload-artifact@v3
-              with:
-                  path: dist/*.tar.gz
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
 
-    pypi-publish:
-        name: Upload release to PyPI
-        if: github.event_name == 'release' && github.event.action == 'published'
-        needs:
-            - build_sdist
-        runs-on: ubuntu-latest
-        environment:
-            name: pypi
-            url: https://pypi.org/p/django-haystack
-        permissions:
-            id-token: write
-        steps:
-            - uses: actions/download-artifact@v3
-              with:
-                  # unpacks default artifact into dist/
-                  # if `name: artifact` is omitted, the action will create extra parent dir
-                  name: artifact
-                  path: dist
-            - name: Publish package distributions to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+  pypi-publish:
+    name: Upload release to PyPI
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs:
+      - build_sdist
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-haystack
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,68 +1,68 @@
 name: Test
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
 
 jobs:
-  ruff:  # https://docs.astral.sh/ruff
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - run: pip install --user ruff
-    - run: ruff --output-format=github
+    ruff: # https://docs.astral.sh/ruff
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - run: pip install --user ruff
+            - run: ruff --output-format=github
 
-  test:
-    runs-on: ubuntu-latest
-    needs: ruff  # Do not run the tests if linting fails.
-    strategy:
-      fail-fast: false
-      matrix:  # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
-        django-version: ["3.2", "4.2", "5.0"]
-        python-version: ["3.8", "3.9"]  # , "3.10", "3.11", "3.12"]  # Whoosh issues with Py3.10+
-        elastic-version: ["7.17.9"]
-        exclude:
-          - django-version: "3.2"
-            python-version: "3.11"
-          - django-version: "3.2"
-            python-version: "3.12"
-          - django-version: "5.0"
-            python-version: "3.8"
-          - django-version: "5.0"
-            python-version: "3.9"
-    services:
-      elastic:
-        image: elasticsearch:${{ matrix.elastic-version }}
-        env:
-          discovery.type: "single-node"
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-        ports:
-          - 9200:9200
-      solr:
-        image: solr:6
-        ports:
-          - 9001:8983
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install system dependencies
-      run: sudo apt install --no-install-recommends -y gdal-bin
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        pip install coverage requests tox tox-gh-actions
-        pip install django==${{ matrix.django-version }} elasticsearch==${{ matrix.elastic-version }}
-        python setup.py clean build install
-    - name: Run test
-      run: tox -v
-      env:
-        DJANGO: ${{ matrix.django-version }}
+    test:
+        runs-on: ubuntu-latest
+        needs: ruff # Do not run the tests if linting fails.
+        strategy:
+            fail-fast: false
+            matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
+                django-version: ["3.2", "4.2", "5.0"]
+                python-version: ["3.8", "3.9"] # , "3.10", "3.11", "3.12"]  # Whoosh issues with Py3.10+
+                elastic-version: ["7.17.9"]
+                exclude:
+                    - django-version: "3.2"
+                      python-version: "3.11"
+                    - django-version: "3.2"
+                      python-version: "3.12"
+                    - django-version: "5.0"
+                      python-version: "3.8"
+                    - django-version: "5.0"
+                      python-version: "3.9"
+        services:
+            elastic:
+                image: elasticsearch:${{ matrix.elastic-version }}
+                env:
+                    discovery.type: "single-node"
+                options: >-
+                    --health-cmd "curl http://localhost:9200/_cluster/health"
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 10
+                ports:
+                    - 9200:9200
+            solr:
+                image: solr:6
+                ports:
+                    - 9001:8983
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v5
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install system dependencies
+              run: sudo apt install --no-install-recommends -y gdal-bin
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip setuptools wheel
+                  pip install coverage requests tox tox-gh-actions
+                  pip install django==${{ matrix.django-version }} elasticsearch==${{ matrix.elastic-version }}
+                  python setup.py clean build install
+            - name: Run test
+              run: tox -v
+              env:
+                  DJANGO: ${{ matrix.django-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,68 +1,68 @@
 name: Test
 
 on:
-    push:
-        branches: [master]
-    pull_request:
-        branches: [master]
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
-    ruff: # https://docs.astral.sh/ruff
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - run: pip install --user ruff
-            - run: ruff --output-format=github
+  ruff: # https://docs.astral.sh/ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install --user ruff
+      - run: ruff --output-format=github
 
-    test:
-        runs-on: ubuntu-latest
-        needs: ruff # Do not run the tests if linting fails.
-        strategy:
-            fail-fast: false
-            matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
-                django-version: ["3.2", "4.2", "5.0"]
-                python-version: ["3.8", "3.9"] # , "3.10", "3.11", "3.12"]  # Whoosh issues with Py3.10+
-                elastic-version: ["7.17.9"]
-                exclude:
-                    - django-version: "3.2"
-                      python-version: "3.11"
-                    - django-version: "3.2"
-                      python-version: "3.12"
-                    - django-version: "5.0"
-                      python-version: "3.8"
-                    - django-version: "5.0"
-                      python-version: "3.9"
-        services:
-            elastic:
-                image: elasticsearch:${{ matrix.elastic-version }}
-                env:
-                    discovery.type: "single-node"
-                options: >-
-                    --health-cmd "curl http://localhost:9200/_cluster/health"
-                    --health-interval 10s
-                    --health-timeout 5s
-                    --health-retries 10
-                ports:
-                    - 9200:9200
-            solr:
-                image: solr:6
-                ports:
-                    - 9001:8983
-        steps:
-            - uses: actions/checkout@v4
-            - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.python-version }}
-            - name: Install system dependencies
-              run: sudo apt install --no-install-recommends -y gdal-bin
-            - name: Install dependencies
-              run: |
-                  python -m pip install --upgrade pip setuptools wheel
-                  pip install coverage requests tox tox-gh-actions
-                  pip install django==${{ matrix.django-version }} elasticsearch==${{ matrix.elastic-version }}
-                  python setup.py clean build install
-            - name: Run test
-              run: tox -v
-              env:
-                  DJANGO: ${{ matrix.django-version }}
+  test:
+    runs-on: ubuntu-latest
+    needs: ruff # Do not run the tests if linting fails.
+    strategy:
+      fail-fast: false
+      matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
+        django-version: ["3.2", "4.2", "5.0"]
+        python-version: ["3.8", "3.9"] # , "3.10", "3.11", "3.12"]  # Whoosh issues with Py3.10+
+        elastic-version: ["7.17.9"]
+        exclude:
+          - django-version: "3.2"
+            python-version: "3.11"
+          - django-version: "3.2"
+            python-version: "3.12"
+          - django-version: "5.0"
+            python-version: "3.8"
+          - django-version: "5.0"
+            python-version: "3.9"
+    services:
+      elastic:
+        image: elasticsearch:${{ matrix.elastic-version }}
+        env:
+          discovery.type: "single-node"
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          - 9200:9200
+      solr:
+        image: solr:6
+        ports:
+          - 9001:8983
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system dependencies
+        run: sudo apt install --no-install-recommends -y gdal-bin
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install coverage requests tox tox-gh-actions
+          pip install django==${{ matrix.django-version }} elasticsearch==${{ matrix.elastic-version }}
+          python setup.py clean build install
+      - name: Run test
+        run: tox -v
+        env:
+          DJANGO: ${{ matrix.django-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,46 +1,46 @@
 exclude: ".*/vendor/.*"
 repos:
-    - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.1.13
-      hooks:
-          - id: ruff
-            # args: [ --fix, --exit-non-zero-on-fix ]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.13
+    hooks:
+      - id: ruff
+        # args: [ --fix, --exit-non-zero-on-fix ]
 
-    - repo: https://github.com/PyCQA/isort
-      rev: 5.13.2
-      hooks:
-          - id: isort
-    - repo: https://github.com/psf/black
-      rev: 23.12.1
-      hooks:
-          - id: black
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.5.0
-      hooks:
-          - id: check-added-large-files
-            args: ["--maxkb=128"]
-          - id: check-ast
-          - id: check-byte-order-marker
-          - id: check-case-conflict
-          - id: check-docstring-first
-          - id: check-executables-have-shebangs
-          - id: check-json
-          - id: check-merge-conflict
-          - id: check-symlinks
-          - id: check-toml
-          - id: check-xml
-          - id: check-yaml
-          - id: debug-statements
-          - id: detect-private-key
-          - id: end-of-file-fixer
-          - id: mixed-line-ending
-            args: ["--fix=lf"]
-          - id: pretty-format-json
-            args: ["--autofix", "--no-sort-keys", "--indent=4"]
-          - id: trailing-whitespace
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=128"]
+      - id: check-ast
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-xml
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: pretty-format-json
+        args: ["--autofix", "--no-sort-keys", "--indent=4"]
+      - id: trailing-whitespace
 
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v4.0.0-alpha.8
-      hooks:
-          - id: prettier
-            types_or: [json, toml, xml, yaml]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        types_or: [json, toml, xml, yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ".*/vendor/.*"
 repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.1.11
+      rev: v0.1.13
       hooks:
           - id: ruff
             # args: [ --fix, --exit-non-zero-on-fix ]
@@ -38,3 +38,9 @@ repos:
           - id: pretty-format-json
             args: ["--autofix", "--no-sort-keys", "--indent=4"]
           - id: trailing-whitespace
+
+    - repo: https://github.com/pre-commit/mirrors-prettier
+      rev: v4.0.0-alpha.8
+      hooks:
+          - id: prettier
+            types_or: [json, toml, xml, yaml]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,9 @@
 version: 2
 
 build:
-    os: ubuntu-22.04
-    tools:
-        python: "3.12"
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
 
 sphinx:
-    configuration: docs/conf.py
+  configuration: docs/conf.py


### PR DESCRIPTION
Add to 
```
    - repo: https://github.com/pre-commit/mirrors-prettier
      rev: v4.0.0-alpha.8
      hooks:
          - id: prettier
            types_or: [json, toml, xml, yaml]
```
* https://github.com/prettier/prettier
* https://github.com/pre-commit/mirrors-prettier

Change `.editorconfig` file setting for yaml files to be `indent_size = 2`.


