### PR TITLE
pre-commit no longer supports the prettier file formater

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,9 +46,3 @@ repos:
       - id: pretty-format-json
         args: ["--autofix", "--no-sort-keys", "--indent=4"]
       - id: trailing-whitespace
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        types_or: [json, toml, xml, yaml]


### PR DESCRIPTION
https://github.com/pre-commit/mirrors-prettier is archived with the note:
> prettier made some changes that breaks plugins entirely