### PR TITLE
eol: Drop support for end-of-life Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
         django-version: ["4.2", "5.1", "5.2", "6.0"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         elastic-version: ["7.17.12"]
         include:
           - django-version: "5.2"
@@ -43,12 +43,6 @@ jobs:
         exclude:
           - django-version: "4.2"
             python-version: "3.13"
-          - django-version: "5.1"
-            python-version: "3.9"
-          - django-version: "5.2"
-            python-version: "3.9"
-          - django-version: "6.0"
-            python-version: "3.9"
           - django-version: "6.0"
             python-version: "3.10"
           - django-version: "6.0"

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Requirements
 
 Haystack has a relatively easily-met set of requirements.
 
-* Python 3.9+
+* Python 3.10+
 * Django 4-6
 
 Additionally, each backend has its own requirements. You should refer to

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -116,7 +116,7 @@ Requirements
 
 Haystack has a relatively easily-met set of requirements.
 
-* Python 3.9+
+* Python 3.10+
 * Django 4-6
 
 Additionally, each backend has its own requirements. You should refer to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 [project]
 name = "django-haystack"
 description = "Pluggable search for Django."
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.rst"
 authors = [{name = "Daniel Lindsley", email = "daniel@toastdriven.com"}]
 license = "BSD-3-Clause"
@@ -26,7 +26,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
     docs
-    py{39,310,311,312,313,314,314t}-django{4.2,5.1,5.2,6.0}-es7.x
+    py{310,311,312,313,314,314t}-django{4.2,5.1,5.2,6.0}-es7.x
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
## Description

_Drop support for end-of-life Python **3.9**_

See: https://endoflife.date/python

<img width="826" height="594" alt="image" src="https://github.com/user-attachments/assets/eabb1823-21c7-4401-92a8-2847d7852934" />
