### PR TITLE
dev: Fix concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   ruff: # https://docs.astral.sh/ruff


### PR DESCRIPTION
Two major improvements; developer quality of life.

* Removes `branches: [master]` from `pull_request`
  Allows the CI to now run when you're linking one PR to another (mostly in the local fork), such as `branch2` depends on `branch1`, a visual improvement since when PRs get backed up, you don't want to be sitting around waiting, and want to iterate.
* Adds `concurrency`
  As you can probably tell, I commit a lot of "crap commits" with very little meaning in the name, this is because I leverage the CI a lot of do most/all of the heavy lifting (they're free anyways). This cancels the previous runs if you commit back to back, you no longer need to wait for the previous commit to finish, the new commit will take precedence. 