### PR TITLE
Fix SOLR setup under Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install system dependencies
         run: sudo apt install --no-install-recommends -y gdal-bin
+      - name: Setup solr test server in Docker
+        run: bash test_haystack/solr_tests/server/setup-solr-test-server-in-docker.sh
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/test_haystack/solr_tests/server/setup-solr-test-server-in-docker.sh
+++ b/test_haystack/solr_tests/server/setup-solr-test-server-in-docker.sh
@@ -1,12 +1,15 @@
 # figure out the solr container ID
 SOLR_CONTAINER=`docker ps -f ancestor=solr:6 --format '{{.ID}}'`
 
+LOCAL_CONFDIR=./test_haystack/solr_tests/server/confdir
+CONTAINER_CONFDIR=/opt/solr/server/solr/collection1/conf
+
 # set up a solr core
 docker exec $SOLR_CONTAINER ./bin/solr create -c collection1 -p 8983 -n basic_config
 # copy the testing schema to the collection and fix permissions
-docker cp ./test_haystack/solr_tests/server/confdir/solrconfig.xml $SOLR_CONTAINER:/opt/solr/server/solr/collection1/conf/solrconfig.xml
-docker cp ./test_haystack/solr_tests/server/confdir/schema.xml $SOLR_CONTAINER:/opt/solr/server/solr/collection1/conf/schema.xml
-docker exec $SOLR_CONTAINER mv /opt/solr/server/solr/collection1/conf/managed-schema /opt/solr/server/solr/collection1/conf/managed-schema.old
+docker cp $LOCAL_CONFDIR/solrconfig.xml $SOLR_CONTAINER:$CONTAINER_CONFDIR/solrconfig.xml
+docker cp $LOCAL_CONFDIR/schema.xml $SOLR_CONTAINER:$CONTAINER_CONFDIR/schema.xml
+docker exec $SOLR_CONTAINER mv $CONTAINER_CONFDIR/managed-schema $CONTAINER_CONFDIR/managed-schema.old
 docker exec -u root $SOLR_CONTAINER chown -R solr:solr /opt/solr/server/solr/collection1
 # reload the solr core
 curl "http://localhost:9001/solr/admin/cores?action=RELOAD&core=collection1"

--- a/test_haystack/solr_tests/server/setup-solr-test-server-in-docker.sh
+++ b/test_haystack/solr_tests/server/setup-solr-test-server-in-docker.sh
@@ -1,0 +1,12 @@
+# figure out the solr container ID
+SOLR_CONTAINER=`docker ps -f ancestor=solr:6 --format '{{.ID}}'`
+
+# set up a solr core
+docker exec $SOLR_CONTAINER ./bin/solr create -c collection1 -p 8983 -n basic_config
+# copy the testing schema to the collection and fix permissions
+docker cp ./test_haystack/solr_tests/server/confdir/solrconfig.xml $SOLR_CONTAINER:/opt/solr/server/solr/collection1/conf/solrconfig.xml
+docker cp ./test_haystack/solr_tests/server/confdir/schema.xml $SOLR_CONTAINER:/opt/solr/server/solr/collection1/conf/schema.xml
+docker exec $SOLR_CONTAINER mv /opt/solr/server/solr/collection1/conf/managed-schema /opt/solr/server/solr/collection1/conf/managed-schema.old
+docker exec -u root $SOLR_CONTAINER chown -R solr:solr /opt/solr/server/solr/collection1
+# reload the solr core
+curl "http://localhost:9001/solr/admin/cores?action=RELOAD&core=collection1"


### PR DESCRIPTION
See #1917 

As #1921 seems a bit stuck, I decided to pursue the same issue, but with smaller PRs. 

We don't really need container networking right now, because the tests run directly on the runner and not inside a container, and while it's nice to have, we can deal with that in a separate PR. Same goes for switching the SOLR port from the custom 9001 back to standard 8983.

This does just one thing - configures the SOLR properly under GH actions, so that the tests run. Also, unlike #1921, I did the configuration in a separate shell script, so that it can be also used for local testing with docker, for example with running solr with `docker run -it --rm -p 9001:8983 solr:6` and then running the same script locally... 