### PR TITLE
Issue #1992: Implemented handling for `track_total_hits` in the Elasticsearch search backend.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -313,3 +313,25 @@ This setting allows you to change the number of terms fuzzy queries will
 expand to when using ``fuzzy`` filter.
 
 Default is ``50``
+
+
+``HAYSTACK_TRACK_TOTAL_HITS``
+==========================
+
+**Optional**
+
+This setting controls how the ``track_total_hits`` parameter is handled in Elasticsearch queries. It allows you to specify whether to include the ``track_total_hits`` parameter and, if so, how to configure it. This can impact the performance and accuracy of hit counts in search results.
+
+If set to ``True``: The ``track_total_hits`` parameter will be included in the Elasticsearch query and will ensure that the total hit count is accurate.
+If set to an integer: The ``track_total_hits`` parameter will be included with the specified integer value, providing an accurate hit count up to the specified number.
+If set to False: The ``track_total_hits`` parameter will be omitted from the Elasticsearch query, which can improve performance but will not provide an exact hit count.
+
+An example::
+
+    HAYSTACK_TRACK_TOTAL_HITS = True
+    # or
+    HAYSTACK_TRACK_TOTAL_HITS = 100
+    # or
+    HAYSTACK_TRACK_TOTAL_HITS = False
+
+The default is ``False``, meaning the track_total_hits parameter is omitted.

--- a/haystack/backends/elasticsearch7_backend.py
+++ b/haystack/backends/elasticsearch7_backend.py
@@ -9,7 +9,13 @@ from haystack.backends.elasticsearch_backend import (
     ElasticsearchSearchBackend,
     ElasticsearchSearchQuery,
 )
-from haystack.constants import DEFAULT_OPERATOR, DJANGO_CT, DJANGO_ID, FUZZINESS
+from haystack.constants import (
+    DEFAULT_OPERATOR,
+    DJANGO_CT,
+    DJANGO_ID,
+    FUZZINESS,
+    TRACK_TOTAL_HITS,
+)
 from haystack.exceptions import MissingDependency
 from haystack.utils import get_identifier, get_model_ct
 
@@ -354,6 +360,29 @@ class Elasticsearch7SearchBackend(ElasticsearchSearchBackend):
                 kwargs["query"]["bool"]["filter"] = filters[0]
             else:
                 kwargs["query"]["bool"]["filter"] = {"bool": {"must": filters}}
+
+        # If TRACK_TOTAL_HITS is False, 0, or None, do not include the parameter
+        if TRACK_TOTAL_HITS:
+            # Define a mapping for the track_total_hits parameter
+            # - If TRACK_TOTAL_HITS is True (bool), map to "true" (string)
+            # - If TRACK_TOTAL_HITS is an integer, use its value directly
+            track_total_hits_mapper = {
+                bool: "true",  # Maps boolean True to "true"
+                int: TRACK_TOTAL_HITS,  # Maps integer to its value
+            }
+
+            # Get the mapped value based on the type of TRACK_TOTAL_HITS
+            # If the type is not in the mapper, fallback to False
+            track_total_hits = track_total_hits_mapper.get(type(TRACK_TOTAL_HITS), False)
+
+            # If a valid track_total_hits value is obtained, add it to search kwargs
+            if track_total_hits:
+                kwargs['track_total_hits'] = track_total_hits
+            else:
+                # Issue a warning if TRACK_TOTAL_HITS is not of type bool or int
+                warnings.warn(
+                    "Wrong value of HAYSTACK_TRACK_TOTAL_HITS is provided. Valid options are `bool` or `int`."
+                )
 
         if extra_kwargs:
             kwargs.update(extra_kwargs)

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -15,7 +15,6 @@ from haystack.constants import (
     FUZZY_MAX_EXPANSIONS,
     FUZZY_MIN_SIM,
     ID,
-    TRACK_TOTAL_HITS,
 )
 from haystack.exceptions import MissingDependency, MoreLikeThisError, SkipDocument
 from haystack.inputs import Clean, Exact, PythonData, Raw
@@ -545,29 +544,6 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 
         if extra_kwargs:
             kwargs.update(extra_kwargs)
-
-        # If TRACK_TOTAL_HITS is False, 0, or None, do not include the parameter
-        if TRACK_TOTAL_HITS:
-            # Define a mapping for the track_total_hits parameter
-            # - If TRACK_TOTAL_HITS is True (bool), map to "true" (string)
-            # - If TRACK_TOTAL_HITS is an integer, use its value directly
-            track_total_hits_mapper = {
-                bool: "true",  # Maps boolean True to "true"
-                int: TRACK_TOTAL_HITS,  # Maps integer to its value
-            }
-
-            # Get the mapped value based on the type of TRACK_TOTAL_HITS
-            # If the type is not in the mapper, fallback to False
-            track_total_hits = track_total_hits_mapper.get(type(TRACK_TOTAL_HITS), False)
-
-            # If a valid track_total_hits value is obtained, add it to search kwargs
-            if track_total_hits:
-                kwargs['track_total_hits'] = track_total_hits
-            else:
-                # Issue a warning if TRACK_TOTAL_HITS is not of type bool or int
-                warnings.warn(
-                    "Wrong value of HAYSTACK_TRACK_TOTAL_HITS is provided. Valid options are `bool` or `int`."
-                )
 
         return kwargs
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -555,19 +555,20 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 bool: "true",  # Maps boolean True to "true"
                 int: TRACK_TOTAL_HITS,  # Maps integer to its value
             }
-            
+
             # Get the mapped value based on the type of TRACK_TOTAL_HITS
             # If the type is not in the mapper, fallback to False
             track_total_hits = track_total_hits_mapper.get(type(TRACK_TOTAL_HITS), False)
-            
-            # If a valid track_total_hits value is obtained, add it to search_kwargs
+
+            # If a valid track_total_hits value is obtained, add it to search kwargs
             if track_total_hits:
-                search_kwargs['track_total_hits'] = track_total_hits
+                kwargs['track_total_hits'] = track_total_hits
             else:
                 # Issue a warning if TRACK_TOTAL_HITS is not of type bool or int
                 warnings.warn(
                     "Wrong value of HAYSTACK_TRACK_TOTAL_HITS is provided. Valid options are `bool` or `int`."
                 )
+
         return kwargs
 
     @log_query

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -15,6 +15,7 @@ from haystack.constants import (
     FUZZY_MAX_EXPANSIONS,
     FUZZY_MIN_SIM,
     ID,
+    TRACK_TOTAL_HITS,
 )
 from haystack.exceptions import MissingDependency, MoreLikeThisError, SkipDocument
 from haystack.inputs import Clean, Exact, PythonData, Raw
@@ -545,6 +546,28 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         if extra_kwargs:
             kwargs.update(extra_kwargs)
 
+        # If TRACK_TOTAL_HITS is False, 0, or None, do not include the parameter
+        if TRACK_TOTAL_HITS:
+            # Define a mapping for the track_total_hits parameter
+            # - If TRACK_TOTAL_HITS is True (bool), map to "true" (string)
+            # - If TRACK_TOTAL_HITS is an integer, use its value directly
+            track_total_hits_mapper = {
+                bool: "true",  # Maps boolean True to "true"
+                int: TRACK_TOTAL_HITS,  # Maps integer to its value
+            }
+            
+            # Get the mapped value based on the type of TRACK_TOTAL_HITS
+            # If the type is not in the mapper, fallback to False
+            track_total_hits = track_total_hits_mapper.get(type(TRACK_TOTAL_HITS), False)
+            
+            # If a valid track_total_hits value is obtained, add it to search_kwargs
+            if track_total_hits:
+                search_kwargs['track_total_hits'] = track_total_hits
+            else:
+                # Issue a warning if TRACK_TOTAL_HITS is not of type bool or int
+                warnings.warn(
+                    "Wrong value of HAYSTACK_TRACK_TOTAL_HITS is provided. Valid options are `bool` or `int`."
+                )
         return kwargs
 
     @log_query

--- a/haystack/constants.py
+++ b/haystack/constants.py
@@ -17,6 +17,9 @@ FUZZINESS = getattr(settings, "HAYSTACK_FUZZINESS", "AUTO")
 FUZZY_MIN_SIM = getattr(settings, "HAYSTACK_FUZZY_MIN_SIM", 0.5)
 FUZZY_MAX_EXPANSIONS = getattr(settings, "HAYSTACK_FUZZY_MAX_EXPANSIONS", 50)
 
+# The track_total_hits parameter. Valid options are of type `bool` or `int`.
+TRACK_TOTAL_HITS = getattr(settings, "HAYSTACK_TRACK_TOTAL_HITS", False)
+
 # Default values on whoosh
 FUZZY_WHOOSH_MIN_PREFIX = getattr(settings, "HAYSTACK_FUZZY_WHOOSH_MIN_PREFIX", 3)
 FUZZY_WHOOSH_MAX_EDITS = getattr(settings, "HAYSTACK_FUZZY_WHOOSH_MAX_EDITS", 2)


### PR DESCRIPTION
 Issue # 1992

- Implemented handling for `track_total_hits` in the Elasticsearch search backend.
- Supports `bool` values (True/False) and `int` values.
- Added a warning for invalid `track_total_hits` values.
- Ensured the parameter is only added to search kwargs when valid.
- Documented the `HAYSTACK_TRACK_TOTAL_HITS` setting in the search backend configuration.
- Implemented test to verify the correct handling of. `track_total_hits`  in Elasticsearch 7.