### PR TITLE
Add `setuptools` to fix failing tests on Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
         django-version: ["3.2", "4.2"] # , "5.0"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"] # , "3.12" # Whoosh issues with Py3.10+
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         elastic-version: ["7.17.9"]
         exclude:
           - django-version: "3.2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
-        django-version: ["3.2", "4.2"] # , "5.0"]
+        django-version: ["3.2", "4.2", "5.0"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         elastic-version: ["7.17.9"]
         exclude:

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ deps =
     geopy==2.0.0
     coverage
     requests
+    setuptools
     django3.2: Django>=3.2,<3.3
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     geopy==2.0.0
     coverage
     requests
-    setuptools
+    setuptools; python_version >= "3.12"  # Can be removed on pysolr >= v3.10
     django3.2: Django>=3.2,<3.3
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1


### PR DESCRIPTION
Like #1962 but for Python 3.12
* #1962