### PR TITLE
updated whoosh backend to utilize datetime from the standard library

### DIFF
--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -4,10 +4,10 @@ import re
 import shutil
 import threading
 import warnings
+from datetime import date, datetime
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.datetime_safe import date, datetime
 from django.utils.encoding import force_str
 
 from haystack.backends import (

--- a/test_haystack/whoosh_tests/test_whoosh_backend.py
+++ b/test_haystack/whoosh_tests/test_whoosh_backend.py
@@ -1,12 +1,11 @@
 import os
 import unittest
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.datetime_safe import date, datetime
 from whoosh.analysis import SpaceSeparatedTokenizer, SubstitutionFilter
 from whoosh.fields import BOOLEAN, DATETIME, KEYWORD, NUMERIC, TEXT
 from whoosh.qparser import QueryParser


### PR DESCRIPTION
Updated the `whoosh` backend to reflect Django 5.0's decision to remove the `datetime_safe` library. It now uses Python's standard library. All tests pass, although I am getting an unhandled exception near the end which seems to be unrelated to the tests.

```
/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/__init__.py:80: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  dist.fetch_build_eggs(dist.setup_requires)
/var/www/example.com/django-haystack/.eggs/setuptools_scm-8.0.4-py3.11.egg/setuptools_scm/_integration/setuptools.py:90: UserWarning: version of django-haystack already set
  warnings.warn(f"version of {dist_name} already set")
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/command/test.py:193: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  ir_d = dist.fetch_build_eggs(dist.install_requires)
/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/command/test.py:194: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  tr_d = dist.fetch_build_eggs(dist.tests_require or [])
/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/command/test.py:195: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  er_d = dist.fetch_build_eggs(
running egg_info
writing django_haystack.egg-info/PKG-INFO
writing dependency_links to django_haystack.egg-info/dependency_links.txt
writing requirements to django_haystack.egg-info/requires.txt
writing top-level names to django_haystack.egg-info/top_level.txt
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
adding license file 'AUTHORS'
writing manifest file 'django_haystack.egg-info/SOURCES.txt'
running build_ext
Found 49 test(s).
System check identified no issues (0 silenced).
..............s.......s..........................
----------------------------------------------------------------------
Ran 49 tests in 12.398s

OK (skipped=2)
Traceback (most recent call last):
  File "/var/www/example.com/django-haystack/setup.py", line 19, in <module>
    setup(
  File "/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/__init__.py", line 103, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
    return run_commands(dist)
           ^^^^^^^^^^^^^^^^^^
  File "/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
    dist.run_commands()
  File "/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
    self.run_command(cmd)
  File "/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/dist.py", line 963, in run_command
    super().run_command(command)
  File "/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
    cmd_obj.run()
  File "/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/command/test.py", line 223, in run
    self.run_tests()
  File "/var/www/example.com/.venv/lib/python3.11/site-packages/setuptools/command/test.py", line 226, in run_tests
    test = unittest.main(
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/main.py", line 101, in __init__
    self.parseArgs(argv)
  File "/usr/lib/python3.11/unittest/main.py", line 150, in parseArgs
    self.createTests()
  File "/usr/lib/python3.11/unittest/main.py", line 161, in createTests
    self.test = self.testLoader.loadTestsFromNames(self.testNames,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/loader.py", line 232, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/loader.py", line 232, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/loader.py", line 223, in loadTestsFromName
    raise TypeError("calling %s returned %s, not a test" %
TypeError: calling <function run_all at 0x7ff027563a60> returned None, not a test
```