### PR TITLE
Dev: Speeds up test by over a minute once the cache has been populated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           echo "$(pwd)/.gdal-root/usr/bin" >> $GITHUB_PATH
           {
-            echo "LD_LIBRARY_PATH=$(pwd)/.gdal-root/usr/lib/x86_64-linux-gnu:$(pwd)/.gdal-root/usr/lib:$(pwd)/.gdal-root/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
+            echo "LD_LIBRARY_PATH=$(pwd)/.gdal-root/usr/lib/x86_64-linux-gnu:$(pwd)/.gdal-root/usr/lib:$(pwd)/.gdal-root/lib/x86_64-linux-gnu:$(pwd)/.gdal-root/usr/lib/x86_64-linux-gnu/blas:$(pwd)/.gdal-root/usr/lib/x86_64-linux-gnu/lapack:${LD_LIBRARY_PATH}"
             echo "PROJ_LIB=$(pwd)/.gdal-root/usr/share/proj"
             echo "GDAL_DATA=$(pwd)/.gdal-root/usr/share/gdal"
           } >> $GITHUB_ENV


### PR DESCRIPTION
Installing `gdal-bin` is extremely slow, best case scenario [34s](https://github.com/django-haystack/django-haystack/actions/runs/17387285912/job/49355756978#step:5:1), average around [1:30s-ish](https://github.com/django-haystack/django-haystack/actions/runs/17387285912/job/49355756982#step:5:1), and i've seen it go as high as 4m+... [cant find it now]. I propose we use this action, the best case scenario remains in the 30s