### PR TITLE
pre-commit: Add zizmor security linter for GitHub Actions, etc.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.x
       - name: Install dependencies

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build distributions
         run: pipx run build
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: dist/
 
@@ -30,11 +30,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir
           name: artifact
           path: dist
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install system dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,8 @@ repos:
       - id: pretty-format-json
         args: ["--autofix", "--no-sort-keys", "--indent=4"]
       - id: trailing-whitespace
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+    - id: zizmor

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,3 @@
+rules:
+  excessive-permissions:
+    disable: true


### PR DESCRIPTION
https://docs.zizmor.sh -- `zizmor` is a static analysis tool that can find and fix security issues in common CI/CD setups, including GitHub Actions, Dependabot, and pre-commit.

Fixes https://docs.zizmor.sh/audits/#unpinned-uses

**_After this is merged_**, if someone has confidence and experience dealing with [excessive permissions](https://docs.zizmor.sh/audits/#excessive-permissions), remove the `zizmor.yml` file and fix all remaining zizmor issues.

I have made regrettable errors trying to fix excessive permissions, so I am reluctant to fix them in this pull request, which does other useful things.

@DhavalGojiya 