### PR TITLE
Fix race condition in ConnectionRouter.routers lazy initialization

### DIFF
--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -143,10 +143,11 @@ class ConnectionRouter:
             if not len(router_list):
                 router_list = default_routers
 
-            self._routers = []
+            routers = []
             for router_path in router_list:
                 router_class = load_router(router_path)
-                self._routers.append(router_class())
+                routers.append(router_class())
+            self._routers = routers
         return self._routers
 
     def _for_action(self, action, many, **hints):


### PR DESCRIPTION
Build the router list in a local variable before assigning to `self._routers`, so concurrent threads never see a partially-initialized empty list.

Previously, `self._routers = []` was set before routers were appended. If another thread accessed the `routers` property between the empty-list assignment and the loop completing, it would see `_routers` as `[]` (not `None`), skip initialization, and return no routers. This caused `SearchIndex.get_backend()` to return `None`