### PR TITLE
fix: handle HEAD requests like GET in generic_views

### DIFF
--- a/haystack/generic_views.py
+++ b/haystack/generic_views.py
@@ -59,7 +59,7 @@ class SearchMixin(MultipleObjectMixin, FormMixin):
         Returns the keyword arguments for instantiating the form.
         """
         kwargs = {"initial": self.get_initial()}
-        if self.request.method == "GET":
+        if self.request.method in ["HEAD", "GET"]:
             kwargs.update({"data": self.request.GET})
         kwargs.update(
             {"searchqueryset": self.get_queryset(), "load_all": self.load_all}

--- a/test_haystack/test_generic_views.py
+++ b/test_haystack/test_generic_views.py
@@ -71,3 +71,11 @@ class GenericSearchViewsTestCase(TestCase):
 
         request = factory_func(url, data=data or {}, **kwargs)
         return request
+
+
+class GenericSearchViewsHEADTestCase(GenericSearchViewsTestCase):
+    """Test case for the generic search views using the HEAD request method."""
+
+    def setUp(self):
+        super().setUp()
+        self.request.method = "HEAD"


### PR DESCRIPTION
As mentioned in #1956, the generic views break when handling a HEAD request, since data from `request.GET` is only added if `request.method == "GET"`. Since `request.GET` can also be used when the method is HEAD we can just treat them the same.

The issue can be reproduced simply by changing the request method in `test_generic_views.py` and running the tests. I have added this as a new test case.

Fixes #1956 

I'm open for feedback if you prefer a different solution.

Thank you!
Jan